### PR TITLE
Strengthen tracker's maximum distance safeguard by ensuring non-measurable distances are dismissed

### DIFF
--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -235,7 +235,7 @@ void Tracker::positionReceived()
     }
     catch ( const QgsException & )
     {
-      mCurrentDistance = 0.0;
+      mCurrentDistance = !qgsDoubleNear( mMaximumDistance, 0.0 ) ? mMaximumDistance + 1.0 : 0.0;
     }
   }
 


### PR DESCRIPTION
Trying to debug this weird situation where tracks will have "spikes" even though the maximum distance safeguard is one. This is how it looks like:

<img width="538" height="1052" alt="image" src="https://github.com/user-attachments/assets/9ee40971-b21a-4051-a29f-2e36dc1f31e5" />

I have no idea what these spikes are, but the only way I could hypothesize we'd end up there is if a/ the position vertex that creates the spike is somehow invalid, which would then b/ create an exception when calculating the distance. Under that scenario, we were setting the distance to 0.0 which defeated the max. distance safeguard.

The PR fixes that. 