### PR TITLE
Fix selected ValueMap item text color

### DIFF
--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -135,7 +135,7 @@ EditorWidgetBase {
               elide: Text.ElideRight
               anchors.centerIn: parent
               font: Theme.defaultFont
-              color: !isEditable && isEditing ? Theme.mainTextDisabledColor : Theme.mainTextColor
+              color: !isEditable && isEditing ? Theme.mainTextDisabledColor : selected && isEditing ? Theme.buttonTextColor : Theme.mainTextColor
             }
 
             MouseArea {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2189,7 +2189,7 @@ ApplicationWindow {
                   text: qsTr("%1°").arg(modelData)
                   font: parent.selected ? Theme.strongTipFont : Theme.tipFont
                   anchors.centerIn: parent
-                  color: Theme.mainTextColor
+                  color: parent.selected ? Theme.buttonTextColor : Theme.mainTextColor
                 }
 
                 Ripple {
@@ -2266,7 +2266,7 @@ ApplicationWindow {
                   text: modelData
                   font: parent.selected ? Theme.strongTipFont : Theme.tipFont
                   anchors.centerIn: parent
-                  color: Theme.mainTextColor
+                  color: tolorenceDelegate.selected ? Theme.buttonTextColor : Theme.mainTextColor
                   elide: Text.ElideRight
                   width: parent.width
                   horizontalAlignment: Text.AlignHCenter


### PR DESCRIPTION
### 🚀 Description

Ensures selected entries in the ValueMap show readable text while editing by using a contrasting color. This prevents selected items from appearing unreadable when edited against the selection background.

**Old**
<img width="1037" height="327" alt="image" src="https://github.com/user-attachments/assets/57653e25-962b-4f8c-a1c2-8a361027b268" />

**new**
<img width="961" height="847" alt="image" src="https://github.com/user-attachments/assets/4c98872e-af0c-449f-abed-b2707df7ed5b" />


Fixes #6834.