### PR TITLE
More resilience for runner updates

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - release-**
-      - x-abi-tools-use-exact-versions
   pull_request:
   release:
     types: ['published']

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -135,7 +135,8 @@ jobs:
                 -D CMAKE_OSX_DEPLOYMENT_TARGET=${{ env.DEPLOYMENT_TARGET }} \
                 -D ENABLE_TESTS=OFF \
                 -D CMAKE_CXX_VISIBILITY_PRESET=hidden \
-                -D WITH_CCACHE=ON
+                -D WITH_CCACHE=ON \
+                -D VCPKG_INSTALL_OPTIONS="--x-abi-tools-use-exact-versions"
 
       - name: 📑 Upload Dep Build Logs
         uses: actions/upload-artifact@v6

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -93,7 +93,8 @@ jobs:
                 -D CMAKE_COMPILE_WARNING_AS_ERROR=ON \
                 -D SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
                 -D SENTRY_ENV="${APP_ENV}" \
-                -D LINUXDEPLOY_EXECUTABLE=${{ env.BUILD_ROOT }}/linuxdeploy-x86_64.AppImage
+                -D LINUXDEPLOY_EXECUTABLE=${{ env.BUILD_ROOT }}/linuxdeploy-x86_64.AppImage \
+                -D VCPKG_INSTALL_OPTIONS="--x-abi-tools-use-exact-versions"
 
       - name: 📑 Upload dep build logs
         uses: actions/upload-artifact@v6

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -108,7 +108,8 @@ jobs:
                 -D CMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.deployment-target }} \
                 -D CMAKE_OSX_ARCHITECTURES=${{ matrix.target-arch }} \
                 -D VCPKG_TARGET_TRIPLET=${{ matrix.triplet }} \
-                -D WITH_CCACHE=ON
+                -D WITH_CCACHE=ON \
+                -D VCPKG_INSTALL_OPTIONS="--x-abi-tools-use-exact-versions"
 
       - name: 🌋 Build
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -94,7 +94,7 @@ jobs:
                 -D CMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded\$<\$<CONFIG:Debug>:Debug>" \
                 -D PKG_CONFIG_EXECUTABLE=${CMAKE_BUILD_DIR}/vcpkg_installed/x64-windows-static/tools/pkgconf/pkgconf.exe \
                 -D WITH_BLUETOOTH=ON \
-                -D VCPKG_INSTALL_OPTIONS="--x-buildtrees-root=C:/src" \
+                -D VCPKG_INSTALL_OPTIONS="--x-buildtrees-root=C:/src;--x-abi-tools-use-exact-versions" \
                 -D CMAKE_COMPILE_WARNING_AS_ERROR=ON \
                 -D SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
                 -D SENTRY_ENV="${APP_ENV}" \


### PR DESCRIPTION
This makes sure we don't need to rebuild all dependencies when the github hosted runners receive updates.
The tradeoff is that not necessarily all dependencies are built with the exact same tools. In general I don't expect a lot of hickups (and in contrast, more stability of our CI).

If we run into troubles, we might need to manually force a dependency rebuild by changing the triplet.