### PR TITLE
Let go of the 1-hour-long network request timeout to avoid frozen projects

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfieldcloudconnection.cpp
@@ -43,12 +43,6 @@ QFieldCloudConnection::QFieldCloudConnection()
   , mProvider( QSettings().value( QStringLiteral( "/QFieldCloud/provider" ) ).toString() )
   , mProviderConfigId( QSettings().value( QStringLiteral( "/QFieldCloud/providerConfigId" ) ).toString() )
 {
-  QgsNetworkAccessManager::instance()->setTimeout( 60 * 60 * 1000 );
-  QgsNetworkAccessManager::instance()->setTransferTimeout( 5 * 60 * 1000 );
-  // we cannot use "/" as separator, since QGIS puts a suffix QGIS/31700 anyway
-  const QString userAgent = QStringLiteral( "qfield|%1|%2|%3|" ).arg( qfield::appVersion, qfield::appVersionStr.normalized( QString::NormalizationForm_KD ), qfield::gitRev );
-  QgsSettings().setValue( QStringLiteral( "/qgis/networkAndProxy/userAgent" ), userAgent );
-
   if ( !QgsApplication::authManager()->availableAuthMethodConfigs().contains( mProviderConfigId ) )
   {
     mProviderConfigId.clear();

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -235,6 +235,12 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
     mScreenDimmer->setTimeout( settings.value( QStringLiteral( "dimTimeoutSeconds" ), 40 ).toInt() );
   }
 
+  QgsNetworkAccessManager::settingsNetworkTimeout->setValue( 60 * 1000 );
+
+  // we cannot use "/" as separator, since QGIS puts a suffix QGIS/31700 anyway
+  const QString userAgent = QStringLiteral( "qfield|%1|%2|%3|" ).arg( qfield::appVersion, qfield::appVersionStr.normalized( QString::NormalizationForm_KD ), qfield::gitRev );
+  settings.setValue( QStringLiteral( "/qgis/networkAndProxy/userAgent" ), userAgent );
+
   AppInterface::setInstance( mIface );
 
   //set the authHandler to qfield-handler


### PR DESCRIPTION
This PR adjusts our app-wide network request timeout away from 1 hour to 1 minute _of inactivity_. I've also relocated the setting away from the QFieldCloudConnection class into QgisMobileApp since it impacts every request across the board (including WMS/WFS/AFS/AMS/etc. providers).

Discovered this 1-hour timeout while dissecting a user project that would "freeze" QField. Indeed, a one hour wait for a dead server does feel like a frozen app :laughing: 