### PR TITLE
Enable automatic reconnect for TCP and UDP NMEA receivers

### DIFF
--- a/src/core/positioning/tcpreceiver.cpp
+++ b/src/core/positioning/tcpreceiver.cpp
@@ -26,10 +26,13 @@ TcpReceiver::TcpReceiver( const QString &address, const int port, QObject *paren
 {
   connect( mSocket, qOverload<QAbstractSocket::SocketError>( &QAbstractSocket::errorOccurred ), this, &TcpReceiver::handleError );
   connect( mSocket, &QTcpSocket::stateChanged, this, [this]( QAbstractSocket::SocketState state ) {
-    setSocketState( state );
     if ( state == QAbstractSocket::SocketState::UnconnectedState && mReconnectOnDisconnect )
     {
       mReconnectTimer.start( 2000 );
+    }
+    else
+    {
+      setSocketState( state );
     }
   } );
 
@@ -61,6 +64,8 @@ void TcpReceiver::handleConnectDevice()
     return;
   }
   qInfo() << QStringLiteral( "TcpReceiver: Initiating connection to address %1 (port %2)" ).arg( mAddress, QString::number( mPort ) );
+  mConnectionFailureCount = 0;
+  mReconnectOnDisconnect = true;
   mSocket->connectToHost( mAddress, mPort, QTcpSocket::ReadWrite );
 }
 
@@ -99,6 +104,16 @@ void TcpReceiver::handleError( QAbstractSocket::SocketError error )
       break;
   }
   qInfo() << QStringLiteral( "TcpReceiver: Error: %1" ).arg( mLastError );
+
+  if ( mReconnectOnDisconnect )
+  {
+    mConnectionFailureCount++;
+  }
+
+  if ( mConnectionFailureCount > 10 )
+  {
+    mReconnectOnDisconnect = false;
+  }
 
   emit lastErrorChanged( mLastError );
 }

--- a/src/core/positioning/tcpreceiver.h
+++ b/src/core/positioning/tcpreceiver.h
@@ -50,6 +50,7 @@ class TcpReceiver : public NmeaGnssReceiver
     QTcpSocket *mSocket = nullptr;
 
     bool mReconnectOnDisconnect = false;
+    int mConnectionFailureCount = 0;
     QTimer mReconnectTimer;
 };
 

--- a/src/core/positioning/udpreceiver.cpp
+++ b/src/core/positioning/udpreceiver.cpp
@@ -39,10 +39,13 @@ UdpReceiver::UdpReceiver( const QString &address, const int port, QObject *paren
 
   connect( mSocket, qOverload<QAbstractSocket::SocketError>( &QAbstractSocket::errorOccurred ), this, &UdpReceiver::handleError );
   connect( mSocket, &QUdpSocket::stateChanged, this, [this]( QAbstractSocket::SocketState state ) {
-    setSocketState( state );
     if ( state == QAbstractSocket::SocketState::UnconnectedState && mReconnectOnDisconnect )
     {
       mReconnectTimer.start( 2000 );
+    }
+    else
+    {
+      setSocketState( state );
     }
   } );
 
@@ -85,6 +88,8 @@ void UdpReceiver::handleConnectDevice()
     return;
   }
   qInfo() << QStringLiteral( "UdpReceiver: Initiating connection to address %1 (port %2)" ).arg( mAddress, QString::number( mPort ) );
+  mConnectionFailureCount = 0;
+  mReconnectOnDisconnect = true;
   mBuffer->open( QIODevice::ReadWrite );
   mSocket->bind( QHostAddress( mAddress ), mPort, QAbstractSocket::ShareAddress | QAbstractSocket::ReuseAddressHint );
   mSocket->joinMulticastGroup( QHostAddress( mAddress ) );
@@ -126,6 +131,16 @@ void UdpReceiver::handleError( QAbstractSocket::SocketError error )
       break;
   }
   qInfo() << QStringLiteral( "UdpReceiver: Error: %1" ).arg( mLastError );
+
+  if ( mReconnectOnDisconnect )
+  {
+    mConnectionFailureCount++;
+  }
+
+  if ( mConnectionFailureCount > 10 )
+  {
+    mReconnectOnDisconnect = false;
+  }
 
   emit lastErrorChanged( mLastError );
 }

--- a/src/core/positioning/udpreceiver.h
+++ b/src/core/positioning/udpreceiver.h
@@ -52,6 +52,7 @@ class UdpReceiver : public NmeaGnssReceiver
     QBuffer *mBuffer = nullptr;
 
     bool mReconnectOnDisconnect = false;
+    int mConnectionFailureCount = 0;
     QTimer mReconnectTimer;
 };
 


### PR DESCRIPTION
The reconnect infrastructure (mReconnectOnDisconnect flag, mReconnectTimer with 2s delay, state change handler) exists in both TcpReceiver and UdpReceiver but is never activated. The flag mReconnectOnDisconnect is initialized to false and never set to true, so when a connection drops the reconnect timer never starts.

This is inconsistent with BluetoothReceiver which correctly sets its equivalent flag (mConnectOnDisconnect = true) in handleConnectDevice().

Fix: set mReconnectOnDisconnect = true in handleConnectDevice() for both TCP and UDP receivers. The flag is already reset to false in handleDisconnectDevice() to prevent reconnection when the user explicitly disconnects.