### PR TITLE
Work around certain Android version misbehaving when switching COGO operations

### DIFF
--- a/src/qml/CogoOperations.qml
+++ b/src/qml/CogoOperations.qml
@@ -91,13 +91,37 @@ Item {
         iconColor: cogoOperationSettings && cogoOperationSettings.name === Name ? Theme.mainColor : Theme.toolButtonColor
 
         onClicked: {
-          Qt.inputMethod.hide();
-          settings.setValue("/QField/CogoOperationLastUsed", Name);
-          cogoOperationSettings.name = Name;
-          cogoOperationSettings.title = DisplayName;
-          displayToast(DisplayName);
+          if (Qt.inputMethod.visible) {
+            Qt.inputMethod.hide();
+            inputTimer.name = Name;
+            inputTimer.title = DisplayName;
+            inputTimer.restart();
+          } else {
+            settings.setValue("/QField/CogoOperationLastUsed", Name);
+            cogoOperationSettings.name = Name;
+            cogoOperationSettings.title = DisplayName;
+            displayToast(DisplayName);
+          }
         }
       }
+    }
+  }
+
+  Timer {
+    id: inputTimer
+
+    property string name: ""
+    property string title: ""
+
+    interval: 300
+    running: false
+    repeat: false
+
+    onTriggered: {
+      settings.setValue("/QField/CogoOperationLastUsed", inputConnection.name);
+      cogoOperationSettings.name = inputConnection.name;
+      cogoOperationSettings.title = inputConnection.title;
+      displayToast(inputConnection.title);
     }
   }
 


### PR DESCRIPTION
A (rather sad) fix for:

<img width="1080" height="2124" alt="image" src="https://github.com/user-attachments/assets/7ccbdc48-b30c-4965-bc0a-ec935baf7a49" />

Sadness comes from the fact that we should really not have to do this :/