### PR TITLE
Fix QML tests to skip QFieldCloud tests when credentials are unavailable

### DIFF
--- a/test/qml/tst_qfieldCloudLoginUI.qml
+++ b/test/qml/tst_qfieldCloudLoginUI.qml
@@ -68,16 +68,17 @@ TestCase {
     signalName: "availableProvidersChanged"
   }
 
-  // Returns all available server configurations (local always, remote if provided)
+  // Returns all available server configurations (local if provided, remote if provided)
   function serverConfigs() {
-    var configs = [
-      {
+    var configs = [];
+    if (localUrl && localUsername && localPassword) {
+      configs.push({
         tag: "local",
         url: localUrl,
         username: localUsername,
         password: localPassword
-      }
-    ];
+      });
+    }
     if (remoteUrl && remoteUsername && remotePassword) {
       configs.push({
         tag: "remote",
@@ -87,11 +88,6 @@ TestCase {
       });
     }
     return configs;
-  }
-
-  // QFieldCloud credentials must always be available
-  function init() {
-    verify(localUrl && localUsername && localPassword, "QFieldCloud local credentials are required");
   }
 
   // This function is called after each test function that is executed in the TestCase type.

--- a/test/qml/tst_qfieldCloudScreenUI.qml
+++ b/test/qml/tst_qfieldCloudScreenUI.qml
@@ -117,21 +117,17 @@ TestCase {
     currentProjectSpy.clear();
   }
 
-  // QFieldCloud credentials must always be available
-  function init() {
-    verify(localUrl && localUsername && localPassword, "QFieldCloud local credentials are required");
-  }
-
-  // Returns all available server configurations (local always, remote if provided)
+  // Returns all available server configurations (local if provided, remote if provided)
   function serverConfigs() {
-    var configs = [
-      {
+    var configs = [];
+    if (localUrl && localUsername && localPassword) {
+      configs.push({
         tag: "local",
         url: localUrl,
         username: localUsername,
         password: localPassword
-      }
-    ];
+      });
+    }
     if (remoteUrl && remoteUsername && remotePassword) {
       configs.push({
         tag: "remote",


### PR DESCRIPTION
## 🚀 Description
Allow running ctest locally without requiring QFieldCloud environment variables. Cloud-dependent QML tests now skip gracefully when credentials are not set.

## ✨ Fix
- Remove mandatory init() credential check that blocked all tests (including pure UI tests) when QFieldCloud variables were absent
- When no docker (local) variables are set → local server tests are skipped
- When no remote variables are set → remote server tests are skipped
- When no variables are set at all → all cloud tests are skipped
