### PR TITLE
Add local QFieldCloud Docker service to CI with dual-server tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -108,7 +108,9 @@ jobs:
         run: |
           QFC_DIR=/tmp/qfieldcloud
           git clone --depth 1 https://github.com/opengisch/QFieldCloud.git $QFC_DIR
-          cp $QFC_DIR/.env.example $QFC_DIR/.env
+          cd $QFC_DIR
+          cp .env.example .env
+          export COMPOSE_FILE=docker-compose.yml:docker-compose.override.standalone.yml
 
           sed -i \
             -e 's|^WEB_HTTP_PORT=80$|WEB_HTTP_PORT=8080|' \
@@ -116,40 +118,38 @@ jobs:
             -e 's|^MINIO_BROWSER_PORT=8010$|MINIO_BROWSER_PORT=8013|' \
             -e 's|^DEBUG_APP_DEBUGPY_PORT=5678$|DEBUG_APP_DEBUGPY_PORT=""|' \
             -e 's|^DEBUG_WORKER_WRAPPER_DEBUGPY_PORT=5679$|DEBUG_WORKER_WRAPPER_DEBUGPY_PORT=""|' \
-            $QFC_DIR/.env
+            .env
 
-          QFC="docker compose -p qfc --env-file $QFC_DIR/.env -f $QFC_DIR/docker-compose.yml -f $QFC_DIR/docker-compose.override.standalone.yml"
-
-          $QFC up -d db minio memcached mkcert
+          docker compose -p qfc up -d db minio memcached mkcert
 
           echo "Waiting for database..."
           for i in $(seq 1 30); do
-            $QFC exec -T db pg_isready -q 2>/dev/null && break
-            [ "$i" -eq 30 ] && { $QFC logs db --tail=20; exit 1; }
+            docker compose -p qfc exec -T db pg_isready -q 2>/dev/null && break
+            [ "$i" -eq 30 ] && { docker compose -p qfc logs db --tail=20; exit 1; }
             sleep 2
           done
 
-          $QFC up -d --build app
+          docker compose -p qfc up -d --build app
           echo "Waiting for app..."
           for i in $(seq 1 20); do
-            $QFC exec -T app python -c "print('ok')" 2>/dev/null && break
-            [ "$i" -eq 20 ] && { $QFC logs app --tail=20; exit 1; }
+            docker compose -p qfc exec -T app python -c "print('ok')" 2>/dev/null && break
+            [ "$i" -eq 20 ] && { docker compose -p qfc logs app --tail=20; exit 1; }
             sleep 2
           done
 
-          $QFC exec -T app python manage.py migrate --no-input
-          $QFC exec -T app python manage.py collectstatic --no-input
-          $QFC exec -T app python manage.py createuser --username admin --email admin@localhost.local --password admin123 --superuser
+          docker compose -p qfc exec -T app python manage.py migrate --no-input
+          docker compose -p qfc exec -T app python manage.py collectstatic --no-input
+          docker compose -p qfc exec -T app python manage.py createuser --username admin --email admin@localhost.local --password admin123 --superuser
 
-          $QFC up -d --build nginx
+          docker compose -p qfc up -d --build nginx
           echo "Waiting for nginx..."
           for i in $(seq 1 40); do
             curl -k -s -f https://localhost:8443/api/v1/status/ > /dev/null 2>&1 && break
-            [ "$i" -eq 40 ] && { $QFC logs nginx --tail=20; $QFC logs mkcert --tail=10; exit 1; }
+            [ "$i" -eq 40 ] && { docker compose -p qfc logs nginx --tail=20; docker compose -p qfc logs mkcert --tail=10; exit 1; }
             sleep 3
           done
 
-          $QFC ps
+          docker compose -p qfc ps
 
       - name: Test QFieldCloud
         run: |
@@ -199,12 +199,12 @@ jobs:
       - name: 🧫 Test
         env:
           PROJ_LIB: ${{ github.workspace }}/build/vcpkg_installed/x64-linux/share/proj
