### PR TITLE
Optimize feature form creation by getting rid of an unused connections for each form widget

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -647,24 +647,6 @@ Page {
             }
 
             Connections {
-              target: form
-
-              function onAboutToSave() {
-                // it may not be implemented
-                if (attributeEditorLoader.item && attributeEditorLoader.item.pushChanges) {
-                  attributeEditorLoader.item.pushChanges(form.model.featureModel.feature);
-                }
-              }
-
-              function onValueChanged(field, oldValue, newValue) {
-                // it may not be implemented
-                if (attributeEditorLoader.item && attributeEditorLoader.item.siblingValueChanged) {
-                  attributeEditorLoader.item.siblingValueChanged(field, form.model.featureModel.feature);
-                }
-              }
-            }
-
-            Connections {
               target: attributeEditorLoader.item
 
               function onValueChangeRequested(value, isNull) {


### PR DESCRIPTION
We long moved this logic to the attribute form model C++ class, we can get rid of it (and in turn have a feature form that feels a tiny bit snappier). 