### PR TITLE
Add QML tests for null and empty value handling in FeatureForm widgets

### DIFF
--- a/test/qml/tst_featureForm.qml
+++ b/test/qml/tst_featureForm.qml
@@ -290,6 +290,214 @@ TestCase {
     compare(attributeEditorLoader.isEditing, true);
     attributeEditorLoader.value = 99;
     compare(attributeEditorLoader.value, 99);
+    attributeEditorLoader.value = 7;
+    wait(50);
+    featureForm.state = 'ReadOnly';
+    wait(50);
+  }
+
+  /**
+   * Test that Range widget properly handles null and empty values
+   * This prevents crashes when empty values are intended for server-side fills
+   */
+  function test_05_rangeWidgetNullHandling() {
+    featureForm.mSelectedLayer = qgisProject.mapLayersByName('Apiary')[0];
+    featureForm.mSelectedFeature = featureForm.mSelectedLayer.getFeature("64");
+
+    // Reset to ReadOnly state first to reload the feature with original values
+    featureForm.state = 'ReadOnly';
+    wait(100);
+
+    // now switch to Edit mode
+    featureForm.state = 'Edit';
+    wait(100);
+
+    const fieldItem = Utils.findChildren(featureForm, "fieldRepeater");
+    const rangeItemLoader = fieldItem.itemAt(0).children[2].children[0];
+    const attributeEditorLoader = Utils.findChildren(featureForm, "attributeEditorLoader" + rangeItemLoader.containerName);
+
+    compare(rangeItemLoader.containerName, "Number of Boxes");
+    compare(attributeEditorLoader.value, 7, "Initial value should be 7");
+
+    // Test setting a valid value
+    attributeEditorLoader.value = 15;
+    wait(100);
+    compare(attributeEditorLoader.value, 15, "Value should update to 15");
+
+    // Test setting null-> should not crash
+    attributeEditorLoader.value = null;
+    wait(100);
+    verify(true, "Setting null value should not crash");
+
+    // Test setting back to valid value after null
+    attributeEditorLoader.value = 20;
+    wait(100);
+    compare(attributeEditorLoader.value, 20, "Value should be set correctly after null");
+
+    // edge case for numeric fields
+    attributeEditorLoader.value = 0;
+    wait(100);
+    compare(attributeEditorLoader.value, 0, "Zero should be handled correctly");
+    attributeEditorLoader.value = 7;
+    wait(50);
+    featureForm.state = "ReadOnly";
+    wait(50);
+  }
+
+  /**
+   * Test TextEdit widgets handling of empty vs null values
+   * Ensures server-side value fills are not corrupted
+   */
+  function test_06_textEditEmptyStringPreservation() {
+    featureForm.mSelectedLayer = qgisProject.mapLayersByName('Tracks')[0];
+    featureForm.mSelectedFeature = featureForm.mSelectedLayer.getFeature("1");
+    featureForm.state = 'Edit';
+    wait(100);
+
+    const fieldItem = Utils.findChildren(featureForm, "fieldRepeater");
+    const regionItemLoader = fieldItem.itemAt(1).children[2].children[0];
+    const attributeEditorLoader = Utils.findChildren(featureForm, "attributeEditorLoader" + regionItemLoader.containerName);
+
+    compare(regionItemLoader.containerName, "Region");
+
+    // Verify initial empty string (server-side fill scenario)
+    compare(attributeEditorLoader.value, '', "Region should start as empty string");
+    verify(attributeEditorLoader.value !== null, "Initial value should be empty string, not null");
+    verify(attributeEditorLoader.value !== undefined, "Initial value should be empty string, not undefined");
+    attributeEditorLoader.value = "test region";
+    wait(100);
+    compare(attributeEditorLoader.value, "test region", "Value should update to 'test region'");
+
+    // set back to empty string-> simulating user clearing the field
+    attributeEditorLoader.value = "";
+    wait(100);
+
+    // empty string should remain empty string, not become null
+    compare(attributeEditorLoader.value, "", "Value should be empty string after clearing");
+    verify(attributeEditorLoader.value !== null, "Cleared value should NOT be null (would break server-side fills)");
+    verify(attributeEditorLoader.value !== undefined, "Cleared value should NOT be undefined");
+    verify(typeof attributeEditorLoader.value === 'string', "Cleared value should be string type");
+
+    // Test null handling separately
+    attributeEditorLoader.value = null;
+    wait(100);
+    verify(true, "Setting null should not crash");
+    attributeEditorLoader.value = "";
+    wait(50);
+    featureForm.state = "ReadOnly";
+    wait(50);
+  }
+
+  /**
+   * Test that different widget types handle null and empty values correctly
+   * This is a regression test for the bug fixed in the PR
+   */
+  function test_07_widgetValueHandlingConsistency() {
+    featureForm.mSelectedLayer = qgisProject.mapLayersByName('Apiary')[0];
+    featureForm.mSelectedFeature = featureForm.mSelectedLayer.getFeature("64");
+    featureForm.state = 'Edit';
+    wait(100);
+
+    const fieldItem = Utils.findChildren(featureForm, "fieldRepeater");
+
+    // Test Range widget
+    const rangeLoader = Utils.findChildren(featureForm, "attributeEditorLoader" + fieldItem.itemAt(0).children[2].children[0].containerName);
+    compare(rangeLoader.widget, "Range");
+
+    const initialRangeValue = rangeLoader.value;
+    rangeLoader.value = null;
+    wait(50);
+    verify(true, "Range widget should handle null without crashing");
+
+    // Restore value
+    rangeLoader.value = initialRangeValue;
+    wait(50);
+
+    // Test TextEdit widget
+    const textEditLoader = Utils.findChildren(featureForm, "attributeEditorLoader" + fieldItem.itemAt(3).children[2].children[0].containerName);
+    compare(textEditLoader.widget, "TextEdit");
+
+    const initialTextValue = textEditLoader.value;
+
+    textEditLoader.value = "Test Name";
+    wait(50);
+    compare(textEditLoader.value, "Test Name");
+
+    // Test empty string preservation
+    textEditLoader.value = "";
+    wait(50);
+    compare(textEditLoader.value, "");
+    verify(textEditLoader.value !== null, "TextEdit empty string should not become null");
+
+    textEditLoader.value = null;
+    wait(50);
+    verify(true, "TextEdit should handle null without crashing");
+
+    // Restore
+    textEditLoader.value = initialTextValue;
+    wait(50);
+
+    // Test ValueMap widget
+    const valueMapLoader = Utils.findChildren(featureForm, "attributeEditorLoader" + fieldItem.itemAt(1).children[2].children[0].containerName);
+    compare(valueMapLoader.widget, "ValueMap");
+
+    const initialValueMapValue = valueMapLoader.value;
+
+    valueMapLoader.value = "";
+    wait(50);
+    verify(true, "ValueMap should handle empty string without crashing");
+
+    // Restore
+    valueMapLoader.value = initialValueMapValue;
+    wait(50);
+  }
+
+  /**
+   * Test state transitions with null or empty values
+   * Ensures that switching between ReadOnly and Edit modes preserves values correctly
+   */
+  function test_08_stateTransitionWithNullValues() {
+    featureForm.mSelectedLayer = qgisProject.mapLayersByName('Tracks')[0];
+    featureForm.mSelectedFeature = featureForm.mSelectedLayer.getFeature("1");
+
+    // Start in ReadOnly mode
+    featureForm.state = 'ReadOnly';
+    wait(100);
+
+    const fieldItem = Utils.findChildren(featureForm, "fieldRepeater");
+    const regionLoader = Utils.findChildren(featureForm, "attributeEditorLoader" + fieldItem.itemAt(1).children[2].children[0].containerName);
+
+    // Region starts as empty string
+    compare(regionLoader.value, "");
+
+    // Switch to Edit mode
+    featureForm.state = 'Edit';
+    wait(100);
+
+    // Empty string should be preserved across state change
+    compare(regionLoader.value, "");
+    verify(regionLoader.value !== null, "Empty string should not become null on state change");
+
+    // set a value
+    regionLoader.value = "Test Region";
+    wait(50);
+
+    // Switch back to ReadOnly
+    featureForm.state = 'ReadOnly';
+    wait(100);
+
+    // Value should be preserved
+    compare(regionLoader.value, "Test Region");
+
+    // Switch back to Edit and clear
+    featureForm.state = 'Edit';
+    wait(100);
+    regionLoader.value = "";
+    wait(50);
+
+    // Empty should still be empty, not null
+    compare(regionLoader.value, "");
+    verify(regionLoader.value !== null, "Cleared value should be empty string, not null");
   }
 
   /**
@@ -341,6 +549,7 @@ TestCase {
 
   Item {
     id: qfieldSettings
+
     property bool autoSave: false
   }
 


### PR DESCRIPTION
This PR adds QML tests to prevent regressions in null and empty string handling across editor widgets, addressing concerns raised about potential crashes when blank values 

## Changes

1. **test_05_rangeWidgetNullHandling**
   - Tests Range widgets handling of null values
   - Verifies null values don't crash the application
   - Tests edge cases like setting value to 0
   - Ensures values can be set correctly after null

2. **test_06_textEditEmptyStringPreservation** 
   - Critical test: Verifies empty strings remain empty strings and don't become null
   - Tests the specific bug that was fixed - empty strings being converted to null
   - Ensures server-side value fill scenario (blank values) works correctly
   - Validates type safety (string type preservation)

3. **test_07_widgetValueHandlingConsistency**
   - Tests multiple widget types (Range, TextEdit, ValueMap) for consistent null/empty handling
   - Ensures all widgets handle null and empty string values without crashing
   - Validates widgets can be restored to original values after changes

4. **test_08_stateTransitionWithNullValues**
   - Tests that ReadOnly <> Edit state transitions preserve values correctly
   - Ensures empty strings don't become null during state changes
   - Validates that cleared values remain as empty strings
  