### PR TITLE
dynamic QR code barcode color

### DIFF
--- a/src/core/barcodeimageprovider.cpp
+++ b/src/core/barcodeimageprovider.cpp
@@ -18,11 +18,11 @@
 
 #include <QFileInfo>
 #include <QUrlQuery>
+#include <qgssymbollayerutils.h>
 
 #include <ZXing/BarcodeFormat.h>
 #include <ZXing/BitMatrix.h>
 #include <ZXing/MultiFormatWriter.h>
-#include <qgssymbollayerutils.h>s
 
 BarcodeImageProvider::BarcodeImageProvider()
   : QQuickImageProvider( Image )

--- a/src/qml/QFieldCloudProjectDetails.qml
+++ b/src/qml/QFieldCloudProjectDetails.qml
@@ -190,7 +190,7 @@ ColumnLayout {
             sourceSize.height: desiredWidth * Screen.devicePixelRatio
             source: cloudProject != undefined ? "image://barcode/?text=" + encodeURIComponent(UrlUtils.createActionUrl("qfield", "cloud", {
               "project": cloudProject.id
-            })) + "&color=%2380cc28" : ""
+            })) + "&color=" + encodeURIComponent(Theme.mainColor) : ""
             property int desiredWidth: Math.min(mainWindow.width - 40, 250)
           }
 


### PR DESCRIPTION
Changed the QColor to QgsSymbolLayerUtils:encodeColor to have flexibility to color encoding, plus changed qml side to use Theme instead of hardcoded color.