### PR TITLE
introduce a cooldown for dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "07:00"
+    cooldown:
+      default-days: 7
     groups:
       all-actions:
         patterns: [ "*" ]


### PR DESCRIPTION
I added it for githhub actions, not sure about "bundler"