### PR TITLE
Moving a singlepart point should adopt Z/M of snapped position

### DIFF
--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -165,9 +165,9 @@ bool MultiFeatureListModel::duplicateSelection()
   return mSourceModel->duplicateSelection();
 }
 
-bool MultiFeatureListModel::moveSelection( const double x, const double y )
+bool MultiFeatureListModel::moveSelection( const double x, const double y, const QgsPoint &destinationPoint )
 {
-  return mSourceModel->moveSelection( x, y );
+  return mSourceModel->moveSelection( x, y, destinationPoint );
 }
 
 bool MultiFeatureListModel::rotateSelection( const double angle )

--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -150,8 +150,11 @@ class MultiFeatureListModel : public QSortFilterProxyModel
     //! Duplicates selected features onto their associated layer
     Q_INVOKABLE bool duplicateSelection();
 
-    //! Moves selected features along a given \a vector.
-    Q_INVOKABLE bool moveSelection( const double x, const double y );
+    /**
+     * Moves selected feature(s) geometry by \a x and \a y. For a single feature with a singlepart point
+     * geometry containing Z and/or M values will adopt non-null values from the \a destinationPoint.
+     */
+    Q_INVOKABLE bool moveSelection( const double x, const double y, const QgsPoint &destinationPoint );
 
     //! Rotate selected features along a given \a vector.
     Q_INVOKABLE bool rotateSelection( const double angle );

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -25,6 +25,7 @@
 #include <qgsgeometrycollection.h>
 #include <qgsmemoryproviderutils.h>
 #include <qgsmessagelog.h>
+#include <qgsmultipoint.h>
 #include <qgsproject.h>
 #include <qgsrasterlayer.h>
 #include <qgsrelationmanager.h>
@@ -761,7 +762,7 @@ bool MultiFeatureListModelBase::duplicateSelection()
   return isSuccess;
 }
 
-bool MultiFeatureListModelBase::moveSelection( const double x, const double y )
+bool MultiFeatureListModelBase::moveSelection( const double x, const double y, const QgsPoint &destinationPoint )
 {
   if ( !canMoveSelection() )
     return false;
@@ -775,17 +776,53 @@ bool MultiFeatureListModelBase::moveSelection( const double x, const double y )
   }
 
   bool isSuccess = false;
+  bool isSingleSelection = mSelectedFeatures.size() == 1;
+  bool isSingleSelectionProcessed = false;
   for ( auto &pair : mSelectedFeatures )
   {
     QgsGeometry geom = pair.second.geometry();
-    geom.translate( x, y );
-    pair.second.setGeometry( geom );
+    if ( isSingleSelection && vlayer->geometryType() == Qgis::GeometryType::Point && !destinationPoint.isEmpty() )
+    {
+      if ( geom.constGet() && geom.constGet()->partCount() == 1 )
+      {
+        QgsPoint *point = nullptr;
+        if ( QgsPoint *singlePoint = dynamic_cast<QgsPoint *>( geom.get() ) )
+        {
+          point = singlePoint;
+        }
+        else if ( QgsMultiPoint *multiPoint = dynamic_cast<QgsMultiPoint *>( geom.get() ) )
+        {
+          point = multiPoint->pointN( 0 );
+        }
+
+        if ( point )
+        {
+          point->setX( destinationPoint.x() );
+          point->setY( destinationPoint.y() );
+          if ( QgsWkbTypes::hasZ( vlayer->wkbType() ) && !std::isnan( destinationPoint.z() ) )
+          {
+            point->setZ( destinationPoint.z() );
+          }
+          if ( QgsWkbTypes::hasZ( vlayer->wkbType() ) && !std::isnan( destinationPoint.m() ) )
+          {
+            point->setM( destinationPoint.m() );
+          }
+          isSingleSelectionProcessed = true;
+        }
+      }
+    }
+
+    if ( !isSingleSelectionProcessed )
+    {
+      geom.translate( x, y );
+    }
     isSuccess = vlayer->changeGeometry( pair.second.id(), geom );
     if ( !isSuccess )
     {
       QgsMessageLog::logMessage( tr( "Cannot change geometry of feature %1 in %2" ).arg( pair.second.id() ).arg( vlayer->name() ), "QField", Qgis::Critical );
       break;
     }
+    pair.second.setGeometry( geom );
   }
 
   if ( isSuccess )

--- a/src/core/multifeaturelistmodelbase.h
+++ b/src/core/multifeaturelistmodelbase.h
@@ -112,7 +112,7 @@ class MultiFeatureListModelBase : public QAbstractItemModel
     bool duplicateSelection();
 
     //! \copydoc MultiFeatureListModel::moveSelection
-    bool moveSelection( const double x, const double y );
+    bool moveSelection( const double x, const double y, const QgsPoint &destinationPoint );
 
     //! \copydoc MultiFeatureListModel::rotateSelection
     bool rotateSelection( const double angle );

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -737,13 +737,13 @@ Pane {
       target: moveFeaturesToolbar
 
       function onMoveConfirmed() {
-        moveFeaturesTransformer.sourcePosition = moveFeaturesToolbar.endPoint;
-        var translateX = moveFeaturesTransformer.projectedPosition.x;
-        var translateY = moveFeaturesTransformer.projectedPosition.y;
         moveFeaturesTransformer.sourcePosition = moveFeaturesToolbar.startPoint;
-        translateX -= moveFeaturesTransformer.projectedPosition.x;
-        translateY -= moveFeaturesTransformer.projectedPosition.y;
-        featureFormList.model.moveSelection(translateX, translateY);
+        let translateX = moveFeaturesTransformer.projectedPosition.x;
+        let translateY = moveFeaturesTransformer.projectedPosition.y;
+        moveFeaturesTransformer.sourcePosition = moveFeaturesToolbar.endPoint;
+        translateX = moveFeaturesTransformer.projectedPosition.x - translateX;
+        translateY = moveFeaturesTransformer.projectedPosition.y - translateY;
+        featureFormList.model.moveSelection(translateX, translateY, moveFeaturesTransformer.projectedPosition);
         moveFeaturesToolbar.startPoint = undefined;
         moveFeaturesToolbar.endPoint = undefined;
       }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1610,7 +1610,6 @@ ApplicationWindow {
       mapSettings: mapCanvas.mapSettings
       mapDistance: {
         if (moveFeaturesToolbar.moveFeaturesRequested && moveFeaturesToolbar.startPoint !== undefined && mapCanvas.mapSettings.center) {
-          console.log(stateMachine.state);
           if (stateMachine.state === "digitize") {
             return coordinateLocator.currentCoordinate.x - moveFeaturesToolbar.startPoint.x;
           } else {


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/7190

Background on this: since QField 4.1, in order to offer a less intimidating interface, we removed the geometry editor button for singlepart points because they only thing that could do is doing a one-vertex movement operation, which is the same thing as moving a feature.

That being said, the move feature would not transfer Z/M the same way a vertex movement did. This PR fixes that.