### PR TITLE
Redesign Read/Edit Mode Styling in Feature Form

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -550,7 +550,7 @@ Page {
             topPadding: 10
             bottomPadding: 5
             opacity: 1
-            color: LabelOverrideColor ? LabelColor : Theme.mainTextColor
+            color: LabelOverrideColor ? LabelColor : !AttributeEditable && form.state === 'Edit' ? Theme.mainTextDisabledColor : Theme.mainTextColor
           }
 
           Label {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -600,9 +600,10 @@ Page {
               // - not in edit mode (ReadOnly)
               // - a relation in multi edit mode
               property bool isAdding: form.state === 'Add'
-              property bool isEditing: form.state === 'Edit'
+              property bool isEditing: form.state !== 'ReadOnly'
               property bool isEnabled: !!AttributeEditable && form.state !== 'ReadOnly' && !(Type === 'relation' && form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel)
-              property bool notEditableInEditMode: !AttributeEditable && form.state === 'Edit'
+              property bool isEditable: !!AttributeEditable && !(Type === 'relation' && form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel)
+
               property var value: AttributeValue
               property var config: (EditorWidgetConfig || {})
               property var widget: EditorWidget

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -549,7 +549,7 @@ Page {
             font.strikeout: LabelOverrideFont ? LabelFont.strikeout : false
             topPadding: 10
             bottomPadding: 5
-            opacity: (form.state === 'ReadOnly' || !AttributeEditable) || embedded && EditorWidget === 'RelationEditor' ? 0.45 : 1
+            opacity: 1
             color: LabelOverrideColor ? LabelColor : Theme.mainTextColor
           }
 
@@ -601,6 +601,7 @@ Page {
               property bool isAdding: form.state === 'Add'
               property bool isEditing: form.state === 'Edit'
               property bool isEnabled: !!AttributeEditable && form.state !== 'ReadOnly' && !(Type === 'relation' && form.model.featureModel.modelMode == FeatureModel.MultiFeatureModel)
+              property bool notEditableInEditMode: !AttributeEditable && form.state === 'Edit'
               property var value: AttributeValue
               property var config: (EditorWidgetConfig || {})
               property var widget: EditorWidget

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -582,6 +582,7 @@ Page {
               left: parent.left
               right: fieldMenuButton.left
               top: constraintDescriptionLabel.bottom
+              rightMargin: fieldMenuButton.visible ? 5 : 0
             }
 
             Loader {
@@ -696,6 +697,7 @@ Page {
             anchors {
               right: rememberButton.left
               top: constraintDescriptionLabel.bottom
+              rightMargin: 5
             }
 
             visible: attributeEditorLoader.isEnabled && attributeEditorLoader.item && attributeEditorLoader.item.hasMenu

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -21,6 +21,7 @@ Item {
   property var currentKeyValue: value
   property EmbeddedFeatureForm embeddedFeatureForm: embeddedPopupLoader.item
   readonly property alias searchPopup: searchFeaturePopup
+  property color displayedTextColor: value === undefined || !enabled ? Theme.mainTextDisabledColor : Theme.mainTextColor
 
   signal requestJumpToPoint(var center, real scale, bool handleMargins)
 
@@ -303,14 +304,14 @@ Item {
       font: Theme.defaultFont
 
       contentItem: Text {
-        leftPadding: enabled ? 5 : 0
+        leftPadding: enabled ? 10 : 0
         height: fontMetrics.height + 20
         text: comboBox.currentIndex === -1 && value !== undefined ? '(' + value + ')' : comboBox.currentText
         font: comboBox.font
-        color: value === undefined || !enabled ? Theme.mainTextDisabledColor : Theme.mainTextColor
         horizontalAlignment: Text.AlignLeft
         verticalAlignment: Text.AlignVCenter
         elide: Text.ElideRight
+        color: displayedTextColor
       }
 
       popup: Popup {
@@ -362,27 +363,8 @@ Item {
         }
       }
 
-      background: Item {
-        implicitWidth: 120
-        implicitHeight: 36
-
-        Rectangle {
-          visible: !enabled
-          y: comboBox.height - 2
-          width: comboBox.width
-          height: comboBox.activeFocus ? 2 : 1
-          color: comboBox.activeFocus ? Theme.accentColor : Theme.accentLightColor
-        }
-
-        Rectangle {
-          visible: enabled
-          anchors.fill: parent
-          border.color: comboBox.pressed ? Theme.accentColor : Theme.accentLightColor
-          border.width: comboBox.visualFocus ? 2 : 1
-          color: Theme.controlBackgroundAlternateColor
-          radius: 2
-        }
-      }
+      background.visible: enabled
+      indicator.visible: enabled
     }
 
     FontMetrics {

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -304,7 +304,7 @@ Item {
       font: Theme.defaultFont
 
       contentItem: Text {
-        leftPadding: relationCombobox.enabled || notEditableInEditMode ? 10 : 0
+        leftPadding: relationCombobox.enabled || (!isEditable && isEditing) ? 10 : 0
         height: fontMetrics.height + 20
         text: comboBox.currentIndex === -1 && value !== undefined ? '(' + value + ')' : comboBox.currentText
         font: comboBox.font
@@ -363,8 +363,8 @@ Item {
         }
       }
 
-      background.visible: relationCombobox.enabled || notEditableInEditMode
-      indicator.visible: relationCombobox.enabled || notEditableInEditMode
+      background.visible: relationCombobox.enabled || (!isEditable && isEditing)
+      indicator.visible: relationCombobox.enabled || (!isEditable && isEditing)
     }
 
     FontMetrics {

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -304,7 +304,7 @@ Item {
       font: Theme.defaultFont
 
       contentItem: Text {
-        leftPadding: enabled ? 10 : 0
+        leftPadding: enabled || notEditableInEditMode ? 10 : 0
         height: fontMetrics.height + 20
         text: comboBox.currentIndex === -1 && value !== undefined ? '(' + value + ')' : comboBox.currentText
         font: comboBox.font
@@ -363,8 +363,8 @@ Item {
         }
       }
 
-      background.visible: enabled
-      indicator.visible: enabled
+      background.visible: enabled || notEditableInEditMode
+      indicator.visible: enabled || notEditableInEditMode
     }
 
     FontMetrics {

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -304,7 +304,7 @@ Item {
       font: Theme.defaultFont
 
       contentItem: Text {
-        leftPadding: enabled || notEditableInEditMode ? 10 : 0
+        leftPadding: relationCombobox.enabled || notEditableInEditMode ? 10 : 0
         height: fontMetrics.height + 20
         text: comboBox.currentIndex === -1 && value !== undefined ? '(' + value + ')' : comboBox.currentText
         font: comboBox.font
@@ -363,8 +363,8 @@ Item {
         }
       }
 
-      background.visible: enabled || notEditableInEditMode
-      indicator.visible: enabled || notEditableInEditMode
+      background.visible: relationCombobox.enabled || notEditableInEditMode
+      indicator.visible: relationCombobox.enabled || notEditableInEditMode
     }
 
     FontMetrics {

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -29,7 +29,7 @@ EditorWidgetBase {
     font.pointSize: Theme.defaultFont.pointSize
     font.bold: Theme.defaultFont.bold
     font.italic: isNull
-    color: isEnabled && !isNull ? Theme.mainTextColor : Theme.mainTextDisabledColor
+    color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
 
     text: !isNull ? checkBox.checked ? checkedLabel : uncheckedLabel : isEnabled ? qsTr('NULL') : ''
   }
@@ -94,6 +94,7 @@ EditorWidgetBase {
     implicitWidth: 120
     height: checkBox.activeFocus || checkBox.pressed || checkArea.containsPress ? 2 : 1
     color: checkBox.activeFocus || checkBox.pressed || checkArea.containsPress ? Theme.accentColor : Theme.accentLightColor
+    visible: isEnabled
   }
 
   FontMetrics {

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -28,7 +28,6 @@ EditorWidgetBase {
 
     topPadding: 10
     bottomPadding: 10
-    leftPadding: isEnabled || notEditableInEditMode ? 10 : 0
     font.pointSize: Theme.defaultFont.pointSize
     font.bold: Theme.defaultFont.bold
     font.italic: isNull
@@ -40,7 +39,6 @@ EditorWidgetBase {
   Switch {
     id: checkBox
     enabled: isEnabled
-    visible: isEnabled || notEditableInEditMode
     width: implicitContentWidth
 
     anchors {
@@ -60,18 +58,6 @@ EditorWidgetBase {
         return !isNull ? String(value) === config['CheckedState'] : false;
       }
     }
-  }
-
-  MaterialTextContainer {
-    implicitWidth: parent.width
-    implicitHeight: checkBoxEditorWidgetBase.Material.textFieldHeight
-
-    outlineColor: (enabled && checkBoxEditorWidgetBase.hovered) ? checkBoxEditorWidgetBase.Material.primaryTextColor : checkBoxEditorWidgetBase.Material.hintTextColor
-    focusedOutlineColor: checkBoxEditorWidgetBase.Material.accentColor
-    controlHasActiveFocus: checkBoxEditorWidgetBase.activeFocus
-    controlHasText: true
-    horizontalPadding: checkBoxEditorWidgetBase.Material.textFieldHorizontalPadding
-    visible: isEnabled || notEditableInEditMode
   }
 
   MouseArea {

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -31,7 +31,7 @@ EditorWidgetBase {
     font.pointSize: Theme.defaultFont.pointSize
     font.bold: Theme.defaultFont.bold
     font.italic: isNull
-    color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
+    color: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
 
     text: !isNull ? checkBox.checked ? checkedLabel : uncheckedLabel : isEnabled ? qsTr('NULL') : ''
   }

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -1,8 +1,10 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.Material.impl
 import Theme
 
 EditorWidgetBase {
+  id: checkBoxEditorWidgetBase
   height: childrenRect.height
 
   // if the field type is boolean, ignore the configured 'CheckedState' and 'UncheckedState' values and work with true/false always
@@ -26,6 +28,7 @@ EditorWidgetBase {
 
     topPadding: 10
     bottomPadding: 10
+    leftPadding: isEnabled || notEditableInEditMode ? 10 : 0
     font.pointSize: Theme.defaultFont.pointSize
     font.bold: Theme.defaultFont.bold
     font.italic: isNull
@@ -34,12 +37,11 @@ EditorWidgetBase {
     text: !isNull ? checkBox.checked ? checkedLabel : uncheckedLabel : isEnabled ? qsTr('NULL') : ''
   }
 
-  QfSwitch {
+  Switch {
     id: checkBox
     enabled: isEnabled
-    visible: isEnabled
+    visible: isEnabled || notEditableInEditMode
     width: implicitContentWidth
-    small: true
 
     anchors {
       right: parent.right
@@ -58,6 +60,18 @@ EditorWidgetBase {
         return !isNull ? String(value) === config['CheckedState'] : false;
       }
     }
+  }
+
+  MaterialTextContainer {
+    implicitWidth: parent.width
+    implicitHeight: checkBoxEditorWidgetBase.Material.textFieldHeight
+
+    outlineColor: (enabled && checkBoxEditorWidgetBase.hovered) ? checkBoxEditorWidgetBase.Material.primaryTextColor : checkBoxEditorWidgetBase.Material.hintTextColor
+    focusedOutlineColor: checkBoxEditorWidgetBase.Material.accentColor
+    controlHasActiveFocus: checkBoxEditorWidgetBase.activeFocus
+    controlHasText: true
+    horizontalPadding: checkBoxEditorWidgetBase.Material.textFieldHorizontalPadding
+    visible: isEnabled || notEditableInEditMode
   }
 
   MouseArea {
@@ -84,17 +98,6 @@ EditorWidgetBase {
       }
       valueChangeRequested(editedValue, false);
     }
-  }
-
-  Rectangle {
-    id: backgroundRect
-    anchors.left: parent.left
-    anchors.right: parent.right
-    y: checkValue.height - height - checkValue.bottomPadding / 2
-    implicitWidth: 120
-    height: checkBox.activeFocus || checkBox.pressed || checkArea.containsPress ? 2 : 1
-    color: checkBox.activeFocus || checkBox.pressed || checkArea.containsPress ? Theme.accentColor : Theme.accentLightColor
-    visible: isEnabled
   }
 
   FontMetrics {

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -95,11 +95,11 @@ EditorWidgetBase {
 
       verticalAlignment: Text.AlignVCenter
       font: Theme.defaultFont
-      color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
+      color: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
       topPadding: 6
       bottomPadding: 6
       rightPadding: 0
-      leftPadding: isEnabled || notEditableInEditMode ? 10 : 0
+      leftPadding: isEnabled || (!isEditable && isEditing) ? 10 : 0
 
       inputMethodHints: Qt.ImhDigitsOnly
 
@@ -187,7 +187,7 @@ EditorWidgetBase {
         }
       }
 
-      background.visible: isEnabled || notEditableInEditMode
+      background.visible: isEnabled || (!isEditable && isEditing)
     }
 
     QfToolButton {

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -99,7 +99,7 @@ EditorWidgetBase {
       topPadding: 6
       bottomPadding: 6
       rightPadding: 0
-      leftPadding: enabled ? 10 : 0
+      leftPadding: enabled || notEditableInEditMode ? 10 : 0
 
       inputMethodHints: Qt.ImhDigitsOnly
 
@@ -187,7 +187,7 @@ EditorWidgetBase {
         }
       }
 
-      background.visible: enabled
+      background.visible: enabled || notEditableInEditMode
     }
 
     QfToolButton {

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -99,7 +99,7 @@ EditorWidgetBase {
       topPadding: 6
       bottomPadding: 6
       rightPadding: 0
-      leftPadding: enabled || notEditableInEditMode ? 10 : 0
+      leftPadding: isEnabled || notEditableInEditMode ? 10 : 0
 
       inputMethodHints: Qt.ImhDigitsOnly
 
@@ -187,7 +187,7 @@ EditorWidgetBase {
         }
       }
 
-      background.visible: enabled || notEditableInEditMode
+      background.visible: isEnabled || notEditableInEditMode
     }
 
     QfToolButton {

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -84,15 +84,6 @@ EditorWidgetBase {
     }
   }
 
-  Rectangle {
-    visible: !enabled
-    y: label.height - height
-    implicitWidth: 120
-    width: label.width
-    height: 1
-    color: Theme.accentLightColor
-  }
-
   RowLayout {
     anchors.left: parent.left
     anchors.right: parent.right
@@ -104,11 +95,11 @@ EditorWidgetBase {
 
       verticalAlignment: Text.AlignVCenter
       font: Theme.defaultFont
-      color: value === undefined || !enabled ? Theme.mainTextDisabledColor : Theme.mainTextColor
+      color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
       topPadding: 6
       bottomPadding: 6
       rightPadding: 0
-      leftPadding: enabled ? 5 : 0
+      leftPadding: enabled ? 10 : 0
 
       inputMethodHints: Qt.ImhDigitsOnly
 
@@ -128,17 +119,6 @@ EditorWidgetBase {
       }
 
       text: main.currentValue !== undefined ? main.currentValue : ''
-
-      background: Rectangle {
-        id: backgroundRect
-        width: label.width
-        height: label.height
-        border.color: label.activeFocus ? Theme.accentColor : Theme.accentLightColor
-        border.width: label.activeFocus ? 2 : 1
-        color: enabled ? Theme.controlBackgroundAlternateColor : "transparent"
-        radius: 2
-        visible: enabled
-      }
 
       MouseArea {
         enabled: config['calendar_popup'] === undefined || config['calendar_popup']
@@ -206,6 +186,8 @@ EditorWidgetBase {
           valueChangeRequested(undefined, true);
         }
       }
+
+      background.visible: enabled
     }
 
     QfToolButton {

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -25,7 +25,7 @@ EditorWidgetBase {
 
     TextField {
       id: textField
-      leftPadding: enabled || notEditableInEditMode ? 10 : 0
+      leftPadding: isEnabled || notEditableInEditMode ? 10 : 0
       width: parent.width - decreaseButton.width - increaseButton.width
 
       font: Theme.defaultFont
@@ -37,7 +37,7 @@ EditorWidgetBase {
 
       inputMethodHints: Qt.ImhFormattedNumbersOnly
 
-      background.visible: enabled || notEditableInEditMode
+      background.visible: isEnabled || notEditableInEditMode
 
       onTextChanged: {
         if (text === '' || !isNaN(parseFloat(text))) {

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -25,15 +25,11 @@ EditorWidgetBase {
 
     TextField {
       id: textField
-      height: fontMetrics.height + 20
-      topPadding: 10
-      bottomPadding: 10
-      rightPadding: 0
-      leftPadding: enabled ? 5 : 0
+      leftPadding: enabled ? 10 : 0
       width: parent.width - decreaseButton.width - increaseButton.width
 
       font: Theme.defaultFont
-      color: value === undefined || !enabled ? Theme.mainTextDisabledColor : Theme.mainTextColor
+      color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
 
       text: value !== undefined ? value : ''
 
@@ -41,17 +37,7 @@ EditorWidgetBase {
 
       inputMethodHints: Qt.ImhFormattedNumbersOnly
 
-      background: Rectangle {
-        implicitWidth: 120
-        color: "transparent"
-
-        Rectangle {
-          y: textField.height - height - textField.bottomPadding / 2
-          width: textField.width
-          height: textField.activeFocus ? 2 : 1
-          color: textField.activeFocus ? Theme.accentColor : Theme.accentLightColor
-        }
-      }
+      background.visible: enabled
 
       onTextChanged: {
         if (text === '' || !isNaN(parseFloat(text))) {
@@ -194,7 +180,7 @@ EditorWidgetBase {
       verticalAlignment: Text.AlignVCenter
       horizontalAlignment: Text.AlignLeft
       font: Theme.defaultFont
-      color: value === undefined || !enabled ? Theme.mainTextDisabledColor : Theme.mainTextColor
+      color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
     }
 
     QfSlider {
@@ -215,15 +201,6 @@ EditorWidgetBase {
         }
       }
     }
-  }
-
-  Rectangle {
-    y: sliderRow.height - height
-    visible: widgetStyle === "Slider"
-    width: sliderRow.width
-    implicitWidth: 120
-    height: slider.activeFocus ? 2 : 1
-    color: slider.activeFocus ? Theme.accentColor : Theme.accentLightColor
   }
 
   FontMetrics {

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -25,7 +25,7 @@ EditorWidgetBase {
 
     TextField {
       id: textField
-      leftPadding: enabled ? 10 : 0
+      leftPadding: enabled || notEditableInEditMode ? 10 : 0
       width: parent.width - decreaseButton.width - increaseButton.width
 
       font: Theme.defaultFont
@@ -37,7 +37,7 @@ EditorWidgetBase {
 
       inputMethodHints: Qt.ImhFormattedNumbersOnly
 
-      background.visible: enabled
+      background.visible: enabled || notEditableInEditMode
 
       onTextChanged: {
         if (text === '' || !isNaN(parseFloat(text))) {

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -25,11 +25,11 @@ EditorWidgetBase {
 
     TextField {
       id: textField
-      leftPadding: isEnabled || notEditableInEditMode ? 10 : 0
+      leftPadding: isEnabled || (!isEditable && isEditing) ? 10 : 0
       width: parent.width - decreaseButton.width - increaseButton.width
 
       font: Theme.defaultFont
-      color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
+      color: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
 
       text: value !== undefined ? value : ''
 
@@ -37,7 +37,7 @@ EditorWidgetBase {
 
       inputMethodHints: Qt.ImhFormattedNumbersOnly
 
-      background.visible: isEnabled || notEditableInEditMode
+      background.visible: isEnabled || (!isEditable && isEditing)
 
       onTextChanged: {
         if (text === '' || !isNaN(parseFloat(text))) {
@@ -180,7 +180,7 @@ EditorWidgetBase {
       verticalAlignment: Text.AlignVCenter
       horizontalAlignment: Text.AlignLeft
       font: Theme.defaultFont
-      color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
+      color: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
     }
 
     QfSlider {

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Controls.Material.impl
 import org.qfield
 import Theme
 
@@ -16,6 +17,7 @@ EditorWidgetBase {
     height: !textArea.visible ? textField.height : 0
     topPadding: 10
     bottomPadding: 10
+    leftPadding: enabled || notEditableInEditMode ? 10 : 0
     visible: height !== 0 && !isEditable
     anchors.left: parent.left
     anchors.right: parent.right
@@ -32,6 +34,18 @@ EditorWidgetBase {
     }
   }
 
+  MaterialTextContainer {
+    implicitWidth: parent.width
+    implicitHeight: topItem.Material.textFieldHeight
+
+    outlineColor: (enabled && topItem.hovered) ? topItem.Material.primaryTextColor : topItem.Material.hintTextColor
+    focusedOutlineColor: topItem.Material.accentColor
+    controlHasActiveFocus: topItem.activeFocus
+    controlHasText: true
+    horizontalPadding: topItem.Material.textFieldHorizontalPadding
+    visible: isEnabled || notEditableInEditMode
+  }
+
   TextField {
     id: textField
     leftPadding: enabled ? 10 : 0
@@ -42,6 +56,7 @@ EditorWidgetBase {
     color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
     maximumLength: field != undefined && field.length > 0 ? field.length : -1
     wrapMode: TextInput.Wrap
+    background.visible: enabled || notEditableInEditMode
 
     text: value == null ? '' : value
 
@@ -104,6 +119,7 @@ EditorWidgetBase {
     onTextChanged: {
       valueChangeRequested(text, text == '');
     }
+    background.visible: enabled || notEditableInEditMode
   }
 
   FontMetrics {

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -17,7 +17,7 @@ EditorWidgetBase {
     height: !textArea.visible ? textField.height : 0
     topPadding: 10
     bottomPadding: 10
-    leftPadding: enabled || notEditableInEditMode ? 10 : 0
+    leftPadding: isEnabled || notEditableInEditMode ? 10 : 0
     visible: height !== 0 && !isEditable
     anchors.left: parent.left
     anchors.right: parent.right

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -20,8 +20,8 @@ EditorWidgetBase {
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
-    color: Theme.mainTextColor
-    opacity: 0.45
+    color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
+    opacity: 1
     wrapMode: Text.Wrap
     textFormat: (config['IsMultiline'] === true && config['UseHtml']) || StringUtils.hasLinks(value) ? TextEdit.RichText : TextEdit.AutoText
 
@@ -34,15 +34,12 @@ EditorWidgetBase {
 
   TextField {
     id: textField
-    topPadding: 10
-    bottomPadding: 10
-    rightPadding: 0
-    leftPadding: enabled ? 5 : 0
+    leftPadding: enabled ? 10 : 0
     visible: (config['IsMultiline'] === undefined || config['IsMultiline'] == false) && isEditable
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
-    color: Theme.mainTextColor
+    color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
     maximumLength: field != undefined && field.length > 0 ? field.length : -1
     wrapMode: TextInput.Wrap
 
@@ -71,12 +68,6 @@ EditorWidgetBase {
 
     inputMethodHints: field && field.isNumeric ? Qt.ImhFormattedNumbersOnly : Qt.ImhNone
 
-    background: Rectangle {
-      width: parent.width
-      height: parent.height
-      color: "transparent"
-    }
-
     onTextChanged: {
       if (text !== '') {
         if (field.isNumeric) {
@@ -97,10 +88,7 @@ EditorWidgetBase {
 
   TextArea {
     id: textArea
-    topPadding: 10
-    bottomPadding: 10
-    rightPadding: 0
-    leftPadding: enabled ? 5 : 0
+    leftPadding: enabled ? 10 : 0
     height: config['IsMultiline'] === true ? undefined : 0
     visible: config['IsMultiline'] === true && isEditable
     enabled: isEditable
@@ -108,29 +96,14 @@ EditorWidgetBase {
     anchors.right: parent.right
     wrapMode: Text.Wrap
     font: Theme.defaultFont
-    color: Theme.mainTextColor
+    color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
 
     text: value !== undefined ? value : ''
     textFormat: config['UseHtml'] ? TextEdit.RichText : TextEdit.PlainText
 
-    background: Rectangle {
-      width: parent.width
-      height: parent.height
-      color: "transparent"
-    }
-
     onTextChanged: {
       valueChangeRequested(text, text == '');
     }
-  }
-
-  Rectangle {
-    anchors.left: parent.left
-    anchors.right: parent.right
-    y: Math.max(textField.height, textArea.height) - height - textField.bottomPadding / 2
-    implicitWidth: 120
-    height: textField.activeFocus || textArea.activeFocus ? 2 : 1
-    color: textField.activeFocus || textArea.activeFocus ? Theme.accentColor : Theme.accentLightColor
   }
 
   FontMetrics {

--- a/src/qml/editorwidgets/TextEdit.qml
+++ b/src/qml/editorwidgets/TextEdit.qml
@@ -17,12 +17,12 @@ EditorWidgetBase {
     height: !textArea.visible ? textField.height : 0
     topPadding: 10
     bottomPadding: 10
-    leftPadding: isEnabled || notEditableInEditMode ? 10 : 0
+    leftPadding: isEnabled || (!isEditable && isEditing) ? 10 : 0
     visible: height !== 0 && !isEditable
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
-    color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
+    color: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
     opacity: 1
     wrapMode: Text.Wrap
     textFormat: (config['IsMultiline'] === true && config['UseHtml']) || StringUtils.hasLinks(value) ? TextEdit.RichText : TextEdit.AutoText
@@ -43,7 +43,7 @@ EditorWidgetBase {
     controlHasActiveFocus: topItem.activeFocus
     controlHasText: true
     horizontalPadding: topItem.Material.textFieldHorizontalPadding
-    visible: isEnabled || notEditableInEditMode
+    visible: isEnabled || (!isEditable && isEditing)
   }
 
   TextField {
@@ -53,10 +53,10 @@ EditorWidgetBase {
     anchors.left: parent.left
     anchors.right: parent.right
     font: Theme.defaultFont
-    color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
+    color: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
     maximumLength: field != undefined && field.length > 0 ? field.length : -1
     wrapMode: TextInput.Wrap
-    background.visible: enabled || notEditableInEditMode
+    background.visible: enabled || (!isEditable && isEditing)
 
     text: value == null ? '' : value
 
@@ -111,7 +111,7 @@ EditorWidgetBase {
     anchors.right: parent.right
     wrapMode: Text.Wrap
     font: Theme.defaultFont
-    color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
+    color: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
 
     text: value !== undefined ? value : ''
     textFormat: config['UseHtml'] ? TextEdit.RichText : TextEdit.PlainText
@@ -119,7 +119,7 @@ EditorWidgetBase {
     onTextChanged: {
       valueChangeRequested(text, text == '');
     }
-    background.visible: enabled || notEditableInEditMode
+    background.visible: enabled || (!isEditable && isEditing)
   }
 
   FontMetrics {

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -186,10 +186,10 @@ EditorWidgetBase {
       currentIndex: model.keyToIndex(value)
       model: listModel
       textRole: 'value'
-      text.color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
-      background.visible: isEnabled || notEditableInEditMode
-      indicator.visible: isEnabled || notEditableInEditMode
-      text.leftPadding: isEnabled || notEditableInEditMode ? 10 : 0
+      text.color: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
+      background.visible: isEnabled || (!isEditable && isEditing)
+      indicator.visible: isEnabled || (!isEditable && isEditing)
+      text.leftPadding: isEnabled || (!isEditable && isEditing) ? 10 : 0
 
       Component.onCompleted: {
         comboBox.popup.z = 10000; // 1000s are embedded feature forms, use a higher value to insure popups always show above embedded feature formes

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -187,9 +187,9 @@ EditorWidgetBase {
       model: listModel
       textRole: 'value'
       text.color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
-      background.visible: enabled || notEditableInEditMode
-      indicator.visible: enabled || notEditableInEditMode
-      text.leftPadding: enabled || notEditableInEditMode ? 10 : 0
+      background.visible: isEnabled || notEditableInEditMode
+      indicator.visible: isEnabled || notEditableInEditMode
+      text.leftPadding: isEnabled || notEditableInEditMode ? 10 : 0
 
       Component.onCompleted: {
         comboBox.popup.z = 10000; // 1000s are embedded feature forms, use a higher value to insure popups always show above embedded feature formes

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -186,6 +186,7 @@ EditorWidgetBase {
       currentIndex: model.keyToIndex(value)
       model: listModel
       textRole: 'value'
+      text.color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
 
       Component.onCompleted: {
         comboBox.popup.z = 10000; // 1000s are embedded feature forms, use a higher value to insure popups always show above embedded feature formes

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -110,7 +110,7 @@ EditorWidgetBase {
             height: 34
             radius: 4
             color: selected ? isEnabled ? Theme.mainColor : Theme.accentLightColor : "transparent"
-            border.color: isEnabled ? selected ? Theme.mainColor : Theme.accentLightColor : "transparent"
+            border.color: isEnabled ? selected ? Theme.mainColor : valueMap.Material.hintTextColor : "transparent"
             border.width: 1
 
             property bool selected: toggleButtons.selectedIndex == index
@@ -135,7 +135,7 @@ EditorWidgetBase {
               elide: Text.ElideRight
               anchors.centerIn: parent
               font: Theme.defaultFont
-              color: isEnabled ? Theme.mainTextColor : Theme.mainTextDisabledColor
+              color: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
             }
 
             MouseArea {
@@ -165,14 +165,6 @@ EditorWidgetBase {
             }
           }
         }
-      }
-
-      Rectangle {
-        y: flow.height + flow.anchors.topMargin + flow.anchors.bottomMargin - 1
-        visible: !isEnabled
-        width: flow.width
-        height: flow.activeFocus ? 2 : 1
-        color: flow.activeFocus ? Theme.accentColor : Theme.accentLightColor
       }
     }
 

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -187,6 +187,9 @@ EditorWidgetBase {
       model: listModel
       textRole: 'value'
       text.color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
+      background.visible: enabled || notEditableInEditMode
+      indicator.visible: enabled || notEditableInEditMode
+      text.leftPadding: enabled || notEditableInEditMode ? 10 : 0
 
       Component.onCompleted: {
         comboBox.popup.z = 10000; // 1000s are embedded feature forms, use a higher value to insure popups always show above embedded feature formes

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -60,7 +60,7 @@ EditorWidgetBase {
     layerResolver: layerResolver
     allowAddFeature: currentLayer && currentLayer.customProperty('QFieldSync/allow_value_relation_feature_addition') !== undefined ? currentLayer.customProperty('QFieldSync/allow_value_relation_feature_addition') : false
 
-    displayedTextColor: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
+    displayedTextColor: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
     onRequestJumpToPoint: function (center, scale, handleMargins) {
       valueRelation.requestJumpToPoint(center, scale, handleMargins);
     }
@@ -214,7 +214,7 @@ EditorWidgetBase {
                   topPadding: 4
                   bottomPadding: 4
                   font: Theme.defaultFont
-                  color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
+                  color: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
                   text: model.displayString
                   wrapMode: Text.WordWrap
                   elide: Text.ElideRight

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -60,6 +60,7 @@ EditorWidgetBase {
     layerResolver: layerResolver
     allowAddFeature: currentLayer && currentLayer.customProperty('QFieldSync/allow_value_relation_feature_addition') !== undefined ? currentLayer.customProperty('QFieldSync/allow_value_relation_feature_addition') : false
 
+    displayedTextColor: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
     onRequestJumpToPoint: function (center, scale, handleMargins) {
       valueRelation.requestJumpToPoint(center, scale, handleMargins);
     }
@@ -213,7 +214,7 @@ EditorWidgetBase {
                   topPadding: 4
                   bottomPadding: 4
                   font: Theme.defaultFont
-                  color: !isEnabled ? Theme.mainTextDisabledColor : Theme.mainTextColor
+                  color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
                   text: model.displayString
                   wrapMode: Text.WordWrap
                   elide: Text.ElideRight

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -94,7 +94,7 @@ RelationEditorBase {
           topPadding: 5
           bottomPadding: 5
           font: Theme.defaultFont
-          color: !isEnabled ? Theme.mainTextDisabledColor : Theme.mainTextColor
+          color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
           elide: Text.ElideRight
           wrapMode: Text.WordWrap
           text: nmRelationId ? model.nmDisplayString : model.displayString

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -94,7 +94,7 @@ RelationEditorBase {
           topPadding: 5
           bottomPadding: 5
           font: Theme.defaultFont
-          color: notEditableInEditMode ? Theme.mainTextDisabledColor : Theme.mainTextColor
+          color: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
           elide: Text.ElideRight
           wrapMode: Text.WordWrap
           text: nmRelationId ? model.nmDisplayString : model.displayString

--- a/src/qml/imports/Theme/QfComboBox.qml
+++ b/src/qml/imports/Theme/QfComboBox.qml
@@ -7,37 +7,20 @@ import QtQuick.Controls.Material.impl
 ComboBox {
   id: comboBox
 
+  property alias text: contentText
+
   contentItem: Text {
-    leftPadding: enabled ? 5 : 0
+    id: contentText
+    leftPadding: enabled ? Material.textFieldHorizontalPadding : 0
 
     text: comboBox.displayText
     font: comboBox.font
-    color: enabled ? Theme.mainTextColor : Theme.mainTextDisabledColor
+    color: Theme.mainTextColor
     verticalAlignment: Text.AlignVCenter
     horizontalAlignment: Text.AlignLeft
     elide: Text.ElideRight
   }
 
-  background: Item {
-    implicitWidth: 120
-    implicitHeight: 36
-
-    Rectangle {
-      visible: !enabled
-      y: comboBox.height - 2
-      width: comboBox.width
-      height: comboBox.activeFocus ? 2 : 1
-      color: comboBox.activeFocus ? Theme.accentColor : Theme.accentLightColor
-    }
-
-    Rectangle {
-      id: backgroundRect
-      visible: enabled
-      anchors.fill: parent
-      border.color: comboBox.pressed ? Theme.accentColor : Theme.accentLightColor
-      border.width: comboBox.visualFocus ? 2 : 1
-      color: Theme.controlBackgroundAlternateColor
-      radius: 2
-    }
-  }
+  background.visible: enabled
+  indicator.visible: enabled
 }

--- a/src/qml/imports/Theme/QfComboBox.qml
+++ b/src/qml/imports/Theme/QfComboBox.qml
@@ -20,7 +20,4 @@ ComboBox {
     horizontalAlignment: Text.AlignLeft
     elide: Text.ElideRight
   }
-
-  background.visible: enabled
-  indicator.visible: enabled
 }

--- a/test/qml/tst_editorwidgets.qml
+++ b/test/qml/tst_editorwidgets.qml
@@ -257,7 +257,7 @@ TestCase {
    * TODO: Test `fieldIsDate = true` too, if the field is a date only -> revert the time zone offset.
    */
   function test_01_dateTime() {
-    const label = dateTime.children[1].children[0];
+    const label = dateTime.children[0].children[0];
     compare(label.text, "2022-01-01");
     const testTimes = ["2023-01-01", "2023-01-01 23:33:56"];
     const displayFormats = ["yyyy-MM-dd", "yyyy-MM.dd", "yyyy-MM-dd HH:mm:ss", "HH:mm:ss", "HH:mm"];


### PR DESCRIPTION
### 🚀 Description

Unify the look and feel of Feature Form widgets for readability and consistency with Material Design.

### Demo

- **Read-only mode**
- **Edit mode**
- **Edit mode (but not editable layouts** 

**New**  

<img width="1574" height="598" alt="image" src="https://github.com/user-attachments/assets/f88b70d7-462d-4cc1-b901-6d5e7422116c" />

**Previous**

<img width="1574" height="599" alt="image" src="https://github.com/user-attachments/assets/7d7816ad-9b0e-4115-a539-4f1e2504c33c" />

 
  

**Note: work is still in progress**
