### PR TITLE
Return to fuzzy score sorting when searching through value relation items

### DIFF
--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -435,7 +435,7 @@ void FeatureListModel::processFeatureList()
     if ( !mSearchTerm.isEmpty() )
     {
       entry.fuzzyScore = StringUtils::calcFuzzyScore( entry.displayString, mSearchTerm );
-      if ( entry.fuzzyScore == 0 )
+      if ( qgsDoubleNear( entry.fuzzyScore, 0.0 ) )
       {
         continue;
       }

--- a/src/core/utils/stringutils.cpp
+++ b/src/core/utils/stringutils.cpp
@@ -47,40 +47,41 @@ QString StringUtils::createUuid()
   return QUuid::createUuid().toString();
 }
 
-bool StringUtils::fuzzyMatch( const QString &source, const QString &term )
-{
-  if ( source.contains( term, Qt::CaseInsensitive ) )
-    return true;
-
-  const QRegularExpression whitespaceRegex( QStringLiteral( "\\W+" ) );
-  const QStringList parts = source.split( whitespaceRegex );
-  const QStringList termParts = term.split( whitespaceRegex );
-  const qsizetype termPartsCount = termParts.size();
-  qsizetype lastMatchedTermPartIdx = -1;
-  qsizetype matchedTermItems = 0;
-
-  for ( const QString &part : parts )
-  {
-    for ( qsizetype i = lastMatchedTermPartIdx + 1; i < termPartsCount; i++ )
-    {
-      if ( part.startsWith( termParts[i], Qt::CaseInsensitive ) )
-      {
-        lastMatchedTermPartIdx = i;
-        matchedTermItems++;
-        break;
-      }
-    }
-  }
-
-  return lastMatchedTermPartIdx >= 0 && matchedTermItems == termPartsCount
-           ? true
-           : false;
-}
-
 double StringUtils::calcFuzzyScore( const QString &string, const QString &searchTerm )
 {
   double fuzzyScore = 0.0;
-  fuzzyScore = StringUtils::fuzzyMatch( string, searchTerm ) ? 0.5 : 0;
+  if ( string.startsWith( searchTerm, Qt::CaseInsensitive ) )
+  {
+    fuzzyScore += 0.5;
+  }
+  else
+  {
+    static QRegularExpression whitespaceRegex( QStringLiteral( "\\W+" ) );
+    const QStringList parts = string.split( whitespaceRegex );
+    const QStringList termParts = searchTerm.split( whitespaceRegex );
+    const qsizetype termPartsCount = termParts.size();
+
+    qsizetype lastMatchedTermPartIdx = -1;
+    qsizetype matchedTermItems = 0;
+    for ( const QString &part : parts )
+    {
+      for ( qsizetype i = lastMatchedTermPartIdx + 1; i < termPartsCount; i++ )
+      {
+        if ( part.startsWith( termParts[i], Qt::CaseInsensitive ) )
+        {
+          lastMatchedTermPartIdx = i;
+          matchedTermItems++;
+          break;
+        }
+      }
+    }
+
+    if ( lastMatchedTermPartIdx >= 0 && matchedTermItems == termPartsCount )
+    {
+      fuzzyScore += 0.5;
+    }
+  }
+
   fuzzyScore += QgsStringUtils::fuzzyScore( string, searchTerm ) * 0.5;
   return fuzzyScore;
 };

--- a/src/core/utils/stringutils.h
+++ b/src/core/utils/stringutils.h
@@ -44,11 +44,8 @@ class QFIELD_CORE_EXPORT StringUtils : public QObject
     //! Returns a new UUID string
     static Q_INVOKABLE QString createUuid();
 
-    //! Checks whether the string \a term is part of \a source
-    static bool fuzzyMatch( const QString &source, const QString &term );
-
     //! Calculates a fuzzy matching score between a \a string and a \a searchTerm.
-    static double calcFuzzyScore( const QString &string, const QString &searchTerm );
+    static Q_INVOKABLE double calcFuzzyScore( const QString &string, const QString &searchTerm );
 
     //! Returns a string highlighting a text using HTML formatting
     static Q_INVOKABLE QString highlightText( const QString &string, const QString &highlightText, const QColor &highlightColor = QColor() );

--- a/test/test_stringutils.cpp
+++ b/test/test_stringutils.cpp
@@ -29,24 +29,6 @@ TEST_CASE( "StringUtils" )
     REQUIRE( StringUtils::insertLinks( QStringLiteral( "before https://osm.org/path?resource=;or=this%20one after" ) ) == QStringLiteral( "before <a href=\"https://osm.org/path?resource=;or=this%20one\">https://osm.org/path?resource=;or=this%20one</a> after" ) );
   }
 
-  SECTION( "FuzzyMatch" )
-  {
-    REQUIRE( StringUtils::fuzzyMatch( "Quercus rubra", "Quercus rubra" ) == true );
-    REQUIRE( StringUtils::fuzzyMatch( "Quercus rubra", "quercus r" ) == true );
-    REQUIRE( StringUtils::fuzzyMatch( "Quercus rubra", "Pinus nigra" ) == false );
-    REQUIRE( StringUtils::fuzzyMatch( "Quercus rubra", "Quercus" ) == true );
-    REQUIRE( StringUtils::fuzzyMatch( "Quercus rubra", "qUERCUS" ) == true );
-    REQUIRE( StringUtils::fuzzyMatch( "Quercus rubra", "ERcU" ) == true );
-    REQUIRE( StringUtils::fuzzyMatch( "Quercus rubra", "rubra" ) == true );
-    REQUIRE( StringUtils::fuzzyMatch( "Quercus rubra", "Rubra" ) == true );
-    REQUIRE( StringUtils::fuzzyMatch( "Quercus rubra", "bra" ) == true );
-    REQUIRE( StringUtils::fuzzyMatch( "Quercus rubra forma variegata", "rubra varieg" ) == true );
-    REQUIRE( StringUtils::fuzzyMatch( "Quercus rubra (forma variegata)", "quercus forma" ) == true );
-    REQUIRE( StringUtils::fuzzyMatch( "Quercus rubra", "q r" ) == true );
-    REQUIRE( StringUtils::fuzzyMatch( "Quercus rubra", "q   r" ) == true );
-    REQUIRE( StringUtils::fuzzyMatch( "Quercus rubra", "q   ubra" ) == false );
-  }
-
   SECTION( "HighlightText" )
   {
     REQUIRE( StringUtils::highlightText( "QField roxx", "", QColor( Qt::black ) ) == "QField roxx" );


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/7174 

I've also taken the time to improve matching text highlight. When a match against a given multi-word term cannot be done in one replacement (i.e. when the source doesn't contain exactly the multi-word term), we highlight individual parts. It makes a big difference. E.g.:

<img width="727" height="678" alt="image" src="https://github.com/user-attachments/assets/fa40ca02-92b9-4538-b27a-e7ed8103e8c0" />
