### PR TITLE
Guard from an uninitialized pointer to a terrain provider

### DIFF
--- a/src/core/3d/quick3dterrainprovider.cpp
+++ b/src/core/3d/quick3dterrainprovider.cpp
@@ -354,7 +354,7 @@ void Quick3DTerrainProvider::calcNormalizedData()
         for ( int col = 0; col < gridSize.width(); ++col )
         {
           const double x = extent.xMinimum() + extent.width() / gridSize.width() * col;
-          const double y = extent.xMinimum() - extent.height() / gridSize.height() * row;
+          const double y = extent.yMaximum() - extent.height() / gridSize.height() * row;
           double value = terrainProvider->heightAt( x, y );
           if ( !std::isnan( value ) )
           {


### PR DESCRIPTION
Sentry reference: https://opengisch.sentry.io/issues/7338483586/?project=6119013&query=is%3Aunresolved%20release%3A%22ch.opengis.qfield%404.1%2A%22&referrer=issue-stream&sort=user

I've not been able to replicate the crash shown in both sentry and on the play store, but I did spot an uninitialized pointer to the pointer used on the line reported as crashing by the stacktrace.