### PR TITLE
Disable all but the smoke test on Windows to speed up CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -83,6 +83,7 @@ jobs:
                 -D VCPKG_HOST_TRIPLET="x64-windows-static" \
                 -D WITH_VCPKG=ON \
                 -D WITH_SPIX=ON \
+                -D WITH_UNITTESTS=OFF \
                 -D WITH_NFC=OFF \
                 -D APP_VERSION="${APP_VERSION}" \
                 -D APP_VERSION_STR="${APP_VERSION_STR}" \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,12 +83,6 @@ set(WITH_NFC
     ON
     CACHE BOOL "Enable NFC support")
 
-set(WITH_SPIX FALSE CACHE BOOL "Compile with Spix for testing")
-
-if (WITH_SPIX)
-  find_package(Spix REQUIRED)
-endif ()
-
 set(SENTRY_DSN "" CACHE STRING "The sentry dsn for logging purpose. If not set, sentry will be disabled")
 set(SENTRY_ENV "" CACHE STRING "The sentry environment for logging purpose.")
 mark_as_advanced(SENTRY_DSN SENTRY_ENV)
@@ -144,8 +138,9 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
   message(STATUS "QT_HOST_PATH: ${QT_HOST_PATH}")
 endif()
 
-set (TEST_DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/test/testdata")
-set(ENABLE_TESTS CACHE BOOL "Build unit tests")
+set(ENABLE_TESTS CACHE BOOL "Enable tests")
+set(WITH_UNITTESTS TRUE CACHE BOOL "Enable unit tests")
+set(WITH_SPIX FALSE CACHE BOOL "Compile with Spix for testing")
 
 if(MSVC)
   add_definitions(-D_USE_MATH_DEFINES)
@@ -171,6 +166,14 @@ else()
 endif()
 file(MAKE_DIRECTORY "${SHARE_DIR}")
 
+if(WITH_SENTRY)
+  add_subdirectory(src/sentry)
+endif()
+
+if (WITH_SPIX)
+  find_package(Spix REQUIRED)
+endif ()
+
 add_subdirectory(src/core)
 add_subdirectory(src/qml)
 if (ANDROID)
@@ -178,11 +181,9 @@ if (ANDROID)
 endif()
 add_subdirectory(src/app)
 
-if(WITH_SENTRY)
-  add_subdirectory(src/sentry)
-endif()
-
 if (ENABLE_TESTS)
+  set (TEST_DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/test/testdata")
+
   find_package(Qt6 COMPONENTS Test QuickTest)
   enable_testing()
   add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,7 +109,7 @@ endif()
 
 add_definitions(-DTEST_DATA_DIR="${TEST_DATA_DIR}")
 
-if (NOT WIN32)
+if (WITH_UNITTESTS)
   ADD_CATCH2_TEST(layerobservertest test_layerobserver.cpp FALSE)
   ADD_CATCH2_TEST(featureutilstest test_featureutils.cpp TRUE)
   ADD_CATCH2_TEST(featuremodeltest test_featuremodel.cpp TRUE)
@@ -128,6 +128,6 @@ if (NOT WIN32)
   ADD_CATCH2_TEST(appinterfacetest test_appinterface.cpp TRUE)
   ADD_CATCH2_TEST(trackingtest test_tracking.cpp FALSE)
   ADD_CATCH2_TEST(identifytool test_identifytool.cpp TRUE)
-endif()
 
-ADD_QFIELD_QML_TEST(qmltest test_qml.cpp)
+  ADD_QFIELD_QML_TEST(qmltest test_qml.cpp)
+endif()


### PR DESCRIPTION
@m-kuhn , can you think of a better idea? I feel that's acceptable to get an OK CI speed for Windows.

FYI, this brings down the build time from 1h1m to 12m.