### PR TITLE
[Backport release-4_1] Fix qtbase build with Xcode 26 / Apple Clang 21 on macOS

### DIFF
--- a/vcpkg/ports/qtbase/fix-qyieldcpu-apple-clang.patch
+++ b/vcpkg/ports/qtbase/fix-qyieldcpu-apple-clang.patch
@@ -1,0 +1,53 @@
+From d90c9e25a4dd22e126e848ff4fc56631268c7c1c Mon Sep 17 00:00:00 2001
+From: Paul Wicking <paul.wicking@qt.io>
+Date: Thu, 26 Mar 2026 07:09:43 +0100
+Subject: [PATCH] qyieldcpu: Fix compilation with macOS 26.4 SDK
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+After updating to the macOS 26.4 SDK, qtbase fails to compile on
+Apple Silicon with an implicit function declaration error for
+__yield() in qyieldcpu.h. It appears that the SDK's Clang now
+reports __has_builtin(__yield) as true, but __yield() requires
+<arm_acle.h> for its declaration.
+
+The compiler's own __builtin_arm_yield intrinsic was already checked
+further down in the cascade. Moving it above the __yield check resolves
+the build failure, without unnecessarily pulling in the header.
+
+Fixes: QTBUG-145239
+Pick-to: 6.8
+Change-Id: I94b4d8f72385a4944c272ed7a66d249537a82e7d
+Reviewed-by: Tor Arne Vestbø <tor.arne.vestbo@qt.io>
+Reviewed-by: Fabian Kosmale <fabian.kosmale@qt.io>
+(cherry picked from commit a76004f16fdc43e1b7af83bfdf3f1a613491b234)
+---
+ src/corelib/thread/qyieldcpu.h | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/src/corelib/thread/qyieldcpu.h b/src/corelib/thread/qyieldcpu.h
+index 66156487d66b..84093f42dbe7 100644
+--- a/src/corelib/thread/qyieldcpu.h
++++ b/src/corelib/thread/qyieldcpu.h
+@@ -33,7 +33,9 @@ void qYieldCpu(void)
+     noexcept
+ #endif
+ {
+-#if __has_builtin(__yield)
++#if __has_builtin(__builtin_arm_yield)
++    __builtin_arm_yield();
++#elif __has_builtin(__yield)
+     __yield();              // Generic
+ #elif defined(_YIELD_PROCESSOR) && defined(Q_CC_MSVC)
+     _YIELD_PROCESSOR();     // Generic; MSVC's <atomic>
+@@ -47,9 +49,6 @@ void qYieldCpu(void)
+     _mm_pause();
+ #elif defined(Q_PROCESSOR_X86)
+     __asm__("pause");           // hopefully asm() works in this compiler
+-
+-#elif __has_builtin(__builtin_arm_yield)
+-    __builtin_arm_yield();
+ #elif defined(Q_PROCESSOR_ARM) && Q_PROCESSOR_ARM >= 7 && defined(Q_CC_GNU)
+     __asm__("yield");           // this works everywhere
+ 

--- a/vcpkg/ports/qtbase/portfile.cmake
+++ b/vcpkg/ports/qtbase/portfile.cmake
@@ -28,6 +28,7 @@ set(${PORT}_PATCHES
         fix-libresolv-test.patch
         framework.patch
         use_inotify_on_freebsd.patch
+        fix-qyieldcpu-apple-clang.patch
 )
  
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)


### PR DESCRIPTION
Backport #7233
 **Authored by:** @kaustuvpokharel