### PR TITLE
Fix image/title/copyright decorators not taking into account the main window's left and right scene margins

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1534,14 +1534,15 @@ ApplicationWindow {
       id: titleDecorationBackground
 
       visible: titleDecoration.text != ''
-      anchors.left: parent.left
-      anchors.leftMargin: 56
       anchors.top: parent.top
       anchors.topMargin: mainWindow.sceneTopMargin + 4
+      anchors.left: parent.left
+      anchors.leftMargin: 56 + mainWindow.sceneLeftMargin
+      anchors.right: parent.right
+      anchors.rightMargin: 56 + mainWindow.sceneRightMargin
 
-      width: parent.width - anchors.leftMargin * 2
       height: 48
-      radius: 4
+      radius: 8
 
       color: '#55000000'
 
@@ -1573,13 +1574,13 @@ ApplicationWindow {
       id: copyrightDecorationBackground
 
       visible: copyrightDecoration.text != ''
-
       anchors.left: parent.left
-      anchors.leftMargin: 56
+      anchors.leftMargin: 56 + mainWindow.sceneLeftMargin
+      anchors.right: parent.right
+      anchors.rightMargin: 56 + mainWindow.sceneRightMargin
       anchors.bottom: parent.bottom
       anchors.bottomMargin: parent.height > 400 || stateMachine.state !== "browse" ? 56 : 6
 
-      width: parent.width - anchors.leftMargin * 2
       height: visible ? Math.min(copyrightDecoration.height, 48) : 0
       radius: 4
       clip: true
@@ -1614,9 +1615,10 @@ ApplicationWindow {
       id: imageDecoration
 
       visible: source != ''
-
       anchors.left: parent.left
-      anchors.leftMargin: 56
+      anchors.leftMargin: 56 + mainWindow.sceneLeftMargin
+      anchors.right: parent.right
+      anchors.rightMargin: 56 + mainWindow.sceneRightMargin
       anchors.bottom: copyrightDecorationBackground.top
       anchors.bottomMargin: 4
 


### PR DESCRIPTION
Decorators were implemented prior to us gaining scene's left and right margins, which led to visual issues such as this title copyright rendering below the top right main menu button:

<img width="482" height="368" alt="image" src="https://github.com/user-attachments/assets/350788c9-fa39-40ff-bc69-97a1a2d283b4" />
