### PR TITLE
Fix zooming to identified features containing mixed point and non-point geometries

### DIFF
--- a/src/core/featurelistextentcontroller.cpp
+++ b/src/core/featurelistextentcontroller.cpp
@@ -96,18 +96,23 @@ void FeatureListExtentController::zoomToSelected( bool skipIfIntersects ) const
 
 void FeatureListExtentController::zoomToAllFeatures() const
 {
-  if ( !mModel || !mMapSettings || mModel->rowCount( QModelIndex() ) == 0 )
+  if ( !mModel || !mMapSettings )
+  {
     return;
+  }
 
+  const int rowCount = mModel->rowCount( QModelIndex() );
+  if ( rowCount == 0 )
+  {
+    return;
+  }
+
+  bool isSinglePointGeometry = rowCount == 1; // Further assessed down below
   QgsRectangle combinedExtent;
-  bool hasNonPointGeometry = false;
-
   for ( int i = 0; i < mModel->rowCount( QModelIndex() ); ++i )
   {
     const QModelIndex index = mModel->index( i, 0 );
     QgsVectorLayer *layer = qvariant_cast<QgsVectorLayer *>( mModel->data( index, MultiFeatureListModel::LayerRole ) );
-    const QgsFeature feature = mModel->data( index, MultiFeatureListModel::FeatureRole ).value<QgsFeature>();
-
     if ( !layer || layer->geometryType() == Qgis::GeometryType::Unknown || layer->geometryType() == Qgis::GeometryType::Null )
     {
       continue;
@@ -115,6 +120,7 @@ void FeatureListExtentController::zoomToAllFeatures() const
 
     try
     {
+      const QgsFeature feature = mModel->data( index, MultiFeatureListModel::FeatureRole ).value<QgsFeature>();
       const QgsGeometry geom( feature.geometry() );
       if ( geom.isNull() )
       {
@@ -123,10 +129,10 @@ void FeatureListExtentController::zoomToAllFeatures() const
 
       if ( geom.type() != Qgis::GeometryType::Point || geom.constGet()->partCount() > 1 )
       {
-        hasNonPointGeometry = true;
+        isSinglePointGeometry = false;
       }
 
-      const QgsRectangle extent = FeatureUtils::extent( mMapSettings, layer, feature );
+      const QgsRectangle extent = FeatureUtils::extent( mMapSettings, layer, feature, !isSinglePointGeometry );
       if ( extent.isNull() )
       {
         continue;
@@ -153,7 +159,7 @@ void FeatureListExtentController::zoomToAllFeatures() const
     const double buffer = std::max( combinedExtent.width(), combinedExtent.height() ) * 0.5;
     combinedExtent = combinedExtent.buffered( buffer );
 
-    const double scale = ( mKeepScale || !hasNonPointGeometry ) ? -1 : mMapSettings->computeScaleForExtent( combinedExtent, true );
+    const double scale = ( mKeepScale || isSinglePointGeometry ) ? -1 : mMapSettings->computeScaleForExtent( combinedExtent, true );
     emit requestJumpToPoint( QgsPoint( combinedExtent.center() ), scale, true );
   }
 }

--- a/src/core/utils/featureutils.cpp
+++ b/src/core/utils/featureutils.cpp
@@ -75,7 +75,7 @@ QString FeatureUtils::displayName( QgsVectorLayer *layer, const QgsFeature &feat
   return name;
 }
 
-QgsRectangle FeatureUtils::extent( QgsQuickMapSettings *mapSettings, QgsVectorLayer *layer, const QgsFeature &feature )
+QgsRectangle FeatureUtils::extent( QgsQuickMapSettings *mapSettings, QgsVectorLayer *layer, const QgsFeature &feature, bool skipSinglePointLogic )
 {
   if ( mapSettings && layer && layer->geometryType() != Qgis::GeometryType::Unknown && layer->geometryType() != Qgis::GeometryType::Null )
   {
@@ -85,7 +85,7 @@ QgsRectangle FeatureUtils::extent( QgsQuickMapSettings *mapSettings, QgsVectorLa
     {
       geom.transform( ct );
       QgsRectangle extent;
-      if ( geom.type() == Qgis::GeometryType::Point && geom.constGet()->partCount() == 1 )
+      if ( !skipSinglePointLogic && geom.type() == Qgis::GeometryType::Point && geom.constGet()->partCount() == 1 )
       {
         extent = mapSettings->extent();
         QgsVector delta = QgsPointXY( geom.asPoint() ) - extent.center();

--- a/src/core/utils/featureutils.h
+++ b/src/core/utils/featureutils.h
@@ -70,9 +70,10 @@ class QFIELD_CORE_EXPORT FeatureUtils : public QObject
      * \param mapSettings the map settings used to determine the CRS
      * \param layer the vector layer containing the feature
      * \param feature the feature from which the geometry will be used
+     * \param skipSinglePointLogic when TRUE, the special handling for determining a single point extent will be skipped
      * \returns a QgsRectangle extent
      */
-    static Q_INVOKABLE QgsRectangle extent( QgsQuickMapSettings *mapSettings, QgsVectorLayer *layer, const QgsFeature &feature );
+    static Q_INVOKABLE QgsRectangle extent( QgsQuickMapSettings *mapSettings, QgsVectorLayer *layer, const QgsFeature &feature, bool skipSinglePointLogic = false );
 
     /**
      * Returns a list of features while attempting to parse a GeoJSON \a string. If the string could not


### PR DESCRIPTION
Prevents the extent from always growing on each identification. Fixes https://github.com/opengisch/QField/issues/7244