### PR TITLE
No need to show scary geometry editing button for single-part points

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -650,7 +650,7 @@ void QgisMobileapp::registerGlobalVariables()
   rootContext()->setContextProperty( "pluginManager", mPluginManager );
   rootContext()->setContextProperty( "settings", &mSettings );
   rootContext()->setContextProperty( "flatLayerTree", mFlatLayerTree );
-  rootContext()->setContextProperty( "CrsFactory", QVariant::fromValue<QgsCoordinateReferenceSystem>( mCrsFactory ) );
+  rootContext()->setContextProperty( "WkbTypes", QVariant::fromValue<QgsWkbTypes>( mWkbTypes ) );
   rootContext()->setContextProperty( "UnitTypes", QVariant::fromValue<QgsUnitTypes>( mUnitTypes ) );
   rootContext()->setContextProperty( "ExifTools", QVariant::fromValue<QgsExifTools>( mExifTools ) );
   rootContext()->setContextProperty( "bookmarkModel", mBookmarkModel );

--- a/src/core/qgismobileapp.h
+++ b/src/core/qgismobileapp.h
@@ -254,7 +254,7 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
     std::unique_ptr<CogoRegistry> mCogoRegistry;
 
     // Dummy objects. We are not able to call static functions from QML, so we need something here.
-    QgsCoordinateReferenceSystem mCrsFactory;
+    QgsWkbTypes mWkbTypes;
     QgsUnitTypes mUnitTypes;
     QgsExifTools mExifTools;
 

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -310,9 +310,10 @@ Rectangle {
   QfToolButton {
     id: editGeomButton
 
+    property bool supportsGeometryEditing: false
     property bool readOnly: false
 
-    visible: stateMachine.state === "digitize" && !selection.focusedGeometry.isNull && !featureForm.model.featureModel.geometryEditingLocked && (projectInfo.editRights || editButton.isCreatedCloudFeature) && toolBar.state === "Navigation" && editButton.supportsEditing && projectInfo.editRights
+    visible: stateMachine.state === "digitize" && toolBar.state === "Navigation" && supportsGeometryEditing && !featureForm.model.featureModel.geometryEditingLocked && (projectInfo.editRights || editButton.isCreatedCloudFeature)
 
     anchors.right: editButton.left
     anchors.top: parent.top
@@ -378,6 +379,7 @@ Rectangle {
 
       function onFocusedItemChanged() {
         editButton.supportsEditing = selection.focusedLayer && selection.focusedLayer.supportsEditing;
+        editGeomButton.supportsGeometryEditing = selection.focusedLayer && selection.focusedLayer.supportsEditing && !selection.focusedGeometry.isNull && (selection.focusedLayer.geometryType() !== Qgis.GeometryType.Point || WkbTypes.isMultiType(selection.focusedLayer.wkbType()));
       }
       function onFocusedFeatureChanged() {
         if (QFieldCloudUtils.getProjectId(qgisProject.fileName) !== '') {


### PR DESCRIPTION
For the longest of time, QField would show the geometry editing button for single-part point layers when in digitizing mode. The only editing tool that's available for such a layer is the vertex editor, which can only do one thing: move the point.

We long gained the ability to move a feature via the feature form's 3-dot menu without the need to go through the intimidating geometry editor UX. 

As such, I think it's a good thing to just hide the geometry editing button for t hose layers. It plays super nicely with our project creation wizard too as the notes (i.e. point) layer we create there is a single part, and thus means our created projects will be less intimidating for newcomers. Win-win.

_Note on this: some users reported disabling geometry editing for these layers simply to get rid of the button. This PR will help them avoid locking completely geometry editing merely to get rid of a UI element :partying_face:_