### PR TITLE
Use seek() instead of play()/pause() for video thumbnail in ExternalResource

### DIFF
--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -368,7 +368,14 @@ EditorWidgetBase {
           onHasVideoChanged: {
             mediaFrame.height = hasVideo ? 254 : 48;
             if (!player.firstFrameDrawn && hasVideo) {
-              play();
+              seek(1);
+            }
+          }
+
+          onSourceChanged: {
+            if (hasVideo) {
+              player.firstFrameDrawn = false;
+              seek(1);
             }
           }
 
@@ -376,7 +383,7 @@ EditorWidgetBase {
             positionSlider.to = duration / 1000;
             positionSlider.value = 0;
             if (!player.firstFrameDrawn && hasVideo) {
-              play();
+              seek(1);
             }
           }
 

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -388,7 +388,7 @@ EditorWidgetBase {
           }
 
           onPositionChanged: {
-            if (!player.firstFrameDrawn && playbackState === MediaPlayer.PlayingState) {
+            if (!player.firstFrameDrawn && position > 0) {
               player.firstFrameDrawn = true;
               if (hasVideo) {
                 pause();


### PR DESCRIPTION
One extra thing added, needs more testing:
onSourceChanged: new handler to support video swaps (ex. when a user replaces one video with another, hasVideo stays true so onHasVideoChanged should't refire)