### PR TITLE
[Backport release-4_1] For projects saved with QGIS < 4.0, restore old always-on remember pin behavior

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -554,7 +554,7 @@ void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, 
         item->setData( !mLayer->editFormConfig().readOnly( fieldIndex ) && setup.type() != QStringLiteral( "Binary" ), AttributeFormModel::AttributeEditable );
         item->setData( setup.type(), AttributeFormModel::EditorWidget );
         item->setData( setup.config(), AttributeFormModel::EditorWidgetConfig );
-        const bool canRemember = mLayer->editFormConfig().reuseLastValuePolicy( fieldIndex ) != Qgis::AttributeFormReuseLastValuePolicy::NotAllowed;
+        const bool canRemember = mLayer->editFormConfig().reuseLastValuePolicy( fieldIndex ) != Qgis::AttributeFormReuseLastValuePolicy::NotAllowed || QgsProject::instance()->lastSaveVersion().majorVersion() < 4;
         item->setData( canRemember, AttributeFormModel::CanRememberValue );
         if ( canRemember )
         {

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -466,7 +466,7 @@ bool FeatureModel::setData( const QModelIndex &index, const QVariant &value, int
         ( *sRememberings )[mLayer].rememberedAttributes[index.row()] = value.toBool();
 
         QgsEditFormConfig config = mLayer->editFormConfig();
-        if ( config.reuseLastValuePolicy( index.row() ) == Qgis::AttributeFormReuseLastValuePolicy::NotAllowed )
+        if ( config.reuseLastValuePolicy( index.row() ) == Qgis::AttributeFormReuseLastValuePolicy::NotAllowed && mProject->lastSaveVersion().majorVersion() >= 4 )
         {
           return false;
         }

--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -569,7 +569,7 @@ void ProjectInfo::restoreSettings( QString &projectFilePath, QgsProject *project
         const QStringList fieldNames = rememberedFields.keys();
         for ( const QString &fieldName : fieldNames )
         {
-          if ( config.reuseLastValuePolicy( vlayer->fields().indexFromName( fieldName ) ) != Qgis::AttributeFormReuseLastValuePolicy::NotAllowed )
+          if ( config.reuseLastValuePolicy( vlayer->fields().indexFromName( fieldName ) ) != Qgis::AttributeFormReuseLastValuePolicy::NotAllowed || project->lastSaveVersion().majorVersion() < 4 )
           {
             config.setReuseLastValuePolicy( vlayer->fields().indexFromName( fieldName ), rememberedFields[fieldName].toBool() ? Qgis::AttributeFormReuseLastValuePolicy::AllowedDefaultOn : Qgis::AttributeFormReuseLastValuePolicy::AllowedDefaultOff );
           }


### PR DESCRIPTION
Backport #7189
 **Authored by:** @nirvn