### PR TITLE
Make WebDAV upload progress monotonic

### DIFF
--- a/src/core/webdavconnection.h
+++ b/src/core/webdavconnection.h
@@ -337,6 +337,9 @@ class WebdavConnection : public QObject
     qint64 mBytesProcessed = 0;
     qint64 mBytesTotal = 0;
 
+    qint64 mCurrentUploadFileSize = 0;
+    qint64 mCurrentUploadBytesSentMax = 0;
+
     QWebdav mWebdavConnection;
     QWebdavDirParser mWebdavDirParser;
     QString mLastError;


### PR DESCRIPTION
Updated upload progress accounting in WebdavConnection::putLocalItems() to track the max bytesSent per file and use the current file size when marking a file as completed
As the uploadProgress(bytesSent …) can reset to 0 on new file / retry / network aspects, which made the progress bar jump backwards and feel broken during multi-file uploads

>No change to WebDAV upload behavior. This is strictly a UI/progress correctness fix so progress stays smooth and non dipping

Related to PR: #7033