### PR TITLE
[Backport release-4_0] Don't crash when fetching legend image from arcmap map services

### DIFF
--- a/src/core/legendimageprovider.cpp
+++ b/src/core/legendimageprovider.cpp
@@ -209,9 +209,6 @@ void AsyncLegendImageResponse::handleFinish( const QImage &image )
 
   mImage = image;
   emit finished();
-
-  mFetcher->deleteLater();
-  mFetcher.release();
 }
 
 void AsyncLegendImageResponse::handleError( const QString & )
@@ -224,9 +221,6 @@ void AsyncLegendImageResponse::handleError( const QString & )
 
   mImage = QImage();
   emit finished();
-
-  mFetcher->deleteLater();
-  mFetcher.release();
 }
 
 QQuickTextureFactory *AsyncLegendImageResponse::textureFactory() const

--- a/src/core/legendimageprovider.h
+++ b/src/core/legendimageprovider.h
@@ -22,6 +22,7 @@
 #include <QQuickImageProvider>
 #include <QQuickImageResponse>
 #include <qgsrasterdataprovider.h>
+#include <qobjectuniqueptr.h>
 
 class QgsLayerTreeModel;
 class QgsLayerTree;
@@ -61,7 +62,7 @@ class AsyncLegendImageResponse : public QQuickImageResponse
 
   private:
     std::unique_ptr<QgsRasterDataProvider> mDataProvider;
-    std::unique_ptr<QgsImageFetcher> mFetcher;
+    QObjectUniquePtr<QgsImageFetcher> mFetcher = nullptr;
 
     QImage mImage;
 };


### PR DESCRIPTION
Backport #7091
 **Authored by:** @nirvn