### PR TITLE
Use QNetworkInformation to queue QFieldCloud pushes offline and resume when back online

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfieldcloudconnection.cpp
@@ -68,30 +68,13 @@ QFieldCloudConnection::QFieldCloudConnection()
   {
     connect( mNetworkInformation, &QNetworkInformation::reachabilityChanged, this,
              [this]( QNetworkInformation::Reachability ) {
-               emit isReachable();
+               emit isReachableChanged();
                tryFlushQueuedProjectPushes();
              } );
   }
 }
 
-
-bool QFieldCloudConnection::beginProjectPushOrQueue( const QString &projectId )
-{
-  if ( projectId.isEmpty() )
-  {
-    return false;
-  }
-
-  if ( !isReachableToCloud() )
-  {
-    requestQueuedProjectPush( projectId );
-    return false;
-  }
-
-  return true;
-}
-
-void QFieldCloudConnection::requestQueuedProjectPush( const QString &projectId )
+void QFieldCloudConnection::queueProjectPush( const QString &projectId )
 {
   if ( projectId.isEmpty() )
   {
@@ -119,7 +102,7 @@ void QFieldCloudConnection::tryFlushQueuedProjectPushes()
     return;
   }
 
-  if ( !isReachableToCloud() )
+  if ( !isReachable() )
   {
     return;
   }
@@ -137,7 +120,7 @@ void QFieldCloudConnection::tryFlushQueuedProjectPushes()
   mIsFlushingQueuedProjectPushes = false;
 }
 
-bool QFieldCloudConnection::isReachableToCloud() const
+bool QFieldCloudConnection::isReachable() const
 {
   if ( !mNetworkInformation || !mNetworkInformation->supports( QNetworkInformation::Feature::Reachability ) )
   {

--- a/src/core/qfieldcloud/qfieldcloudconnection.h
+++ b/src/core/qfieldcloud/qfieldcloudconnection.h
@@ -85,6 +85,8 @@ class QFieldCloudConnection : public QObject
 
     Q_PROPERTY( QList<AuthenticationProvider> availableProviders READ availableProviders NOTIFY availableProvidersChanged )
     Q_PROPERTY( bool isFetchingAvailableProviders READ isFetchingAvailableProviders NOTIFY isFetchingAvailableProvidersChanged )
+    Q_PROPERTY( bool isReachable READ isReachable NOTIFY isReachableChanged )
+
 
   public:
     enum class ConnectionStatus
@@ -220,14 +222,21 @@ class QFieldCloudConnection : public QObject
      */
     qsizetype uploadPendingAttachments();
 
+    /**
+     * Queues a project push request when the network is not reachable.
+     *
+     * The push will be automatically triggered once the connection is back online
+     * and the user is logged in.
+     */
+    void queueProjectPush( const QString &projectId );
 
     /**
-     * Called by the push initiator (typically QFieldCloudProject) before starting a push.
-     *      * Returns true if the push can start now.
-     * If the device is offline, the projectId is queued and will be re-emitted via
-     * queuedProjectPushRequested(projectId) once the connection becomes reachable again.
+     * Returns whether the network is currently reachable.
+     *
+     * If reachability information is not available, this returns true to keep
+     * the existing behavior unchanged.
      */
-    bool beginProjectPushOrQueue( const QString &projectId );
+    bool isReachable() const;
 
   signals:
     void providerChanged();
@@ -251,7 +260,7 @@ class QFieldCloudConnection : public QObject
     void availableProvidersChanged();
     void isFetchingAvailableProvidersChanged();
 
-    void isReachable();
+    void isReachableChanged();
     void queuedProjectPushRequested( const QString &projectId );
 
   private:
@@ -290,8 +299,6 @@ class QFieldCloudConnection : public QObject
     bool mIsFlushingQueuedProjectPushes = false;
 
     const QNetworkInformation *mNetworkInformation = nullptr;
-    bool isReachableToCloud() const;
-    void requestQueuedProjectPush( const QString &projectId );
     void tryFlushQueuedProjectPushes();
 };
 

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -131,7 +131,6 @@ void QFieldCloudProjectsModel::setCurrentProjectId( const QString &currentProjec
   mLayerObserver->setDeltaFileWrapper( mCurrentProject ? mCurrentProject->deltaFileWrapper() : nullptr );
 
   emit currentProjectIdChanged();
-  emit currentProjectChanged();
 }
 
 QFieldCloudProject *QFieldCloudProjectsModel::currentProject() const
@@ -359,8 +358,9 @@ void QFieldCloudProjectsModel::projectPush( const QString &projectId, const bool
     return;
   }
 
-  if ( !mCloudConnection->beginProjectPushOrQueue( projectId ) )
+  if ( !mCloudConnection->isReachable() )
   {
+    mCloudConnection->queueProjectPush( projectId );
     emit warning( tr( "Network is not currently active. "
                       "We will push the changes automatically once you are back online." ) );
     return;


### PR DESCRIPTION
This change adds a small push-deferral mechanism in QFieldCloudConnection: when a project push is requested while the device is offline (or reachability is not confirmed), the project ID is queued and the push is automatically retried once the device becomes reachable again.

- Uses QNetworkInformation::Reachability to detect online/offline transitions (reachabilityChanged)
- Adds queueProjectPush(), and tryFlushQueuedProjectPushes() in QFieldCloudConnection
- Queues project IDs (deduped via QSet<QString>) and flushes them only when LoggedIn + reachable
- Emits queuedProjectPush(projectId) when flushing; QFieldCloudProjectsModel listens and calls projectPush(projectId, /*shouldDownloadUpdates=*/false)
- Keeps behavior unchanged when no reachability backend is available (treats as “online” / no deferral)

https://github.com/user-attachments/assets/c1545f8c-22ab-4187-92be-9be88d2a7746