### PR TITLE
Prevent map zoom when scrolling FeatureList/FeatureForm.

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -256,6 +256,7 @@ Pane {
   clip: true
 
   WheelHandler {
+    acceptedDevices: PointerDevice.AllDevices
     onWheel: {
     }
   }


### PR DESCRIPTION
### 🚀 Description
This PR fixes an issue where scrolling within FeatureList or FeatureForm using a laptop touchpad would unintentionally cause the map to zoom.

### Issue demo

https://github.com/user-attachments/assets/27d09137-962d-4d7c-b3be-4a9d65a51645

### Fix
To fix this, the WheelHandler is updated to:

```qml
WheelHandler {
    acceptedDevices: PointerDevice.AllDevices // <- here
    onWheel: {
        // prevent propagation
    }
}
