### PR TITLE
Fix Dev Container environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,5 +57,5 @@
   ],
 
 
-  "onCreateCommand": "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y git curl wget zip bison gperf flex libtool libxcb-cursor-dev autopoint '^libxcb.*-dev' libx11-xcb-dev libegl1-mesa libegl1-mesa-dev libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libxrandr-dev libxxf86vm-dev autoconf-archive libgstreamer-gl1.0-0 libgstreamer-plugins-base1.0-0 libfuse2 libpulse-dev libcups2-dev nasm python3-tk python3-jinja2",
+  "onCreateCommand": "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y git curl wget zip bison gperf flex libtool libxcb-cursor-dev autopoint '^libxcb.*-dev' libx11-xcb-dev libegl1-mesa libegl1-mesa-dev libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libxrandr-dev libxxf86vm-dev autoconf-archive libgstreamer-gl1.0-0 libgstreamer-plugins-base1.0-0 libfuse2 libpulse-dev libcups2-dev libsm-dev nasm python3-tk python3-jinja2",
 }


### PR DESCRIPTION
This PR re-enables developing QField using Dev Containers by having `libsm-dev` preinstalled in the container.

Libsm is required after [introduction](https://github.com/opengisch/QField/blob/57b0dd3bfb23cc4be1e1fb679b7edcc60b00a92d/vcpkg/ports/qtbase/vcpkg.json#L126)  of xcb-sm for qtbase in 9009ad49f65169bf6020d37700fc008233bd4d07.