-          QFIELDCLOUD_CI_URL: https://localhost:8443
-          QFIELDCLOUD_CI_USERNAME: admin
-          QFIELDCLOUD_CI_PASSWORD: admin123
-          QFIELDCLOUD_PRODUCTION_URL: ${{ secrets.QFIELDCLOUD_TEST_SERVER_URL }}
-          QFIELDCLOUD_PRODUCTION_USERNAME: ${{ secrets.QFIELDCLOUD_TEST_USERNAME }}
-          QFIELDCLOUD_PRODUCTION_PASSWORD: ${{ secrets.QFIELDCLOUD_TEST_PASSWORD }}
+          QFIELDCLOUD_URL: https://localhost:8443
+          QFIELDCLOUD_USERNAME: admin
+          QFIELDCLOUD_PASSWORD: admin123
+          QFIELDCLOUD_REMOTE_URL: ${{ secrets.QFIELDCLOUD_TEST_SERVER_URL }}
+          QFIELDCLOUD_REMOTE_USERNAME: ${{ secrets.QFIELDCLOUD_TEST_USERNAME }}
+          QFIELDCLOUD_REMOTE_PASSWORD: ${{ secrets.QFIELDCLOUD_TEST_PASSWORD }}
         run: |
           pip install -r "${{ github.workspace }}/test/spix/requirements.txt"
           docker compose -f "${{ github.workspace }}/test/docker-compose.yaml" up -d
@@ -227,22 +227,20 @@ jobs:
           chmod 700 ${{ github.workspace }}/test/postgis_docker/cert_keys/server.crt
 
           cd build
-          export QFIELDCLOUD_CI_URL="${QFIELDCLOUD_CI_URL}"
-          export QFIELDCLOUD_CI_USERNAME="${QFIELDCLOUD_CI_USERNAME}"
-          export QFIELDCLOUD_CI_PASSWORD="${QFIELDCLOUD_CI_PASSWORD}"
-          export QFIELDCLOUD_PRODUCTION_URL="${QFIELDCLOUD_PRODUCTION_URL}"
-          export QFIELDCLOUD_PRODUCTION_USERNAME="${QFIELDCLOUD_PRODUCTION_USERNAME}"
-          export QFIELDCLOUD_PRODUCTION_PASSWORD="${QFIELDCLOUD_PRODUCTION_PASSWORD}"
+          export QFIELDCLOUD_URL="${QFIELDCLOUD_URL}"
+          export QFIELDCLOUD_USERNAME="${QFIELDCLOUD_USERNAME}"
+          export QFIELDCLOUD_PASSWORD="${QFIELDCLOUD_PASSWORD}"
+          export QFIELDCLOUD_REMOTE_URL="${QFIELDCLOUD_REMOTE_URL}"
+          export QFIELDCLOUD_REMOTE_USERNAME="${QFIELDCLOUD_REMOTE_USERNAME}"
+          export QFIELDCLOUD_REMOTE_PASSWORD="${QFIELDCLOUD_REMOTE_PASSWORD}"
           xvfb-run --server-args="-screen 0 640x480x24" ctest --output-on-failure -C ${{ env.BUILD_TYPE }}
 
       - name: Docker cleanup
         if: always()
         run: |
-          QFC_DIR=/tmp/qfieldcloud
-          docker compose -p qfc --env-file $QFC_DIR/.env \
-            -f $QFC_DIR/docker-compose.yml \
-            -f $QFC_DIR/docker-compose.override.standalone.yml \
-            down 2>/dev/null || true
+          cd /tmp/qfieldcloud
+          export COMPOSE_FILE=docker-compose.yml:docker-compose.override.standalone.yml
+          docker compose -p qfc down 2>/dev/null || true
           docker compose -f "${{ github.workspace }}/test/docker-compose.yaml" down 2>/dev/null || true
 
       - name: 📑 Upload package logs

