### PR TITLE
Fix absence of visibility toggle for groups containing all empty vector layer(s)

### DIFF
--- a/src/qml/Legend.qml
+++ b/src/qml/Legend.qml
@@ -164,7 +164,7 @@ ListView {
 
         Item {
           id: layerVisibility
-          property bool isVisible: Checkable && HasSpatialExtent
+          property bool isVisible: Checkable
           height: 24
           width: visible ? parent.height : 0
           anchors.verticalCenter: parent.verticalCenter


### PR DESCRIPTION
By requiring a spatial extent for the visibility toggle to show, we were creating a bad UX within groups containing all empty vector layer (s).

Scenario from user observed in the wild:
- a group contains 3 layers (point, line, polygon) that are empty by default so field users can fill them in
- the group will be shown grayed out and if not visible by default, users will not be able to toggle the visibility on