### PR TITLE
Fix settings panel ignoring scene left/right margin restraints

### DIFF
--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -295,11 +295,11 @@ Page {
 
     SwipeView {
       id: swipeView
-      width: mainWindow.width
       currentIndex: bar.currentIndex
       Layout.fillHeight: true
       Layout.fillWidth: true
       onCurrentIndexChanged: bar.currentIndex = swipeView.currentIndex
+      clip: true
 
       Item {
         ScrollView {
@@ -316,7 +316,7 @@ Page {
 
           ColumnLayout {
             id: generalSettingsGrid
-            width: parent.parent.width
+            width: swipeView.width
 
             GridLayout {
               Layout.fillWidth: true
@@ -339,7 +339,7 @@ Page {
             }
 
             ListView {
-              Layout.preferredWidth: mainWindow.width
+              Layout.fillWidth: true
               Layout.preferredHeight: childrenRect.height
               interactive: false
 
@@ -437,7 +437,7 @@ Page {
             }
 
             ListView {
-              Layout.preferredWidth: mainWindow.width
+              Layout.fillWidth: true
               Layout.preferredHeight: childrenRect.height
               interactive: false
 
@@ -528,7 +528,7 @@ Page {
             }
 
             ListView {
-              Layout.preferredWidth: mainWindow.width
+              Layout.fillWidth: true
               Layout.preferredHeight: childrenRect.height
               interactive: false
 
@@ -797,7 +797,7 @@ Page {
             }
 
             ListView {
-              Layout.preferredWidth: mainWindow.width
+              Layout.fillWidth: true
               Layout.preferredHeight: childrenRect.height
               interactive: false
 


### PR DESCRIPTION
Fixes settings going under navigation bar, as seen here:

<img width="1600" height="725" alt="image" src="https://github.com/user-attachments/assets/b7db8151-c7d5-4ef4-a2f9-de1adac6659e" />

@beanzmo , should fix it.