### PR TITLE
[Backport release-4_1] Fix regression with range editor widget handling typed thousand and decimal characters

### DIFF
--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -74,10 +74,14 @@ EditorWidgetBase {
               clampedValue = rangeItem.max;
             }
 
-            valueChangeRequested(clampedValue, false);
-            text = Qt.binding(function () {
-              return isNull ? '' : value;
-            });
+            if (clampedValue !== value) {
+              valueChangeRequested(clampedValue, false);
+            }
+            if (parsedValue !== value) {
+              text = Qt.binding(function () {
+                return isNull ? '' : value;
+              });
+            }
           }
         } else if (!isNull) {
           valueChangeRequested(text, true);


### PR DESCRIPTION
Backport #7225
 **Authored by:** @nirvn