### PR TITLE
For projects saved with QGIS < 4.0, restore old always-on remember pin behavior

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -554,7 +554,7 @@ void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, 
         item->setData( !mLayer->editFormConfig().readOnly( fieldIndex ) && setup.type() != QStringLiteral( "Binary" ), AttributeFormModel::AttributeEditable );
         item->setData( setup.type(), AttributeFormModel::EditorWidget );
         item->setData( setup.config(), AttributeFormModel::EditorWidgetConfig );
-        const bool canRemember = mLayer->editFormConfig().reuseLastValuePolicy( fieldIndex ) != Qgis::AttributeFormReuseLastValuePolicy::NotAllowed;
+        const bool canRemember = mLayer->editFormConfig().reuseLastValuePolicy( fieldIndex ) != Qgis::AttributeFormReuseLastValuePolicy::NotAllowed || QgsProject::instance()->lastSaveVersion().majorVersion() < 4;
         item->setData( canRemember, AttributeFormModel::CanRememberValue );
         if ( canRemember )
         {

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -466,7 +466,7 @@ bool FeatureModel::setData( const QModelIndex &index, const QVariant &value, int
         ( *sRememberings )[mLayer].rememberedAttributes[index.row()] = value.toBool();
 
         QgsEditFormConfig config = mLayer->editFormConfig();
-        if ( config.reuseLastValuePolicy( index.row() ) == Qgis::AttributeFormReuseLastValuePolicy::NotAllowed )
+        if ( config.reuseLastValuePolicy( index.row() ) == Qgis::AttributeFormReuseLastValuePolicy::NotAllowed && mProject->lastSaveVersion().majorVersion() >= 4 )
         {
           return false;
         }

--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -569,7 +569,7 @@ void ProjectInfo::restoreSettings( QString &projectFilePath, QgsProject *project
         const QStringList fieldNames = rememberedFields.keys();
         for ( const QString &fieldName : fieldNames )
         {
-          if ( config.reuseLastValuePolicy( vlayer->fields().indexFromName( fieldName ) ) != Qgis::AttributeFormReuseLastValuePolicy::NotAllowed )
+          if ( config.reuseLastValuePolicy( vlayer->fields().indexFromName( fieldName ) ) != Qgis::AttributeFormReuseLastValuePolicy::NotAllowed || project->lastSaveVersion().majorVersion() < 4 )
           {
             config.setReuseLastValuePolicy( vlayer->fields().indexFromName( fieldName ), rememberedFields[fieldName].toBool() ? Qgis::AttributeFormReuseLastValuePolicy::AllowedDefaultOn : Qgis::AttributeFormReuseLastValuePolicy::AllowedDefaultOff );
           }


### PR DESCRIPTION
Based on feedback we got from users who were surprised the remember pins were not always visible, this PR tweaks the behavior for project _saved using QGIS < 4.0_. If someone (re)opens a project that was saved with QGIS prior to 4.0, we'll always show the pin like we used to.

This will allow people to maintain their current UX until they migrate to QGIS 4.0, where they will have the UI to configure this.

For people already using QGIS 4.0, the pins will remain hidden unless the configuration says otherwise. Best of both worlds.

Link to community discussion: https://community.qfield.org/t/remember-attribute-values-pin-gone/1546/6