### PR TITLE
Force native camera usage on iOS until the crasher can be addressed

### DIFF
--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -750,7 +750,7 @@ EditorWidgetBase {
 
   function capturePhoto() {
     Qt.inputMethod.hide();
-    if (platformUtilities.capabilities & PlatformUtilities.NativeCamera && settings.valueBool("nativeCamera2", true)) {
+    if (platformUtilities.capabilities & PlatformUtilities.NativeCamera && (settings.valueBool("nativeCamera2", true) || Qt.platform.os === "ios")) {
       var filepath = getResourceFilePath();
       // Pictures taken by cameras will always be JPG
       filepath = filepath.replace('{extension}', 'JPG');
@@ -764,7 +764,7 @@ EditorWidgetBase {
 
   function captureVideo() {
     Qt.inputMethod.hide();
-    if (platformUtilities.capabilities & PlatformUtilities.NativeCamera && settings.valueBool("nativeCamera2", true)) {
+    if (platformUtilities.capabilities & PlatformUtilities.NativeCamera && (settings.valueBool("nativeCamera2", true) || Qt.platform.os === "ios")) {
       var filepath = getResourceFilePath();
       // Video taken by cameras will always be MP4
       filepath = filepath.replace('{extension}', 'MP4');


### PR DESCRIPTION
We've got a regression on iOS whereas capturing a photo through the Qt Camera QML items crash. Let's force the use of native camera until we can figure out what's wrong (so far, our attempts at fixing this have failed).