### PR TITLE
[Backport release-4_1] Strengthen tracker's maximum distance safeguard by ensuring non-measurable distances are dismissed

### DIFF
--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -235,7 +235,7 @@ void Tracker::positionReceived()
     }
     catch ( const QgsException & )
     {
-      mCurrentDistance = 0.0;
+      mCurrentDistance = !qgsDoubleNear( mMaximumDistance, 0.0 ) ? mMaximumDistance + 1.0 : 0.0;
     }
   }
 


### PR DESCRIPTION
Backport #7196
 **Authored by:** @nirvn