### PR TITLE
Upon QField launch, do not lock the coordinator locator to the current GNSS position until we hold a valid position

### DIFF
--- a/src/qml/CoordinateLocator.qml
+++ b/src/qml/CoordinateLocator.qml
@@ -47,7 +47,7 @@ Item {
   //! Overwritten by stylus / hoverHandler.
   property variant sourceLocation: undefined // Screen coordinate
 
-  readonly property variant currentCoordinate: !!overrideLocation ? overrideLocation : snappingUtils.snappedCoordinate
+  readonly property variant currentCoordinate: !!overrideLocation && overrideLocation.x ? overrideLocation : snappingUtils.snappedCoordinate
 
   // some trickery here: the first part (!mapSettings.visibleExtent) is only there to get a signal when
   // the map canvas extent changes (user pans/zooms) and the calculation of the display position is retriggered
@@ -234,7 +234,7 @@ Item {
 
     ShapePath {
       id: crosshairPath
-      strokeColor: overrideLocation !== undefined ? Theme.positionColor : "#000000"
+      strokeColor: !!overrideLocation && overrideLocation.x ? Theme.positionColor : "#000000"
       strokeWidth: 2
       fillColor: "transparent"
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -5261,7 +5261,7 @@ ApplicationWindow {
     id: appScopesGenerator
 
     positionInformation: positionSource.positionInformation
-    positionLocked: positionSource.active && coordinateLocator.positionLocked
+    positionLocked: coordinateLocator.positionLocked
     cloudUserInformation: projectInfo.cloudUserInformation
   }
 


### PR DESCRIPTION
Upon relaunching QField, there's a window of time when a user might have their positioning active but not yet fixed on a defined position. We didn't guard ourselves from this situation, resulting in bogus geometries being generated _when the coordinate locator was locked to the GNSS position_.

Fixes https://github.com/opengisch/QField/issues/7192 , https://github.com/opengisch/QField/issues/3619.
