### PR TITLE
[Backport release-4_1] When deselecting a value map item, pass on null as empty value

### DIFF
--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -84,6 +84,7 @@ EditorWidgetBase {
       id: toggleButtons
       Layout.fillWidth: true
       Layout.minimumHeight: toggleButtons.height
+      Layout.bottomMargin: 5
 
       model: listModel
       textRole: "value"
@@ -97,7 +98,7 @@ EditorWidgetBase {
       }
 
       onItemDeselected: function () {
-        valueChangeRequested("", false);
+        valueChangeRequested("", true);
       }
     }
 

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -116,6 +116,7 @@ EditorWidgetBase {
     id: toggleButtons
     anchors.left: parent.left
     anchors.right: parent.right
+    anchors.bottomMargin: 5
     visible: false
 
     model: valueRelation.useToggleButtons ? listModel : null


### PR DESCRIPTION
Backport #7268
 **Authored by:** @nirvn