### PR TITLE
Make some space to fix random linux CI failures

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,6 +24,17 @@ jobs:
         with:
           submodules: recursive
 
+      - name: ♻️ Check disk space
+        run: df . -h
+
+      - name: 🧹 Reclaim disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android/
+          sudo rm -rf /opt/ghc
+
+      - name: ♻️ Check disk space
+        run: df . -h
+
       - name: 🌾 Prepare variables
         id: vars
         run: |


### PR DESCRIPTION
Let's see if that's enough.

We gained ~9GB, it should be enough:

<img width="537" height="341" alt="image" src="https://github.com/user-attachments/assets/eea33335-6fa7-407f-be44-7f5b4fb128c6" />
