### PR TITLE
Improve expand/collapse all behavior, use properties

### DIFF
--- a/src/core/layertreemodel.cpp
+++ b/src/core/layertreemodel.cpp
@@ -38,6 +38,8 @@ FlatLayerTreeModel::FlatLayerTreeModel( QgsLayerTree *layerTree, QgsProject *pro
   connect( mSourceModel, &FlatLayerTreeModelBase::layersAdded, this, &FlatLayerTreeModel::layersAdded );
   connect( mSourceModel, &FlatLayerTreeModelBase::layersRemoved, this, &FlatLayerTreeModel::layersRemoved );
   connect( mSourceModel, &FlatLayerTreeModelBase::mapThemeChanged, this, &FlatLayerTreeModel::mapThemeChanged );
+  connect( mSourceModel, &FlatLayerTreeModelBase::hasCollapsibleItemsChanged, this, &FlatLayerTreeModel::hasCollapsibleItemsChanged );
+  connect( mSourceModel, &FlatLayerTreeModelBase::isCollapsedChanged, this, &FlatLayerTreeModel::isCollapsedChanged );
   connect( mSourceModel, &FlatLayerTreeModelBase::isTemporalChanged, this, &FlatLayerTreeModel::isTemporalChanged );
   connect( mSourceModel, &FlatLayerTreeModelBase::isFrozenChanged, this, &FlatLayerTreeModel::isFrozenChanged );
 }
@@ -124,30 +126,11 @@ void FlatLayerTreeModel::setAllCollapsed( bool collapsed )
 
 bool FlatLayerTreeModel::hasCollapsibleItems() const
 {
-  const int count = rowCount();
-  for ( int i = 0; i < count; i++ )
-  {
-    const QModelIndex idx = index( i, 0 );
-    if ( data( idx, FlatLayerTreeModel::HasChildren ).toBool() )
-    {
-      return true;
-    }
-  }
-  return false;
+  return mSourceModel->hasCollapsibleItems();
 }
-
-bool FlatLayerTreeModel::isAllCollapsed() const
+bool FlatLayerTreeModel::isCollapsed() const
 {
-  const int count = rowCount();
-  for ( int i = 0; i < count; i++ )
-  {
-    const QModelIndex idx = index( i, 0 );
-    if ( data( idx, FlatLayerTreeModel::HasChildren ).toBool() && !data( idx, FlatLayerTreeModel::IsCollapsed ).toBool() )
-    {
-      return false;
-    }
-  }
-  return true;
+  return mSourceModel->isCollapsed();
 }
 
 FlatLayerTreeModelBase::FlatLayerTreeModelBase( QgsLayerTree *layerTree, QgsProject *project, QObject *parent )
@@ -510,7 +493,12 @@ int FlatLayerTreeModelBase::buildMap( QgsLayerTreeModel *model, const QModelInde
   }
 
   if ( reset )
+  {
     endResetModel();
+    checkHasCollapsibleItems();
+    checkIsCollapsed();
+  }
+
   return row;
 }
 
@@ -1294,9 +1282,12 @@ bool FlatLayerTreeModelBase::setData( const QModelIndex &index, const QVariant &
       int treeLevel = mTreeLevelMap[index.row()];
       int endRow = index.row();
       while ( mTreeLevelMap.contains( endRow + 1 ) && mTreeLevelMap[endRow + 1] > treeLevel )
+      {
         endRow++;
+      }
 
       emit dataChanged( index, createIndex( endRow, 0 ), QVector<int>() << FlatLayerTreeModel::IsCollapsed << FlatLayerTreeModel::IsParentCollapsed );
+      checkIsCollapsed();
       return true;
     }
 
