### PR TITLE
Do not attach locations to translation source strings

### DIFF
--- a/scripts/ci/update-translations.sh
+++ b/scripts/ci/update-translations.sh
@@ -4,7 +4,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 SOURCE_DIR=${DIR}/../..
 source ${SOURCE_DIR}/scripts/version_number.sh
 
-/usr/lib/qt6/bin/lupdate -recursive ${SOURCE_DIR} -ts ${SOURCE_DIR}/i18n/qfield_en.ts
+/usr/lib/qt6/bin/lupdate -locations none -recursive ${SOURCE_DIR} -ts ${SOURCE_DIR}/i18n/qfield_en.ts
 
 # release only if the branch is master
 if [[ ${CI_BRANCH} = master ]]; then


### PR DESCRIPTION
Since we moved lupdate to Qt6, source locations are being appended and it creates a lot of noise on the translation synchronization front. Let's skip the location when we push to transifex.