--- a/test/qml/tst_qfieldCloudLoginUI.qml
+++ b/test/qml/tst_qfieldCloudLoginUI.qml
@@ -9,15 +9,15 @@ TestCase {
   name: "QFieldCloudLoginUI"
   when: windowShown
 
-  // QFieldCloud CI credentials
-  property string ciUrl: typeof (qfcCiUrl) !== "undefined" ? qfcCiUrl : ""
-  property string ciUsername: typeof (qfcCiUsername) !== "undefined" ? qfcCiUsername : ""
-  property string ciPassword: typeof (qfcCiPassword) !== "undefined" ? qfcCiPassword : ""
+  // QFieldCloud local credentials
+  property string localUrl: typeof (qfcUrl) !== "undefined" ? qfcUrl : ""
+  property string localUsername: typeof (qfcUsername) !== "undefined" ? qfcUsername : ""
+  property string localPassword: typeof (qfcPassword) !== "undefined" ? qfcPassword : ""
 
-  // QFieldCloud production credentials
-  property string productionUrl: typeof (qfcProductionUrl) !== "undefined" ? qfcProductionUrl : ""
-  property string productionUsername: typeof (qfcProductionUsername) !== "undefined" ? qfcProductionUsername : ""
-  property string productionPassword: typeof (qfcProductionPassword) !== "undefined" ? qfcProductionPassword : ""
+  // QFieldCloud remote credentials
+  property string remoteUrl: typeof (qfcRemoteUrl) !== "undefined" ? qfcRemoteUrl : ""
+  property string remoteUsername: typeof (qfcRemoteUsername) !== "undefined" ? qfcRemoteUsername : ""
+  property string remotePassword: typeof (qfcRemotePassword) !== "undefined" ? qfcRemotePassword : ""
 
   // Dummy mainWindow required by some components
   Item {
@@ -68,30 +68,30 @@ TestCase {
     signalName: "availableProvidersChanged"
   }
 
-  // Returns all available server configurations (CI always, production if provided)
+  // Returns all available server configurations (local always, remote if provided)
   function serverConfigs() {
     var configs = [
       {
-        tag: "ci",
-        url: ciUrl,
-        username: ciUsername,
-        password: ciPassword
+        tag: "local",
+        url: localUrl,
+        username: localUsername,
+        password: localPassword
       }
     ];
-    if (productionUrl && productionUsername && productionPassword) {
+    if (remoteUrl && remoteUsername && remotePassword) {
       configs.push({
-        tag: "production",
-        url: productionUrl,
-        username: productionUsername,
-        password: productionPassword
+        tag: "remote",
+        url: remoteUrl,
+        username: remoteUsername,
+        password: remotePassword
       });
     }
     return configs;
   }
 
-  // CI credentials must always be available
+  // QFieldCloud credentials must always be available
   function init() {
-    verify(ciUrl && ciUsername && ciPassword, "CI QFieldCloud credentials are required");
+    verify(localUrl && localUsername && localPassword, "QFieldCloud local credentials are required");
   }
 
   // This function is called after each test function that is executed in the TestCase type.

--- a/test/qml/tst_qfieldCloudScreenUI.qml
+++ b/test/qml/tst_qfieldCloudScreenUI.qml
@@ -9,15 +9,15 @@ TestCase {
   name: "QFieldCloudScreenUI"
   when: windowShown
 
-  // QFieldCloud CI credentials
-  property string ciUrl: typeof (qfcCiUrl) !== "undefined" ? qfcCiUrl : ""
-  property string ciUsername: typeof (qfcCiUsername) !== "undefined" ? qfcCiUsername : ""
-  property string ciPassword: typeof (qfcCiPassword) !== "undefined" ? qfcCiPassword : ""
+  // QFieldCloud local credentials
+  property string localUrl: typeof (qfcUrl) !== "undefined" ? qfcUrl : ""
+  property string localUsername: typeof (qfcUsername) !== "undefined" ? qfcUsername : ""
+  property string localPassword: typeof (qfcPassword) !== "undefined" ? qfcPassword : ""
 
-  // QFieldCloud production credentials
-  property string productionUrl: typeof (qfcProductionUrl) !== "undefined" ? qfcProductionUrl : ""
-  property string productionUsername: typeof (qfcProductionUsername) !== "undefined" ? qfcProductionUsername : ""
-  property string productionPassword: typeof (qfcProductionPassword) !== "undefined" ? qfcProductionPassword : ""
+  // QFieldCloud remote credentials
+  property string remoteUrl: typeof (qfcRemoteUrl) !== "undefined" ? qfcRemoteUrl : ""
+  property string remoteUsername: typeof (qfcRemoteUsername) !== "undefined" ? qfcRemoteUsername : ""
+  property string remotePassword: typeof (qfcRemotePassword) !== "undefined" ? qfcRemotePassword : ""
 
   // Dummy mainWindow required by QFieldCloudScreen
   Item {
@@ -117,41 +117,41 @@ TestCase {
     currentProjectSpy.clear();
   }
 
-  // CI credentials must always be available
+  // QFieldCloud credentials must always be available
   function init() {
-    verify(ciUrl && ciUsername && ciPassword, "CI QFieldCloud credentials are required");
+    verify(localUrl && localUsername && localPassword, "QFieldCloud local credentials are required");
   }
 
-  // Returns all available server configurations (CI always, production if provided)
+  // Returns all available server configurations (local always, remote if provided)
   function serverConfigs() {
     var configs = [
       {
-        tag: "ci",
-        url: ciUrl,
-        username: ciUsername,
-        password: ciPassword
+        tag: "local",
+        url: localUrl,
+        username: localUsername,
+        password: localPassword
       }
     ];
-    if (productionUrl && productionUsername && productionPassword) {
+    if (remoteUrl && remoteUsername && remotePassword) {
       configs.push({
-        tag: "production",
-        url: productionUrl,
-        username: productionUsername,
-        password: productionPassword
+        tag: "remote",
+        url: remoteUrl,
+        username: remoteUsername,
+        password: remotePassword
       });
     }
     return configs;
   }
 
-  // Returns only production config (for tests requiring specific projects)
-  function productionConfigs() {
+  // Returns only remote config (for tests requiring specific projects)
+  function remoteConfigs() {
     var configs = [];
-    if (productionUrl && productionUsername && productionPassword) {
+    if (remoteUrl && remoteUsername && remotePassword) {
       configs.push({
-        tag: "production",
-        url: productionUrl,
-        username: productionUsername,
-        password: productionPassword
+        tag: "remote",
+        url: remoteUrl,
+        username: remoteUsername,
+        password: remotePassword
       });
     }
     return configs;
@@ -245,7 +245,7 @@ TestCase {
    * Scenario: Entering search text filters the projects list and clearing it restores full list.
    */
   function test_03_searchBarFiltering_data() {
-    return productionConfigs();
+    return remoteConfigs();
   }
   function test_03_searchBarFiltering(data) {
     compare(table.count, 0);
@@ -291,7 +291,7 @@ TestCase {
    * Scenario: TestCloudLargeProject and QFieldCloudTesting appear as visible delegates in table.
    */
   function test_05_verifyTestProjectsExist_data() {
-    return productionConfigs();
+    return remoteConfigs();
   }
   function test_05_verifyTestProjectsExist(data) {
     loginAndRefresh(data);
@@ -324,7 +324,7 @@ TestCase {
    * Scenario: Click download button, wait for download to complete, verify project is locally available.
    */
   function test_06_completeDownloadWorkflow_data() {
-    return productionConfigs();
+    return remoteConfigs();
   }
   function test_06_completeDownloadWorkflow(data) {
     loginAndRefresh(data);
@@ -357,7 +357,7 @@ TestCase {
    * Scenario: Start download then cancel by clicking the button again during download.
    */
   function test_07_cancelDownload_data() {
-    return productionConfigs();
+    return remoteConfigs();
   }
   function test_07_cancelDownload(data) {
     loginAndRefresh(data);
@@ -390,7 +390,7 @@ TestCase {
    * Scenario: Start downloads for two projects simultaneously and verify both complete successfully.
    */
   function test_08_concurrentDownloads_data() {
-    return productionConfigs();
+    return remoteConfigs();
   }
   function test_08_concurrentDownloads(data) {
     loginAndRefresh(data);
@@ -439,7 +439,7 @@ TestCase {
    * Scenario: Download and cancel same project multiple times, then complete final download successfully.
    */
   function test_09_repeatedDownloadCancel_data() {
-    return productionConfigs();
+    return remoteConfigs();
   }
   function test_09_repeatedDownloadCancel(data) {
     loginAndRefresh(data);
@@ -497,7 +497,7 @@ TestCase {
    * currentProjectChanged, and currentProject matches the expected project.
    */
   function test_10_setCurrentProjectIdSignalsAndBinding_data() {
-    return productionConfigs();
+    return remoteConfigs();
   }
   function test_10_setCurrentProjectIdSignalsAndBinding(data) {
     loginAndRefresh(data);

--- a/test/test_qml.cpp
+++ b/test/test_qml.cpp
@@ -173,15 +173,15 @@ class Setup : public QObject
       engine->rootContext()->setContextProperty( QStringLiteral( "qgisProject" ), QgsProject::instance() );
       engine->rootContext()->setContextProperty( QStringLiteral( "dataDir" ), mDataDir );
 
-      // QFieldCloud CI instance credentials
-      engine->rootContext()->setContextProperty( QStringLiteral( "qfcCiUrl" ), QString::fromUtf8( qgetenv( "QFIELDCLOUD_CI_URL" ) ) );
-      engine->rootContext()->setContextProperty( QStringLiteral( "qfcCiUsername" ), QString::fromUtf8( qgetenv( "QFIELDCLOUD_CI_USERNAME" ) ) );
-      engine->rootContext()->setContextProperty( QStringLiteral( "qfcCiPassword" ), QString::fromUtf8( qgetenv( "QFIELDCLOUD_CI_PASSWORD" ) ) );
+      // QFieldCloud credentials
+      engine->rootContext()->setContextProperty( QStringLiteral( "qfcUrl" ), QString::fromUtf8( qgetenv( "QFIELDCLOUD_URL" ) ) );
+      engine->rootContext()->setContextProperty( QStringLiteral( "qfcUsername" ), QString::fromUtf8( qgetenv( "QFIELDCLOUD_USERNAME" ) ) );
+      engine->rootContext()->setContextProperty( QStringLiteral( "qfcPassword" ), QString::fromUtf8( qgetenv( "QFIELDCLOUD_PASSWORD" ) ) );
 
-      // QFieldCloud production credentials
-      engine->rootContext()->setContextProperty( QStringLiteral( "qfcProductionUrl" ), QString::fromUtf8( qgetenv( "QFIELDCLOUD_PRODUCTION_URL" ) ) );
-      engine->rootContext()->setContextProperty( QStringLiteral( "qfcProductionUsername" ), QString::fromUtf8( qgetenv( "QFIELDCLOUD_PRODUCTION_USERNAME" ) ) );
-      engine->rootContext()->setContextProperty( QStringLiteral( "qfcProductionPassword" ), QString::fromUtf8( qgetenv( "QFIELDCLOUD_PRODUCTION_PASSWORD" ) ) );
+      // QFieldCloud remote credentials
+      engine->rootContext()->setContextProperty( QStringLiteral( "qfcRemoteUrl" ), QString::fromUtf8( qgetenv( "QFIELDCLOUD_REMOTE_URL" ) ) );
+      engine->rootContext()->setContextProperty( QStringLiteral( "qfcRemoteUsername" ), QString::fromUtf8( qgetenv( "QFIELDCLOUD_REMOTE_USERNAME" ) ) );
+      engine->rootContext()->setContextProperty( QStringLiteral( "qfcRemotePassword" ), QString::fromUtf8( qgetenv( "QFIELDCLOUD_REMOTE_PASSWORD" ) ) );
 
       QgsExifTools mExifTools;
       engine->rootContext()->setContextProperty( "ExifTools", QVariant::fromValue<QgsExifTools>( mExifTools ) );


### PR DESCRIPTION
### 🚀 Description
This PR integrates a local QFieldCloud instance via Docker Compose into the Linux CI workflow, enabling QFieldCloud-related tests to run against a self-hosted server without depending on external services. Tests are additionally run against production (`app.qfield.cloud`) when credentials are available via secrets.

### ✨ Key Changes
- **CI workflow**: Spin up a local QFieldCloud Docker stack (db, minio, memcached, mkcert, app, nginx) with staged startup and health checks
- **Data-driven QML tests**: Refactored `tst_qfieldCloudLoginUI` and `tst_qfieldCloudScreenUI` to use Qt Quick Test `_data()` functions, running each test case against both CI and production servers
- **C++ test harness**: Inject dual sets of QFieldCloud credentials (`CI` + `production`) as QML context properties via environment variables
- **Graceful fallback**: CI server tests always run; production tests are skipped automatically when secrets are not available