@@ -1579,6 +1570,11 @@ QgsRectangle FlatLayerTreeModelBase::nodeExtent( const QModelIndex &index, QgsQu
 
 void FlatLayerTreeModelBase::setAllCollapsed( bool collapsed )
 {
+  if ( !mHasCollapsibleItems || mIsCollapsed == collapsed )
+  {
+    return;
+  }
+
   bool anyChanged = true;
   while ( anyChanged )
   {
@@ -1598,5 +1594,64 @@ void FlatLayerTreeModelBase::setAllCollapsed( bool collapsed )
         anyChanged = true;
       }
     }
+  }
+}
+
+bool FlatLayerTreeModelBase::hasCollapsibleItems() const
+{
+  return mHasCollapsibleItems;
+}
+
+void FlatLayerTreeModelBase::checkHasCollapsibleItems()
+{
+  bool hasCollpasibleItems = false;
+  const int count = rowCount();
+  for ( int i = 0; i < count; i++ )
+  {
+    const QModelIndex idx = index( i, 0 );
+    if ( data( idx, FlatLayerTreeModel::HasChildren ).toBool() )
+    {
+      hasCollpasibleItems = true;
+      break;
+    }
+  }
+
+  if ( mHasCollapsibleItems != hasCollpasibleItems )
+  {
+    mHasCollapsibleItems = hasCollpasibleItems;
+    emit hasCollapsibleItemsChanged();
+  }
+}
+
+bool FlatLayerTreeModelBase::isCollapsed() const
+{
+  return mIsCollapsed;
+}
+
+void FlatLayerTreeModelBase::checkIsCollapsed()
+{
+  bool isCollapsed = false;
+  if ( mHasCollapsibleItems )
+  {
+    isCollapsed = true;
+    const int count = rowCount();
+    for ( int i = 0; i < count; i++ )
+    {
+      const QModelIndex idx = index( i, 0 );
+      if ( data( idx, FlatLayerTreeModel::HasChildren ).toBool() && data( idx, FlatLayerTreeModel::TreeLevel ).toInt() == 0 )
+      {
+        if ( !data( idx, FlatLayerTreeModel::IsCollapsed ).toBool() )
+        {
+          isCollapsed = false;
+          break;
+        }
+      }
+    }
+  }
+
+  if ( mIsCollapsed != isCollapsed )
+  {
+    mIsCollapsed = isCollapsed;
+    emit isCollapsedChanged();
   }
 }

--- a/src/core/layertreemodel.h
+++ b/src/core/layertreemodel.h
@@ -77,15 +77,23 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
     bool isTemporal() const { return mIsTemporal; }
 
     //! Calculate layer tree node extent and add optional buffer
-    Q_INVOKABLE QgsRectangle nodeExtent( const QModelIndex &index, QgsQuickMapSettings *mapSettings, const float buffer );
+    QgsRectangle nodeExtent( const QModelIndex &index, QgsQuickMapSettings *mapSettings, const float buffer );
 
     //! Collapses or expands all collapsible items in the layer tree
-    Q_INVOKABLE void setAllCollapsed( bool collapsed );
+    void setAllCollapsed( bool collapsed );
+
+    //! Returns TRUE if the layer tree has at least one collapsible item
+    bool hasCollapsibleItems() const;
+
+    //! Returns TRUE if all collapsible items are currently collapsed
+    bool isCollapsed() const;
 
   signals:
     void layersAdded();
     void layersRemoved();
     void mapThemeChanged();
+    void hasCollapsibleItemsChanged();
+    void isCollapsedChanged();
     void isTemporalChanged();
     void isFrozenChanged();
 
@@ -101,6 +109,9 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
     void updateTemporalState();
     void adjustTemporalStateFromAddedLayers( const QList<QgsMapLayer *> &layers );
 
+    void checkHasCollapsibleItems();
+    void checkIsCollapsed();
+
     QMap<QModelIndex, int> mRowMap;
     QMap<int, QModelIndex> mIndexMap;
     QMap<int, int> mTreeLevelMap;
@@ -110,6 +121,9 @@ class FlatLayerTreeModelBase : public QAbstractProxyModel
     QString mMapTheme;
     QgsProject *mProject = nullptr;
     QList<QgsLayerTreeLayer *> mLayersInTracking;
+
+    bool mHasCollapsibleItems = false;
+    bool mIsCollapsed = false;
 
     bool mIsTemporal = false;
     int mFrozen = 0;
