### PR TITLE
Deleted preview nodes must be removed from the parent canvas node to avoid crashes

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -541,6 +541,14 @@ QSGNode *QgsQuickMapCanvasMap::updatePaintNode( QSGNode *oldNode, QQuickItem::Up
     mDirty = false;
   }
 
+  if ( mDirtyPreviewNodes )
+  {
+    node->removeAllChildNodes();
+    qDeleteAll( mPreviewNodes );
+    mPreviewNodes.fill( nullptr, 8 );
+    mDirtyPreviewNodes = false;
+  }
+
   if ( !mPreviewImages.isEmpty() )
   {
     for ( auto previewImagesIterator = mPreviewImages.constBegin(); previewImagesIterator != mPreviewImages.constEnd(); ++previewImagesIterator )
@@ -833,9 +841,7 @@ void QgsQuickMapCanvasMap::setPreviewJobsEnabled( bool enabled )
 void QgsQuickMapCanvasMap::clearPreviews()
 {
   mPreviewImages.clear();
-  qDeleteAll( mPreviewNodes );
-  mPreviewNodes.clear();
-  mPreviewNodes.resize( 8 );
+  mDirtyPreviewNodes = true;
 }
 
 QList<int> QgsQuickMapCanvasMap::previewJobsQuadrants() const

--- a/src/core/qgsquick/qgsquickmapcanvasmap.h
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.h
@@ -350,6 +350,7 @@ class QgsQuickMapCanvasMap : public QQuickItem
     QMetaObject::Connection mPreviewTimerConnection;
     QMap<int, QImage> mPreviewImages;
     QList<QSGSimpleTextureNode *> mPreviewNodes;
+    bool mDirtyPreviewNodes = false;
 
     QQuickWindow *mWindow = nullptr;
 };


### PR DESCRIPTION
Follow up to https://github.com/opengisch/QField/pull/7130