### PR TITLE
Remove glossy effect on 3D map canvas terrain material

### DIFF
--- a/resources/3d/terrain_material.frag
+++ b/resources/3d/terrain_material.frag
@@ -36,4 +36,8 @@ void MAIN() {
             BASE_COLOR = bgColor;
         }
     }
+
+    ROUGHNESS = 0.9;
+    SPECULAR_AMOUNT = 0.0;
+    METALNESS = 0.0;
 }


### PR DESCRIPTION
Our custom material's shader was missing a couple of declarations to avoid our terrain looking like a reflective, glossy piece of plastic. This fixes it.