### PR TITLE
Add additional QFieldCloud CI tests

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -128,7 +128,10 @@ void QFieldCloudProjectsModel::setCurrentProjectId( const QString &currentProjec
   mCurrentProjectId = currentProjectId;
   mCurrentProject = findProject( mCurrentProjectId );
 
-  mLayerObserver->setDeltaFileWrapper( mCurrentProject ? mCurrentProject->deltaFileWrapper() : nullptr );
+  if ( mLayerObserver )
+  {
+    mLayerObserver->setDeltaFileWrapper( mCurrentProject ? mCurrentProject->deltaFileWrapper() : nullptr );
+  }
 
   emit currentProjectIdChanged();
   emit currentProjectChanged();


### PR DESCRIPTION
### 🚀 Description
Extends existing QFieldCloud screen tests with comprehensive download workflow coverage. Tests interact with UI elements (button clicks, delegates) to verify download functionality, cancellation, and concurrent operations.

### ✨ Key Changes
* Add 5 new test cases 
  * Test project existence verification
  * Complete downloads 
  * Cancellation
  * Concurrent downloads
  * Repeated cycles (download/cancel)

### 🧪 New tests verify
- ✅ Test projects (QFieldCloudTesting, TestCloudLargeProject) appear in table delegates
- ✅ Download button click triggers state transitions (Idle → Downloading → Idle)
- ✅ Progress tracking updates correctly (0 → 1) and localPath gets populated
- ✅ Cancellation during download resets state properly
- ✅ Two projects can download simultaneously without conflicts
- ✅ Repeated cancel/download cycles maintain consistent behavior
- ✅ With the QFieldCloudProjectsModel , when we setCurrentProjectId
   - A/ the currentProjectId and currentProject changed signals are both triggered
   - B/ that the currentProject points to the correct cloud protect with the matching id
