### PR TITLE
Insure that external positioning device names will never break the devices model

### DIFF
--- a/src/core/positioning/positioningdevicemodel.cpp
+++ b/src/core/positioning/positioningdevicemodel.cpp
@@ -57,7 +57,7 @@ void PositioningDeviceModel::reloadModel()
   {
     settings.beginGroup( deviceKeys.at( i ) );
     mDevices << Device( static_cast<Type>( settings.value( QStringLiteral( "type" ), InternalDevice ).toInt() ),
-                        deviceKeys.at( i ),
+                        QUrl::fromPercentEncoding( deviceKeys.at( i ).toLatin1() ),
                         settings.value( QStringLiteral( "settings" ), QVariantMap() ).toMap() );
     settings.endGroup();
   }
@@ -113,7 +113,7 @@ int PositioningDeviceModel::addDevice( const Type &type, const QString &name, co
     uniqueName = QStringLiteral( "%1 %2" ).arg( name, QString::number( ++suffix ) );
   }
 
-  settings.beginGroup( uniqueName );
+  settings.beginGroup( QUrl::toPercentEncoding( uniqueName ) );
   settings.setValue( "type", static_cast<int>( type ) );
   settings.setValue( "settings", deviceSettings );
   settings.endGroup();

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -736,7 +736,7 @@ Page {
                 property variant languageCodes: undefined
                 property string currentLanguageCode: undefined
 
-                onCurrentIndexChanged: {
+                onActivated: {
                   if (currentLanguageCode != undefined) {
                     var newLanguageCode = languageCodes[currentIndex];
                     if (newLanguageCode !== currentLanguageCode) {
@@ -936,14 +936,19 @@ Page {
                     }
                   }
 
+                  property bool loaded: false
+
                   onCurrentIndexChanged: {
-                    var modelIndex = positioningDeviceModel.index(currentIndex, 0);
-                    positioningSettings.positioningDevice = positioningDeviceModel.data(modelIndex, PositioningDeviceModel.DeviceId);
-                    positioningSettings.positioningDeviceName = positioningDeviceModel.data(modelIndex, PositioningDeviceModel.DeviceName);
+                    if (loaded && currentIndex !== -1) {
+                      const modelIndex = positioningDeviceModel.index(currentIndex, 0);
+                      positioningSettings.positioningDevice = positioningDeviceModel.data(modelIndex, PositioningDeviceModel.DeviceId);
+                      positioningSettings.positioningDeviceName = positioningDeviceModel.data(modelIndex, PositioningDeviceModel.DeviceName);
+                    }
                   }
 
                   Component.onCompleted: {
-                    currentIndex = positioningDeviceModel.findIndexFromDeviceId(settings.value('positioningDevice', ''));
+                    currentIndex = positioningDeviceModel.findIndexFromDeviceId(positioningSettings.positioningDevice);
+                    loaded = true;
                   }
                 }
               }
@@ -1687,7 +1692,6 @@ Page {
       }
       var index = positioningDeviceModel.addDevice(type, name, settings);
       positioningDeviceComboBox.currentIndex = index;
-      positioningDeviceComboBox.onCurrentIndexChanged();
     }
   }
 


### PR DESCRIPTION
Names containing \ and / would break our model, this PR fixes that.  I had seen this issue a long time ago, and never managed to reproduce until today.