### PR TITLE
Update QGIS to catch more QML properties and add crucial WFS filter patch

### DIFF
--- a/vcpkg/ports/qgis/portfile.cmake
+++ b/vcpkg/ports/qgis/portfile.cmake
@@ -1,5 +1,5 @@
-set(QGIS_REF 0b6fed59e797ad26de56b8b437abc26a4c3ea171)
-set(QGIS_SHA512 972fcaa21694e7dfad4640af7f49c066ea3dc9469bafcbb82a00fa6925919dff8e61edd036fb529f2e29ac4397d800bf1a297fd072176c8ab741a37dc007447a)
+set(QGIS_REF e0c3959ffc57116664d48f4b687686d0360c6c89)
+set(QGIS_SHA512 07120e1754e1bcfd5a4f05a3225e266d8cc11525f85d933b50677c3aefff35b3d2b9c73db61795233eca8f472c631d509034d02461173095b4f7bbd66d88b641)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
@@ -15,6 +15,7 @@ vcpkg_from_github(
         crssync-no-install.patch
         include-qthread.patch
         processing.patch # Needed to avoid link issue with tinygltf (ATM embedded into QGIS) and _GEOSQueryCallback defined multiple times
+        wfsfilter.patch
 )
 
 

--- a/vcpkg/ports/qgis/wfsfilter.patch
+++ b/vcpkg/ports/qgis/wfsfilter.patch
@@ -1,0 +1,59 @@
+diff --git a/src/core/qgsogcutils.cpp b/src/core/qgsogcutils.cpp
+index 5d8e9f6b056..b49ab380748 100644
+--- a/src/core/qgsogcutils.cpp
++++ b/src/core/qgsogcutils.cpp
+@@ -2091,39 +2091,26 @@ QDomElement QgsOgcUtils::expressionToOgcExpression( const QgsExpression &express
+   if ( !node )
+     return QDomElement();
+ 
+-  switch ( node->nodeType() )
+-  {
+-    case QgsExpressionNode::ntFunction:
+-    case QgsExpressionNode::ntLiteral:
+-    case QgsExpressionNode::ntColumnRef:
+-    case QgsExpressionNode::ntUnaryOperator:
+-    {
+-      QgsOgcUtilsExprToFilter utils( doc, gmlVersion, filterVersion, QString(), QString(), geometryName, srsName, honourAxisOrientation, invertAxisOrientation, fieldNameToXPathMap, namespacePrefixToUriMap );
+-      const QDomElement exprRootElem = utils.expressionNodeToOgcFilter( node, &exp, &context );
+-
+-      if ( errorMessage )
+-        *errorMessage = utils.errorMessage();
++  QgsOgcUtilsExprToFilter utils( doc, gmlVersion, filterVersion, QString(), QString(), geometryName, srsName, honourAxisOrientation, invertAxisOrientation, fieldNameToXPathMap, namespacePrefixToUriMap );
++  const QDomElement exprRootElem = utils.expressionNodeToOgcFilter( node, &exp, &context );
+ 
+-      if ( !exprRootElem.isNull() )
+-      {
+-        if ( requiresFilterElement )
+-        {
+-          QDomElement filterElem = filterElement( doc, gmlVersion, filterVersion, utils.GMLNamespaceUsed() );
++  if ( errorMessage )
++  {
++    *errorMessage = utils.errorMessage();
++  }
+ 
+-          filterElem.appendChild( exprRootElem );
+-          return filterElem;
+-        }
+-        return exprRootElem;
+-      }
+-      break;
+-    }
+-    default:
++  if ( !exprRootElem.isNull() )
++  {
++    if ( requiresFilterElement )
+     {
+-      if ( errorMessage )
+-        *errorMessage = QObject::tr( "Node type not supported in expression translation: %1" ).arg( node->nodeType() );
++      QDomElement filterElem = filterElement( doc, gmlVersion, filterVersion, utils.GMLNamespaceUsed() );
++
++      filterElem.appendChild( exprRootElem );
++      return filterElem;
+     }
++    return exprRootElem;
+   }
+-  // got an error
++
+   return QDomElement();
+ }
+ 


### PR DESCRIPTION
The WFS filter patch is an important one. Without it, handling parent/children relationships within a feature form against WFS data sources leads to long UI freezes.