### PR TITLE
Add libsm and libice dependencies to Dockerfile

### DIFF
--- a/.docker/android_dev/Dockerfile
+++ b/.docker/android_dev/Dockerfile
@@ -29,7 +29,7 @@ ENV APT_PACKAGES="$APT_PACKAGES libxext-dev libxfixes-dev libxrender-dev \
   libxcb-image0-dev libxcb-shm0-dev libxcb-icccm4-dev libxcb-sync-dev \
   libxcb-xfixes0-dev libxcb-shape0-dev libxcb-randr0-dev \
   libxcb-render-util0-dev libxcb-xinerama0-dev libxcb-xkb-dev libxcb-xinput-dev \
-  libxcb-cursor-dev libxkbcommon-x11-dev libcups2-dev"
+  libxcb-cursor-dev libxkbcommon-x11-dev libcups2-dev libsm-dev libice-dev"
 
 ## qtbase for android
 ENV APT_PACKAGES="$APT_PACKAGES openjdk-17-jre-headless openjdk-17-jdk-headless"


### PR DESCRIPTION
Building Qt-Base ( x64-linux ) fails if those deps aren't installed. Error look like this :

```
ERROR: Feature "xcb_sm": Forcing to "ON" breaks its condition:
    QT_FEATURE_sessionmanager AND X11_SM_FOUND
Condition values dump:
    QT_FEATURE_sessionmanager = "ON"
    X11_SM_FOUND = ""

CMake Error at cmake/QtBuildInformation.cmake:240 (message):
  Check the configuration messages for an error that has occurred.
``