### PR TITLE
Pass on a desktop ID value to give us a GeoClue-derived position on Linux

### DIFF
--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -20,8 +20,8 @@
 
 InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
   : AbstractGnssReceiver( parent )
-  , mGeoPositionSource( std::unique_ptr<QGeoPositionInfoSource>( QGeoPositionInfoSource::createDefaultSource( nullptr ) ) )
-  , mGeoSatelliteSource( std::unique_ptr<QGeoSatelliteInfoSource>( QGeoSatelliteInfoSource::createDefaultSource( nullptr ) ) )
+  , mGeoPositionSource( std::unique_ptr<QGeoPositionInfoSource>( QGeoPositionInfoSource::createDefaultSource( { { "desktopId", "ch.opengis.qfield" } }, nullptr ) ) )
+  , mGeoSatelliteSource( std::unique_ptr<QGeoSatelliteInfoSource>( QGeoSatelliteInfoSource::createDefaultSource( { { "desktopId", "ch.opengis.qfield" } }, nullptr ) ) )
 {
   if ( mGeoPositionSource )
   {


### PR DESCRIPTION
For a few versions now, we get the following warning when launching QField: `qt.positioning.geoclue2: Neither desktopId plugin parameter nor QGuiApplication::desktopFileName has been set. Please consider setting one of the two.`

Turns out this is now required for Linux OSes to give us a generic position (derived from IP, etc.) on GNSS-less systems.

This is a nice fix as it allows for at least one generic position to appear in QField when doing testing.

