### PR TITLE
 Refactor WebdavConnection path lookup functions

### DIFF
--- a/src/core/webdavconnection.cpp
+++ b/src/core/webdavconnection.cpp
@@ -1242,14 +1242,7 @@ void WebdavConnection::requestUpload( const QString &projectPath, bool force )
 
 bool WebdavConnection::hasWebdavConfiguration( const QString &path )
 {
-  const QFileInfo fileInfo( path );
-  QDir dir( fileInfo.isFile() ? fileInfo.absolutePath() : fileInfo.absoluteFilePath() );
-  bool webdavConfigurationExists = dir.exists( WEBDAV_CONFIGURATION_FILENAME );
-  while ( !webdavConfigurationExists && dir.cdUp() )
-  {
-    webdavConfigurationExists = dir.exists( WEBDAV_CONFIGURATION_FILENAME );
-  }
-  return webdavConfigurationExists;
+  return !findWebdavRootForPath( path ).isEmpty();
 }
 
 bool WebdavConnection::tryLockUpload( const QString &root, QString *errorMessage )
@@ -1316,7 +1309,7 @@ QString WebdavConnection::ensureTrailingSlash( QString path ) const
   return path;
 }
 
-QString WebdavConnection::findWebdavRootForPath( const QString &path ) const
+QString WebdavConnection::findWebdavRootForPath( const QString &path )
 {
   QFileInfo fi( QDir::cleanPath( path ) );
   QDir dir( fi.isFile() ? fi.absolutePath() : fi.absoluteFilePath() );

--- a/src/core/webdavconnection.h
+++ b/src/core/webdavconnection.h
@@ -236,6 +236,13 @@ class WebdavConnection : public QObject
      */
     Q_INVOKABLE static QStringList findWebdavProjectFolders( const QString &basePath );
 
+    /**
+     * Finds the WebDAV project root by walking up from the given path.
+     * \param path the file or folder path to start from
+     * \return the project root path, or empty string if not found
+     */
+    Q_INVOKABLE static QString findWebdavRootForPath( const QString &path );
+
     Q_INVOKABLE static void forgetHistory( const QString &url = QString(), const QString &username = QString() );
 
   signals:
@@ -285,9 +292,6 @@ class WebdavConnection : public QObject
 
     //! Ensures the path ends with a trailing slash.
     QString ensureTrailingSlash( QString path ) const;
-
-    //! Finds the WebDAV project root by walking up from the given path.
-    QString findWebdavRootForPath( const QString &path ) const;
 
     /**
      * Reads and parses the WebDAV config JSON stored at on rootPath.


### PR DESCRIPTION
These functions/changes are based on the need of the WebDAV auto-upload plugin to discover projects from QML. Previously, the walk-up logic existed in two places (hasWebdavConfiguration() and findWebdavRootForPath()), and the scan-down logic was embedded in importHistory() and duplicated in the QML plugin using FolderListModel.
- To eliminate redundant code by having hasWebdavConfiguration() call findWebdavRootForPath()
- To extract the scanning logic from importHistory() into reusable findWebdavProjectFolders()
- To expose both functions to QML, allowing the plugin to drop its Qt.labs.folderlistmodel dependency completely