### PR TITLE
Clamp range widget values to configured min/max limits

### DIFF
--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -65,8 +65,19 @@ EditorWidgetBase {
 
       onTextChanged: {
         if (text !== "") {
-          if (!isNaN(parseFloat(text))) {
-            valueChangeRequested(text, false);
+          const parsedValue = parseFloat(text);
+          if (!isNaN(parsedValue)) {
+            let clampedValue = parsedValue;
+            if (Number.isFinite(rangeItem.min) && parsedValue < rangeItem.min) {
+              clampedValue = rangeItem.min;
+            } else if (Number.isFinite(rangeItem.max) && parsedValue > rangeItem.max) {
+              clampedValue = rangeItem.max;
+            }
+
+            valueChangeRequested(clampedValue, false);
+            text = Qt.binding(function () {
+              return isNull ? '' : value;
+            });
           }
         } else if (!isNull) {
           valueChangeRequested(text, true);
@@ -167,7 +178,8 @@ EditorWidgetBase {
     let newValue;
     if (!isNaN(currentValue)) {
       newValue = roundValue(currentValue - rangeItem.step, rangeItem.precision);
-      valueChangeRequested(Math.max(rangeItem.min, newValue), false);
+      newValue = Math.max(rangeItem.min, Math.min(rangeItem.max, newValue));
+      valueChangeRequested(newValue, false);
     } else {
       newValue = 0;
       valueChangeRequested(newValue, false);
@@ -179,7 +191,8 @@ EditorWidgetBase {
     let newValue;
     if (!isNaN(currentValue)) {
       newValue = roundValue(currentValue + rangeItem.step, rangeItem.precision);
-      valueChangeRequested(Math.min(rangeItem.max, newValue), false);
+      newValue = Math.min(rangeItem.max, Math.max(rangeItem.min, newValue));
+      valueChangeRequested(newValue, false);
     } else {
       newValue = 0;
       valueChangeRequested(newValue, false);


### PR DESCRIPTION
## 🚀 Description

Fix the Range editor widget to properly enforce minimum and maximum value limits when values are entered via keyboard or changed using the [+]/[-] buttons.

## Problem

When a numeric attribute has min/max limits configured (e.g., 0–100), QField did not validate keyboard input against those limits

## ✨ Fix

- **Keyboard input (`onTextChanged`):** parsed values are now clamped to the  configured `[min, max]` range before being committed via `valueChangeRequested`, and the text binding is restored so the field  displays the corrected value
- **`decreaseValue()`:** now clamps to both min *and* max  (`Math.max(min, Math.min(max, newValue))`) so that decrementing from an out-of-range value immediately snaps into the valid range
- **`increaseValue()`:** same dual clamp applied (`Math.min(max, Math.max(min, newValue))`)

Closes #7120