### PR TITLE
Allow feature list labels to wrap.

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -338,6 +338,7 @@ Pane {
         id: featureText
         anchors {
           leftMargin: featureFormList.multiSelection ? 50 : 10
+          rightMargin: 10
           left: parent.left
           right: parent.right
           verticalCenter: parent.verticalCenter


### PR DESCRIPTION
### 🚀 Description

Adds wrapping for labels in the feature list to prevent truncation and allow long feature names to flow onto multiple lines, improving readability in narrow layouts.

### 🎥 Demo
**old**  


https://github.com/user-attachments/assets/1a06a7fe-c919-4769-98a8-d0e46c5de6de

**new**


https://github.com/user-attachments/assets/c6c25c2a-84dd-4208-9cc7-396721df11e4
