### PR TITLE
Clear QML cache when unloading plugins to prevent unwanted interference

### DIFF
--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -122,6 +122,9 @@ void PluginManager::unloadPlugin( const QString &pluginPath )
     {
       emit appPluginDisabled( pluginUuid );
     }
+
+    // Clear QML components cache of dynamically loaded items
+    mEngine->clearComponentCache();
   }
 }
 


### PR DESCRIPTION
Second try at fixing https://github.com/opengisch/QField/issues/6847 , will the second be the charm?