### PR TITLE
Avoid unwanted overlap between feature form header and content when adding features

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -853,7 +853,7 @@ Page {
     rightPadding: 0
     bottomPadding: 0
 
-    height: visible ? form.topMargin + 48 : 0
+    height: visible ? form.topMargin + 58 : 0
     visible: form.state === 'Add'
     objectName: "toolbar"
     background: Rectangle {


### PR DESCRIPTION
Fixes this:

<img width="543" height="370" alt="image" src="https://github.com/user-attachments/assets/96051ab8-3a65-4521-ac71-fb2bbf91a4af" />
