### PR TITLE
Fix deprecated warnings within publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -3,7 +3,7 @@
 # metadata file that makes public software easily discoverable.
 # More info at https://github.com/italia/publiccode.yml
 
-publiccodeYmlVersion: '0.2'
+publiccodeYmlVersion: '0'
 name: QField
 url: 'https://github.com/opengisch/QField'
 logo: https://raw.githubusercontent.com/opengisch/QField/master/images/icons/qfield_logo.svg
@@ -26,7 +26,6 @@ description:
       - Spatial data management
       - Cartography
 
-    genericName: QField
     longDescription: |
       QField is the leading GIS data collection app.
       It integrates perfectly with QGIS.
@@ -102,13 +101,8 @@ intendedAudience:
     - transportation
     - tourism
     - welfare
-it:
-  conforme:
-    gdpr: true
-    lineeGuidaDesign: false
-    misureMinimeSicurezza: false
-    modelloInteroperabilita: false
-  countryExtensionVersion: '0.2'
+IT:
+  countryExtensionVersion: '1.0'
   piattaforme:
     anpr: false
     cie: false


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/7023

I assume we got that when qfield.org became briefly inaccessible, but we might as well remove the deprecated stuff. 