@@ -125,6 +139,10 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
     Q_OBJECT
 
     Q_PROPERTY( QString mapTheme READ mapTheme WRITE setMapTheme NOTIFY mapThemeChanged )
+
+    Q_PROPERTY( bool hasCollapsibleItems READ hasCollapsibleItems NOTIFY hasCollapsibleItemsChanged )
+    Q_PROPERTY( bool isCollapsed READ isCollapsed NOTIFY isCollapsedChanged )
+
     Q_PROPERTY( bool isTemporal READ isTemporal NOTIFY isTemporalChanged )
     Q_PROPERTY( bool isFrozen READ isFrozen NOTIFY isFrozenChanged )
 
@@ -210,16 +228,18 @@ class FlatLayerTreeModel : public QSortFilterProxyModel
     //! Collapses or expands all collapsible items in the layer tree
     Q_INVOKABLE void setAllCollapsed( bool collapsed );
 
-    //! Returns true if the layer tree has at least one collapsible item
-    Q_INVOKABLE bool hasCollapsibleItems() const;
+    //! Returns TRUE if the layer tree has at least one collapsible item
+    bool hasCollapsibleItems() const;
 
-    //! Returns true if all collapsible items are currently collapsed
-    Q_INVOKABLE bool isAllCollapsed() const;
+    //! Returns TRUE if all collapsible items are currently collapsed
+    bool isCollapsed() const;
 
   signals:
     void layersAdded();
     void layersRemoved();
     void mapThemeChanged();
+    void hasCollapsibleItemsChanged();
+    void isCollapsedChanged();
     void isTemporalChanged();
     void isFrozenChanged();
 

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -394,34 +394,24 @@ Drawer {
         QfButton {
           id: toggleAllButton
 
-          property bool allCollapsed: true
-
           anchors {
             verticalCenter: parent.verticalCenter
             right: parent.right
             rightMargin: 10
           }
+          visible: legend.model.hasCollapsibleItems
 
-          text: toggleAllButton.allCollapsed ? qsTr('Expand All') : qsTr('Collapse All')
+          text: legend.model.isCollapsed ? qsTr('Expand All') : qsTr('Collapse All')
           bgcolor: Theme.darkTheme ? Theme.mainBackgroundColorSemiOpaque : Theme.lightestGraySemiOpaque
           color: Theme.mainTextColor
-          icon.source: toggleAllButton.allCollapsed ? Theme.getThemeVectorIcon('ic_expand_all_24dp') : Theme.getThemeVectorIcon('ic_collapse_all_24dp')
+          icon.source: legend.model.isCollapsed ? Theme.getThemeVectorIcon('ic_expand_all_24dp') : Theme.getThemeVectorIcon('ic_collapse_all_24dp')
           icon.width: 14
           icon.height: 14
           font.pointSize: 8
 
           onClicked: {
-            legend.model.setAllCollapsed(!toggleAllButton.allCollapsed);
-            toggleAllButton.allCollapsed = !toggleAllButton.allCollapsed;
+            legend.model.setAllCollapsed(!legend.model.isCollapsed);
             projectInfo.saveLayerTreeState();
-          }
-        }
-
-        Connections {
-          target: iface
-          function onLoadProjectEnded() {
-            toggleAllButton.visible = legend.model.hasCollapsibleItems();
-            toggleAllButton.allCollapsed = legend.model.isAllCollapsed();
           }
         }
       }


### PR DESCRIPTION
This PR improves the newly introduced collapse/expand all button by insuring that the toggle switches to expand all when all root layer tree nodes are collapsed (and vice versa) to avoid the double-clicking situation described by @JuhoErvasti during his testing.

@JuhoErvasti , this fixes the second UX issue you raised during your review. 

For the other point raised - i.e the need to collapse all before being able to expand all after - I'm inclined to leave it like that for now. There's something good with keep the UX simple, and here I the extra tap needed is really not that big a deal. Also, long presses are just impossible to discover :)

Big thanks for testing!

UX in action:

https://github.com/user-attachments/assets/d7e6ba89-89a7-4ed3-bd7c-52f25e10825c

