### PR TITLE
Fix flacky map canvas scale logic introduced in 4.0

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -342,21 +342,19 @@ void QgsQuickMapCanvasMap::onZRangeChanged()
 
 void QgsQuickMapCanvasMap::updateTransform( bool skipSmooth )
 {
-  const QgsRectangle imageExtent = mImageMapSettings.extent();
-  const QgsPointXY center = imageExtent.center();
+  const QgsPointXY center = mImageMapSettings.extent().center();
   const QgsPointXY pixelPt = mMapSettings->coordinateToScreen( QgsPoint( center.x(), center.y() ) );
-  const QgsRectangle newExtent = mMapSettings->mapSettings().extent();
 
   if ( mSmooth && !skipSmooth )
   {
-    setProperty( "scale", static_cast<double>( mMapSettings->computeScaleForExtent( imageExtent ) ) / mMapSettings->computeScaleForExtent( newExtent ) );
+    setProperty( "scale", mImageMapSettings.mapUnitsPerPixel() / mMapSettings->mapSettings().mapUnitsPerPixel() );
     setProperty( "rotation", mMapSettings->mapSettings().rotation() - mImageMapSettings.rotation() );
     setProperty( "x", pixelPt.x() - static_cast<qreal>( mMapSettings->outputSize().width() ) / mMapSettings->devicePixelRatio() / 2 );
     setProperty( "y", pixelPt.y() - static_cast<qreal>( mMapSettings->outputSize().height() ) / mMapSettings->devicePixelRatio() / 2 );
   }
   else
   {
-    setScale( static_cast<double>( mMapSettings->computeScaleForExtent( imageExtent ) ) / mMapSettings->computeScaleForExtent( newExtent ) );
+    setScale( mImageMapSettings.mapUnitsPerPixel() / mMapSettings->mapSettings().mapUnitsPerPixel() );
     setRotation( mMapSettings->mapSettings().rotation() - mImageMapSettings.rotation() );
     setX( pixelPt.x() - static_cast<qreal>( mMapSettings->outputSize().width() ) / mMapSettings->devicePixelRatio() / 2 );
     setY( pixelPt.y() - static_cast<qreal>( mMapSettings->outputSize().height() ) / mMapSettings->devicePixelRatio() / 2 );


### PR DESCRIPTION
When developing the jump to location/geometry functionality for 4.0, we moved from using extent to using scale when computing the item scale transform. This resulted in flacky behavior on quite a few projections including WGS84 since scale value will change for the same given extent based on your latitude. 

This PR relies on MUPP values instead. 