### PR TITLE
Make standard dialog button labels translatable via qsTr()

### DIFF
--- a/src/qml/imports/Theme/QfDialog.qml
+++ b/src/qml/imports/Theme/QfDialog.qml
@@ -15,19 +15,19 @@ Dialog {
   y: (mainWindow.height - height) / 2
 
   onAboutToShow: {
-    var okBtn = standardButton(Dialog.Ok);
+    const okBtn = standardButton(Dialog.Ok);
     if (okBtn)
       okBtn.text = qsTr("OK");
-    var cancelBtn = standardButton(Dialog.Cancel);
+    const cancelBtn = standardButton(Dialog.Cancel);
     if (cancelBtn)
       cancelBtn.text = qsTr("Cancel");
-    var yesBtn = standardButton(Dialog.Yes);
+    const yesBtn = standardButton(Dialog.Yes);
     if (yesBtn)
       yesBtn.text = qsTr("Yes");
-    var noBtn = standardButton(Dialog.No);
+    const noBtn = standardButton(Dialog.No);
     if (noBtn)
       noBtn.text = qsTr("No");
-    var closeBtn = standardButton(Dialog.Close);
+    const closeBtn = standardButton(Dialog.Close);
     if (closeBtn)
       closeBtn.text = qsTr("Close");
   }


### PR DESCRIPTION
Qt's standard button labels (OK, Cancel, Yes, No, Close) rely on Qt's own translation files which are not part of QField's Transifex project. Override button text in QfDialog's onAboutToShow using qsTr() so lupdate picks them up and they become available for translation on Transifex.

Example: Aborting a edit session of a feature, language set to german.

![Screenshot_20260311-120742](https://github.com/user-attachments/assets/4b9dad56-1bdc-4a12-8ec5-dd405856209d)

found with the help of AI: claude