### PR TITLE
Add a good visual queue when all constraints are met

### DIFF
--- a/src/core/attributeformmodel.cpp
+++ b/src/core/attributeformmodel.cpp
@@ -25,6 +25,7 @@ AttributeFormModel::AttributeFormModel( QObject *parent )
 
   connect( mSourceModel, &AttributeFormModelBase::hasTabsChanged, this, &AttributeFormModel::hasTabsChanged );
   connect( mSourceModel, &AttributeFormModelBase::hasRemembranceChanged, this, &AttributeFormModel::hasRemembranceChanged );
+  connect( mSourceModel, &AttributeFormModelBase::hasConstraintsChanged, this, &AttributeFormModel::hasConstraintsChanged );
   connect( mSourceModel, &AttributeFormModelBase::featureModelChanged, this, &AttributeFormModel::featureModelChanged );
   connect( mSourceModel, &AttributeFormModelBase::featureChanged, this, &AttributeFormModel::featureChanged );
   connect( mSourceModel, &AttributeFormModelBase::constraintsHardValidChanged, this, &AttributeFormModel::constraintsHardValidChanged );
@@ -39,6 +40,11 @@ bool AttributeFormModel::hasTabs() const
 bool AttributeFormModel::hasRemembrance() const
 {
   return mSourceModel->hasRemembrance();
+}
+
+bool AttributeFormModel::hasConstraints() const
+{
+  return mSourceModel->hasConstraints();
 }
 
 FeatureModel *AttributeFormModel::featureModel() const

--- a/src/core/attributeformmodel.h
+++ b/src/core/attributeformmodel.h
@@ -32,6 +32,7 @@ class AttributeFormModel : public QSortFilterProxyModel
     Q_PROPERTY( FeatureModel *featureModel READ featureModel WRITE setFeatureModel NOTIFY featureModelChanged )
     Q_PROPERTY( bool hasTabs READ hasTabs NOTIFY hasTabsChanged )
     Q_PROPERTY( bool hasRemembrance READ hasRemembrance NOTIFY hasRemembranceChanged )
+    Q_PROPERTY( bool hasConstraints READ hasConstraints NOTIFY hasConstraintsChanged )
     Q_PROPERTY( bool constraintsHardValid READ constraintsHardValid NOTIFY constraintsHardValidChanged )
     Q_PROPERTY( bool constraintsSoftValid READ constraintsSoftValid NOTIFY constraintsSoftValidChanged )
 
@@ -76,6 +77,7 @@ class AttributeFormModel : public QSortFilterProxyModel
 
     bool hasTabs() const;
     bool hasRemembrance() const;
+    bool hasConstraints() const;
 
     FeatureModel *featureModel() const;
     void setFeatureModel( FeatureModel *featureModel );
@@ -124,6 +126,7 @@ class AttributeFormModel : public QSortFilterProxyModel
     void featureModelChanged();
     void hasTabsChanged();
     void hasRemembranceChanged();
+    void hasConstraintsChanged();
     void featureChanged();
     void constraintsHardValidChanged();
     void constraintsSoftValidChanged();

--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -193,6 +193,7 @@ void AttributeFormModelBase::resetModel()
   setConstraintsSoftValid( true );
   setHasTabs( false );
   setHasRemembrance( false );
+  setHasConstraints( false );
 
   if ( !mFeatureModel )
     return;
@@ -587,7 +588,15 @@ void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, 
           descriptions << tr( "Unique" );
         }
 
-        item->setData( descriptions.join( ", " ), AttributeFormModel::ConstraintDescription );
+        if ( !descriptions.isEmpty() )
+        {
+          setHasConstraints( true );
+          item->setData( descriptions.join( ", " ), AttributeFormModel::ConstraintDescription );
+        }
+        else
+        {
+          item->setData( QString(), AttributeFormModel::ConstraintDescription );
+        }
 
         QgsProperty property = mLayer->editFormConfig().dataDefinedFieldProperties( field.name() ).property( QgsEditFormConfig::DataDefinedProperty::Alias );
         if ( property.isActive() )
@@ -1204,6 +1213,20 @@ void AttributeFormModelBase::setHasRemembrance( bool hasRemembrance )
 
   mHasRemembrance = hasRemembrance;
   emit hasRemembranceChanged();
