### PR TITLE
Adds skip condition for QFieldCloud tests

### DIFF
--- a/test/qml/tst_qfieldCloudLoginUI.qml
+++ b/test/qml/tst_qfieldCloudLoginUI.qml
@@ -10,9 +10,9 @@ TestCase {
   when: windowShown
 
   // QFieldCloud test credentials — injected via context properties.
-  property string qfcTestServerUrl: typeof(qfcTestServerUrl) !== "undefined" ? qfcTestServerUrl : ""
-  property string qfcTestUsername: typeof(qfcTestUsername) !== "undefined" ? qfcTestUsername : ""
-  property string qfcTestPassword: typeof(qfcTestPassword) !== "undefined" ? qfcTestPassword : ""
+  property string qfcTestServerUrl: typeof (qfcTestServerUrl) !== "undefined" ? qfcTestServerUrl : ""
+  property string qfcTestUsername: typeof (qfcTestUsername) !== "undefined" ? qfcTestUsername : ""
+  property string qfcTestPassword: typeof (qfcTestPassword) !== "undefined" ? qfcTestPassword : ""
 
   // Dummy mainWindow required by some components
   Item {
@@ -63,13 +63,11 @@ TestCase {
     signalName: "availableProvidersChanged"
   }
 
-  // Skip test if QFieldCloud credentials are not available
-  function skipIfNoCredentials() {
+  // Skip tests if QFieldCloud credentials are not available
+  function init() {
     if (!qfcTestServerUrl || !qfcTestUsername || !qfcTestPassword) {
       skip("QFieldCloud test credentials not available, skipping");
-      return true;
     }
-    return false;
   }
 
   // This function is called after each test function that is executed in the TestCase type.
@@ -95,7 +93,6 @@ TestCase {
    * Scenario: Fields should be visible when disconnected, hidden when logged in
    */
   function test_01_fieldsVisibilityByConnectionStatus() {
-    if (skipIfNoCredentials()) return;
     compare(cloudConnection.status, QFieldCloudConnection.Disconnected);
     verify(usernameField.visible);
     verify(passwordField.visible);
@@ -133,7 +130,6 @@ TestCase {
    * Scenario: Error message should appear when login fails and Error message should clear when attempting new login
    */
   function test_03_loginFeedbackOnFailure() {
-    if (skipIfNoCredentials()) return;
     compare(loginFeedbackLabel.visible, false);
     cloudConnection.url = qfcTestServerUrl;
     cloudConnection.username = "wrong_user_name";
@@ -186,7 +182,6 @@ TestCase {
    * and hasCredentialsAuthentication is set based on whether credentials provider exists
    */
   function test_06_authProvidersRepeaterModelUpdate() {
-    if (skipIfNoCredentials()) return;
     var initialCount = availableProvidersRepeater.model.length;
     availableProvidersChangedSpy.clear();
     cloudConnection.url = qfcTestServerUrl;
@@ -225,7 +220,6 @@ TestCase {
    * Scenario: After login, username field should show the logged-in username
    */
   function test_08_usernameFieldSyncsAfterLogin() {
-    if (skipIfNoCredentials()) return;
     usernameField.text = "";
     cloudConnection.url = qfcTestServerUrl;
     cloudConnection.username = qfcTestUsername;

--- a/test/qml/tst_qfieldCloudScreenUI.qml
+++ b/test/qml/tst_qfieldCloudScreenUI.qml
@@ -10,9 +10,9 @@ TestCase {
   when: windowShown
 
   // QFieldCloud test credentials — injected via context properties..
-  property string qfcTestServerUrl: typeof(qfcTestServerUrl) !== "undefined" ? qfcTestServerUrl : ""
-  property string qfcTestUsername: typeof(qfcTestUsername) !== "undefined" ? qfcTestUsername : ""
-  property string qfcTestPassword: typeof(qfcTestPassword) !== "undefined" ? qfcTestPassword : ""
+  property string qfcTestServerUrl: typeof (qfcTestServerUrl) !== "undefined" ? qfcTestServerUrl : ""
+  property string qfcTestUsername: typeof (qfcTestUsername) !== "undefined" ? qfcTestUsername : ""
+  property string qfcTestPassword: typeof (qfcTestPassword) !== "undefined" ? qfcTestPassword : ""
 
   // Dummy mainWindow required by QFieldCloudScreen
   Item {
@@ -112,13 +112,11 @@ TestCase {
     currentProjectSpy.clear();
   }
 
-  // Skip test if QFieldCloud credentials are not available
-  function skipIfNoCredentials() {
+  // Skip tests if QFieldCloud credentials are not available
+  function init() {
     if (!qfcTestServerUrl || !qfcTestUsername || !qfcTestPassword) {
       skip("QFieldCloud test credentials not available, skipping");
-      return true;
     }
-    return false;
   }
 
   // Helper: Login and refresh projects list
@@ -162,7 +160,6 @@ TestCase {
    * Scenario: When disconnected, show login form. When logged in, show projects list.
    */
   function test_01_viewVisibilityByConnectionStatus() {
-    if (skipIfNoCredentials()) return;
     compare(cloudConnection.status, QFieldCloudConnection.Disconnected);
     verify(connectionSettings.visible);
     compare(projectsSwipeView.visible, false);
@@ -182,7 +179,6 @@ TestCase {
    * Scenario: Switching between 'My Projects' and 'Community' tabs changes the table filter.
    */
   function test_02_filterBarTabSwitching() {
-    if (skipIfNoCredentials()) return;
     cloudConnection.url = qfcTestServerUrl;
     cloudConnection.username = qfcTestUsername;
     cloudConnection.login(qfcTestPassword);
@@ -205,7 +201,6 @@ TestCase {
    * Scenario: Entering search text filters the projects list and clearing it restores full list.
    */
   function test_03_searchBarFiltering() {
-    if (skipIfNoCredentials()) return;
     compare(table.count, 0);
     loginAndRefresh();
     const initialCount = table.count;
@@ -224,7 +219,6 @@ TestCase {
    * Scenario: Login shows projects view, logout returns to login form and clears project list.
    */
   function test_04_loginLogoutViewTransitions() {
-    if (skipIfNoCredentials()) return;
     verify(connectionSettings.visible);
     compare(projectsSwipeView.visible, false);
     cloudConnection.url = qfcTestServerUrl;
@@ -247,7 +241,6 @@ TestCase {
    * Scenario: TestCloudLargeProject and QFieldCloudTesting appear as visible delegates in table.
    */
   function test_05_verifyTestProjectsExist() {
-    if (skipIfNoCredentials()) return;
     loginAndRefresh();
     verify(table.count > 0);
     let foundLargeProject = false;
@@ -278,7 +271,6 @@ TestCase {
    * Scenario: Click download button, wait for download to complete, verify project is locally available.
    */
   function test_06_completeDownloadWorkflow() {
-    if (skipIfNoCredentials()) return;
     loginAndRefresh();
     const projectInfo = prepareProjectForDownload("QFieldCloudTesting");
     let project = cloudProjectsModel.findProject(projectInfo.id);
@@ -309,7 +301,6 @@ TestCase {
    * Scenario: Start download then cancel by clicking the button again during download.
    */
   function test_07_cancelDownload() {
-    if (skipIfNoCredentials()) return;
     loginAndRefresh();
     const projectInfo = prepareProjectForDownload("TestCloudLargeProject");
     let project = cloudProjectsModel.findProject(projectInfo.id);
@@ -340,7 +331,6 @@ TestCase {
    * Scenario: Start downloads for two projects simultaneously and verify both complete successfully.
    */
   function test_08_concurrentDownloads() {
-    if (skipIfNoCredentials()) return;
     loginAndRefresh();
     const project1Info = prepareProjectForDownload("QFieldCloudTesting");
     const project2Info = prepareProjectForDownload("TestCloudLargeProject");
@@ -387,7 +377,6 @@ TestCase {
    * Scenario: Download and cancel same project multiple times, then complete final download successfully.
    */
   function test_09_repeatedDownloadCancel() {
-    if (skipIfNoCredentials()) return;
     loginAndRefresh();
     const projectInfo = prepareProjectForDownload("TestCloudLargeProject");
     let project = cloudProjectsModel.findProject(projectInfo.id);
@@ -443,7 +432,6 @@ TestCase {
    * currentProjectChanged, and currentProject matches the expected project.
    */
   function test_10_setCurrentProjectIdSignalsAndBinding() {
-    if (skipIfNoCredentials()) return;
     loginAndRefresh();
     verify(cloudProjectsModel.rowCount() > 0);
     const index = cloudProjectsModel.index(0, 0);


### PR DESCRIPTION
Adds a skip condition to QFieldCloud QML tests to gracefully handle missing credentials

### 🚀 Description

This PR introduces a credential availability check for QFieldCloud QML UI tests. When QFieldCloud test credentials (server URL, username, password) are not injected via context properties, the affected tests are now **skipped** instead of failing, making the test suite more resilient in environments where cloud credentials are unavailable (e.g., local development, forks, or CI without secrets configured).

### ✨ Key Changes

- **Utilized QML's built-in `init()` function** which runs before each test function to check for credential availability. If any of the three credentials (server URL, username, password) are empty, the test is skipped with a descriptive message using `skip()`.