### PR TITLE
Fix QFieldCamera bug not opening reliably/immediately after permission allowed

### DIFF
--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -24,10 +24,12 @@ Popup {
   property bool captureLoaderActivated: false
 
   function requiredPermissionsGranted() {
-    if (cameraPermission.status !== Qt.PermissionStatus.Granted)
+    if (cameraPermission.status !== Qt.PermissionStatus.Granted) {
       return false;
-    if (state === "VideoCapture" && microphonePermission.status !== Qt.PermissionStatus.Granted)
+    }
+    if (state === "VideoCapture" && microphonePermission.status !== Qt.PermissionStatus.Granted) {
       return false;
+    }
     return true;
   }
 


### PR DESCRIPTION
When using the in-app camera (QFieldCamera), if the system permission popup (camera/mic) appeared, the camera wouldn’t open immediately after the user accepted, but appears blank, so either we had to navigate back and reopen camera, in this case worked because permission was granted before.

Fix
- Added a Loader (captureLoader) around the whole camera stack (VideoOutput, CaptureSession, Camera, ImageCapture, MediaRecorder). -> don’t even create/activate the camera session until permissions are granted as this avoids the “blank preview after accepting permission” problem.

- Made captureLoader.active depend on permissions

- Moved init work into captureLoader.onLoaded (instead of always-on objects):
Set recorder format (AAC/H264/MPEG4)
Pick camera device (saved deviceId or default)

- Apply camera format -> These only make sense once the camera session exists (after permissions)

- Updated all references from direct ids -> loader item aliases like captureSession / camera / imageCapture / recorder / videoOutput now accessed via captureLoader.item.*

- Added “Loader.Ready” guards everywhere
PinchArea/WheelHandler enabled checks include captureLoader.status === Loader.Ready
Capture button returns early if loader isn’t ready

- Flash/zoom/menus require loader ready -> prevents calling camera APIs while the session doesn’t exist yet

- Grid overlay changed a bit with added readyForGrid check and only uses videoOutput.contentRect when valid -> contentRect can be 0/invalid right after load; avoids bad math or layout glitches.

- Reset cleanup added in onAboutToShow - > currentPath = "", clear previews, stop video preview ..-> ensures reopening camera always starts from a clean state

Below is the video showing how it used to work before and how it works now;

https://github.com/user-attachments/assets/b19f400d-98eb-4811-acd6-07423d5e1ced

After

https://github.com/user-attachments/assets/6116a113-94cf-46dd-94e9-506525a4ebd7