### PR TITLE
Fix hard (impossible?) to read QField green on light gray combobox text

### DIFF
--- a/src/qml/imports/Theme/QfComboBox.qml
+++ b/src/qml/imports/Theme/QfComboBox.qml
@@ -13,6 +13,8 @@ ComboBox {
 
   property alias text: contentText
 
+  Material.accent: Material.primaryTextColor
+
   contentItem: T.TextField {
     id: contentText
     leftPadding: comboBox.background.visible ? Material.textFieldHorizontalPadding : 0


### PR DESCRIPTION
Fix this:

<img width="818" height="483" alt="image" src="https://github.com/user-attachments/assets/eb9fc91b-15e2-42c6-826c-35b949e53cd5" />

@kaustuvpokharel , your nightmare is over :wink: 