### PR TITLE
Simplify and improve feature list form height's logic

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -96,8 +96,7 @@ Pane {
         return parent.height;
       } else {
         const defaultMin = Math.min(Math.max(200, parent.height / 2), parent.height);
-        var minContentHeight = featureForm.visible ? defaultMin : featureListToolBar.height + (48 * globalFeaturesList.count) + (30 * globalFeaturesList.sectionCount()) + 5;
-        minContentHeight += globalFeaturesList.count === 1 ? 30 : 0;
+        var minContentHeight = featureForm.visible ? defaultMin : featureListToolBar.height + (globalFeaturesList.contentHeight + globalFeaturesList.anchors.bottomMargin) + 25;
         const newHeight = Math.min(minContentHeight, defaultMin);
         lastHeight = newHeight;
         return newHeight;


### PR DESCRIPTION
@mohsenD98 , FYI, a listview's contentheight is a more accurate and robust way to detect the height of a list content. That way you don't need to rely on guestimated average height of items & sections etc.