+}
+
+bool AttributeFormModelBase::hasConstraints() const
+{
+  return mHasConstraints;
+}
+
+void AttributeFormModelBase::setHasConstraints( bool hasConstraints )
+{
+  if ( hasConstraints == mHasConstraints )
+    return;
+
+  mHasConstraints = hasConstraints;
+  emit hasConstraintsChanged();
 }
 
 bool AttributeFormModelBase::save()

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -47,6 +47,9 @@ class AttributeFormModelBase : public QStandardItemModel
     bool hasRemembrance() const;
     void setHasRemembrance( bool hasRemembrance );
 
+    bool hasConstraints() const;
+    void setHasConstraints( bool hasConstraints );
+
     //! \copydoc AttributeFormModel::save
     bool save();
 
@@ -82,6 +85,7 @@ class AttributeFormModelBase : public QStandardItemModel
     void featureModelChanged();
     void hasTabsChanged();
     void hasRemembranceChanged();
+    void hasConstraintsChanged();
     void featureChanged();
     void constraintsHardValidChanged();
     void constraintsSoftValidChanged();
@@ -152,6 +156,7 @@ class AttributeFormModelBase : public QStandardItemModel
 
     bool mHasTabs = false;
     bool mHasRemembrance = false;
+    bool mHasConstraints = false;
 
     typedef QPair<QgsExpression, QStandardItem *> VisibilityExpression;
     QList<VisibilityExpression> mVisibilityExpressions;

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -887,7 +887,7 @@ Page {
 
         iconSource: Theme.getThemeVectorIcon("ic_check_white_24dp")
         iconColor: (form.state === 'Add' && model.featureModel.featureAdditionLocked) || !model.constraintsHardValid ? Theme.mainOverlayColor : Theme.mainTextColor
-        bgcolor: (form.state === 'Add' && model.featureModel.featureAdditionLocked) || !model.constraintsHardValid ? Theme.errorColor : !model.constraintsSoftValid ? Theme.warningColor : "transparent"
+        bgcolor: (form.state === 'Add' && model.featureModel.featureAdditionLocked) || !model.constraintsHardValid ? Theme.errorColor : !model.constraintsSoftValid ? Theme.warningColor : model.hasConstraints ? Theme.goodColor : "transparent"
         borderColor: Theme.mainBackgroundColor
         roundborder: true
         round: true

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -257,7 +257,7 @@ Rectangle {
 
     iconSource: Theme.getThemeVectorIcon("ic_check_white_24dp")
     iconColor: !featureForm.model.constraintsHardValid ? Theme.mainOverlayColor : Theme.mainTextColor
-    bgcolor: !featureForm.model.constraintsHardValid ? Theme.errorColor : !featureForm.model.constraintsSoftValid ? Theme.warningColor : "transparent"
+    bgcolor: !featureForm.model.constraintsHardValid ? Theme.errorColor : !featureForm.model.constraintsSoftValid ? Theme.warningColor : featureForm.model.hasConstraints ? Theme.goodColor : "transparent"
     borderColor: Theme.mainBackgroundColor
     roundborder: true
     round: true

--- a/src/qml/imports/Theme/Theme.qml
+++ b/src/qml/imports/Theme/Theme.qml
@@ -85,6 +85,7 @@ QtObject {
   property color lightestGraySemiOpaque: "#e0eeeeee"
   property color light: "#ffffff"
 
+  property color goodColor: "#80cc28"
   property color errorColor: darkTheme ? "#df3422" : "#c0392b"
   property color warningColor: "orange"
   property color cloudColor: "#4c6dac"


### PR DESCRIPTION
For QField 4.0, as part of our UI/UX improvements to be less intimidating and keep the focus on the data and canvas, we got rid of QField-green filled header bar.

However, it turns out that the QField-green filled header was used as a good "every constraints are met, go ahead" visual feedback when a feature form had constraints. And while it never occurred to me because all I see in this green is "QField", is of course makes _complete_ sense :)

So, this PR re-introduced that visual language. Screenshot time.

When a layer has no constraints, we continue to look like QField >= 4.0:

<img width="522" height="494" alt="image" src="https://github.com/user-attachments/assets/754af132-01b4-4f61-ab5e-a62fc4dbe867" />

When a layer has constraints and hard constraints are not met:

<img width="522" height="494" alt="image" src="https://github.com/user-attachments/assets/ae3c978a-3351-406c-a88c-2d4463c2585a" />

When a layer has constraints and soft constraints are not met:

<img width="522" height="494" alt="image" src="https://github.com/user-attachments/assets/6d2cecfb-78e4-4807-9827-f7db8d9da34e" />

When a layer has constraints and all constraints are positively met:

<img width="522" height="494" alt="image" src="https://github.com/user-attachments/assets/5d47ab90-fc90-4371-8098-7bf750113d83" />
