### PR TITLE
Fix project folder view and message log lack of scene left/right margin support

### DIFF
--- a/src/qml/MessageLog.qml
+++ b/src/qml/MessageLog.qml
@@ -18,6 +18,8 @@ Page {
 
   visible: false
   focus: visible
+  leftPadding: mainWindow.sceneLeftMargin
+  rightPadding: mainWindow.sceneRightMargin
 
   header: QfPageHeader {
     title: qsTr('Message Logs')

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -19,6 +19,8 @@ Page {
   signal finished(var loading)
 
   focus: visible
+  leftPadding: mainWindow.sceneLeftMargin
+  rightPadding: mainWindow.sceneRightMargin
 
   onVisibleChanged: {
     if (visible) {


### PR DESCRIPTION
Fixes inaccessible 3-dot menu here:

<img width="1015" height="415" alt="image" src="https://github.com/user-attachments/assets/e88bf096-771c-42e4-9303-27e59a9aa8f6" />
