### PR TITLE
Fix: trackpad pan/zoom interaction on MapCanvas

### DIFF
--- a/src/qml/MapCanvas.qml
+++ b/src/qml/MapCanvas.qml
@@ -256,9 +256,7 @@ Item {
     id: stylusTapHandler
     enabled: interactive
     grabPermissions: PointerHandler.CanTakeOverFromHandlersOfDifferentType | PointerHandler.ApprovesTakeOverByAnything | PointerHandler.ApprovesCancellation
-    acceptedDevices: !qfieldSettings.mouseAsTouchScreen
-                        ? PointerDevice.Stylus | PointerDevice.Mouse | PointerDevice.TouchPad
-                        : PointerDevice.Stylus
+    acceptedDevices: !qfieldSettings.mouseAsTouchScreen ? PointerDevice.Stylus | PointerDevice.Mouse | PointerDevice.TouchPad : PointerDevice.Stylus
     acceptedButtons: Qt.LeftButton | Qt.RightButton
 
     property bool longPressActive: false
@@ -291,9 +289,7 @@ Item {
     enabled: interactive && !freehandDigitizing
     target: null
     grabPermissions: PointerHandler.CanTakeOverFromHandlersOfDifferentType | PointerHandler.ApprovesTakeOverByHandlersOfDifferentType
-    acceptedDevices: !qfieldSettings.mouseAsTouchScreen
-                        ? PointerDevice.Stylus | PointerDevice.Mouse | PointerDevice.TouchPad
-                        : PointerDevice.Stylus | PointerDevice.TouchPad
+    acceptedDevices: !qfieldSettings.mouseAsTouchScreen ? PointerDevice.Stylus | PointerDevice.Mouse | PointerDevice.TouchPad : PointerDevice.Stylus | PointerDevice.TouchPad
     acceptedButtons: Qt.NoButton | Qt.LeftButton
     dragThreshold: 5
 
@@ -356,9 +352,7 @@ Item {
     enabled: interactive && !hovered
     acceptedButtons: Qt.NoButton | Qt.LeftButton | Qt.RightButton
     grabPermissions: PointerHandler.CanTakeOverFromHandlersOfDifferentType | PointerHandler.ApprovesTakeOverByHandlersOfDifferentType
-    acceptedDevices: !qfieldSettings.mouseAsTouchScreen
-                        ? PointerDevice.TouchScreen
-                        : PointerDevice.TouchScreen | PointerDevice.Mouse | PointerDevice.TouchPad
+    acceptedDevices: !qfieldSettings.mouseAsTouchScreen ? PointerDevice.TouchScreen : PointerDevice.TouchScreen | PointerDevice.Mouse | PointerDevice.TouchPad
 
     property bool longPressActive: false
     property bool doublePressed: false
@@ -406,9 +400,7 @@ Item {
     target: null
     acceptedButtons: Qt.NoButton | Qt.LeftButton
     grabPermissions: PointerHandler.CanTakeOverFromHandlersOfDifferentType | PointerHandler.ApprovesTakeOverByHandlersOfDifferentType
-    acceptedDevices: !qfieldSettings.mouseAsTouchScreen
-                        ? PointerDevice.TouchScreen
-                        : PointerDevice.TouchScreen | PointerDevice.Mouse | PointerDevice.TouchPad
+    acceptedDevices: !qfieldSettings.mouseAsTouchScreen ? PointerDevice.TouchScreen : PointerDevice.TouchScreen | PointerDevice.Mouse | PointerDevice.TouchPad
     dragThreshold: 5
 
     property var oldPos


### PR DESCRIPTION
**On laptop with a touchpad, pan and feature clicks could stop working**
after performing a two-finger scroll or pinch gesture. Zoom continued to work, but the map became effectively non-interactive for panning and tapping. (Note that: the button zoom was not effecting this, only the track-pad zoom gestures).
like in the screen records, as how panning was working for everything, before I used 2 finger scroll (track-pad) to zoom, and then the map becomes un-interactive for panning and tapping (zoom still working though).

https://github.com/user-attachments/assets/5a5df167-6ead-42d9-aee8-a9de0fdfbfca

Root cause found:
- Qt reports laptop touchpad events as PointerDevice.TouchPad.
- MapCanvas TapHandler/DragHandler instances only accepted Stylus/Mouse or TouchScreen devices. After a touchpad gesture, subsequent events were coming from a TouchPad device and were ignored by all pan/click handlers.

Fix used:
- Treat touchpad like mouse on desktop for the "stylus" handlers, and keep the "main" handlers dedicated to touch (or mouse-as-touchscreen) only.
- Update acceptedDevices as follows:
  * stylusTapHandler / stylusDragHandler:
    - When qfieldSettings.mouseAsTouchScreen == false:
      accept Stylus | Mouse | TouchPad.
    - When qfieldSettings.mouseAsTouchScreen == true:
      accept Stylus only (mouse/touchpad handled by main* handlers).
  * mainTapHandler / mainDragHandler:
    - When qfieldSettings.mouseAsTouchScreen == false:
      accept TouchScreen only (original behavior).
    - When qfieldSettings.mouseAsTouchScreen == true:
      accept TouchScreen | Mouse | TouchPad.
- PinchHandler is restricted back to PointerDevice.TouchScreen to avoid
  accidentally grabbing platform-specific touchpad gestures on desktop.

Behavior after the fix:
- On desktop/laptop with a touchpad:
  * Left-click + drag pans immediately after opening.
  * Feature tap/click works before and after any two-finger scroll zoom.
  * Two-finger scroll (wheel) still zooms via WheelHandler.

This keeps the original MapCanvas interaction model intact, but extends it to correctly handle PointerDevice.TouchPad without breaking existing touch and mouse behavior.
