### PR TITLE
Fix QFC token update fetching the wrong (non-token) auth configuration

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfieldcloudconnection.cpp
@@ -674,7 +674,7 @@ void QFieldCloudConnection::setToken( const QByteArray &token )
     QgsAuthMethodConfig config;
     if ( QgsApplication::authManager()->availableAuthMethodConfigs().contains( mTokenConfigId ) )
     {
-      QgsApplication::authManager()->loadAuthenticationConfig( mProviderConfigId, config, true );
+      QgsApplication::authManager()->loadAuthenticationConfig( mTokenConfigId, config, true );
     }
     else
     {


### PR DESCRIPTION
A copy/paste typo highlighted in https://github.com/opengisch/QField/issues/7126 .

