### PR TITLE
[Backport release-4_1] Add a FileUtils.nativeSeparatorsPath function to ease cross-platform plugin authoring

### DIFF
--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -70,6 +70,11 @@ QString FileUtils::absolutePath( const QString &filePath )
   return fileInfo.absolutePath();
 }
 
+QString FileUtils::nativeSeparatorsPath( const QString &filePath )
+{
+  return QDir::toNativeSeparators( filePath );
+}
+
 QString FileUtils::fileName( const QString &filePath )
 {
   QFileInfo fileInfo( filePath );

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -58,6 +58,8 @@ class QFIELD_CORE_EXPORT FileUtils : public QObject
     Q_INVOKABLE static QString sanitizeFilePathPart( const QString &filePathPart, const QString &replacement = QLatin1String( "_" ) );
     //! Returns the absolute path of the folder containing the \a filePath.
     Q_INVOKABLE static QString absolutePath( const QString &filePath );
+    //! Returns the \a filePath with '/' separators converted to separators that are appropriate for the underlying operating system.
+    Q_INVOKABLE static QString nativeSeparatorsPath( const QString &filePath );
 
     /**
     * Checks if a file path is securely within the current project directory.


### PR DESCRIPTION
Backport #7227
 **Authored by:** @nirvn