### PR TITLE
Adds zoom in/out functionality to 3D map

### DIFF
--- a/src/qml/3d/MapCanvas3D.qml
+++ b/src/qml/3d/MapCanvas3D.qml
@@ -302,4 +302,12 @@ Item {
   function lookAtPoint(pos3d, distance) {
     cameraController.lookAtPoint(pos3d, distance);
   }
+
+  function zoomIn() {
+    cameraController.distance = cameraController.clampDistance(cameraController.distance * 0.8);
+  }
+
+  function zoomOut() {
+    cameraController.distance = cameraController.clampDistance(cameraController.distance * 1.25);
+  }
 }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1998,13 +1998,19 @@ ApplicationWindow {
         height: 36
 
         onClicked: {
-          if (gnssButton.followActive) {
-            gnssButton.followActiveSkipExtentChanged = true;
-          }
-          mapCanvasMap.zoomIn(Qt.point(mapCanvas.x + (mapCanvas.width - mapCanvasMap.rightMargin) / 2, mapCanvas.y + (mapCanvas.height - mapCanvasMap.bottomMargin) / 2));
-          if (gnssButton.followActive) {
-            // Trigger a mao redraw
-            gnssButton.followLocation(true);
+          if (stateMachine.state === '3d') {
+            if (mapCanvas3DLoader.item) {
+              mapCanvas3DLoader.item.zoomIn();
+            }
+          } else {
+            if (gnssButton.followActive) {
+              gnssButton.followActiveSkipExtentChanged = true;
+            }
+            mapCanvasMap.zoomIn(Qt.point(mapCanvas.x + (mapCanvas.width - mapCanvasMap.rightMargin) / 2, mapCanvas.y + (mapCanvas.height - mapCanvasMap.bottomMargin) / 2));
+            if (gnssButton.followActive) {
+              // Trigger a map redraw
+              gnssButton.followLocation(true);
+            }
           }
         }
       }
@@ -2021,13 +2027,19 @@ ApplicationWindow {
         height: 36
 
         onClicked: {
-          if (gnssButton.followActive) {
-            gnssButton.followActiveSkipExtentChanged = true;
-          }
-          mapCanvasMap.zoomOut(Qt.point(mapCanvas.x + (mapCanvas.width - mapCanvasMap.rightMargin) / 2, mapCanvas.y + (mapCanvas.height - mapCanvasMap.bottomMargin) / 2));
-          if (gnssButton.followActive) {
-            // Trigger a mao redraw
-            gnssButton.followLocation(true);
+          if (stateMachine.state === '3d') {
+            if (mapCanvas3DLoader.item) {
+              mapCanvas3DLoader.item.zoomOut();
+            }
+          } else {
+            if (gnssButton.followActive) {
+              gnssButton.followActiveSkipExtentChanged = true;
+            }
+            mapCanvasMap.zoomOut(Qt.point(mapCanvas.x + (mapCanvas.width - mapCanvasMap.rightMargin) / 2, mapCanvas.y + (mapCanvas.height - mapCanvasMap.bottomMargin) / 2));
+            if (gnssButton.followActive) {
+              // Trigger a map redraw
+              gnssButton.followLocation(true);
+            }
           }
         }
       }


### PR DESCRIPTION
### 🚀 Description
This PR adds zoom in/out button support for the 3D map view. Previously, the zoom in/out buttons in the toolbar only worked for the 2D map canvas. When the application was in 3D mode, clicking these buttons had no effect (or worse, they attempted to manipulate the 2D canvas). This change makes the existing zoom buttons context-aware so they properly control the 3D camera distance when in 3D mode.

### ✨ Key Changes

- **`MapCanvas3D`** — Added two new public functions `zoomIn()` and `zoomOut()` to the 3D map canvas component. 
