### PR TITLE
Removed legacy Xcode buildsystem flag from macOS dev guide

### DIFF
--- a/doc/dev.md
+++ b/doc/dev.md
@@ -84,7 +84,7 @@ The following line will configure the build.
 
 ```sh
 # We call this from the `dev` folder again
-cmake -S QField -B build -GXcode -Tbuildsystem=1 -DWITH_VCPKG=ON
+cmake -S QField -B build -G Xcode -DWITH_VCPKG=ON
 ```
 
 Please note that this will download and build the complete dependency


### PR DESCRIPTION
buildsystem=1 is now the legacy Xcode build system and is only supported up to Xcode 13.x, 
https://cmake.org/cmake/help/latest/variable/CMAKE_XCODE_BUILD_SYSTEM.html#:~:text=The%20original%20Xcode%20build%20system.%20This%20is%20the%20default%20when%20using%20Xcode%2011.x%20or%20below%20and%20supported%20up%20to%20Xcode%2013.x.

Because of that, using -Tbuildsystem=1 with newer Xcode versions results in an error like:
`toolset specification field buildsystem=1 is not allowed with Xcode <version above 13.x>`

CMake only supports this setting up to Xcode 13. The macOS GitHub Actions workflow [.github/workflows/macos.yml](https://github.com/opengisch/QField/blob/master/.github/workflows/macos.yml) has already been updated to use a newer xcode without -Tbuildsystem=1, so I m assuming the macOS section of the dev docs just wasn’t updated at the same time and is now out of date