### PR TITLE
Check what happens when camera is hardcoded to fixed focus/exposure/white balance

### DIFF
--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -179,6 +179,9 @@ Popup {
               id: camera
               property bool restarting: false
               active: cameraItem.visible && cameraPermission.status === Qt.PermissionStatus.Granted && !restarting
+              focusMode: Camera.FocusModeInfinity
+              exposureMode: Camera.ExposurePortrait
+              whiteBalanceMode: Camera.WhiteBalanceSunlight
 
               function applyCameraFormat() {
                 if (cameraSettings.pixelFormat != 0) {


### PR DESCRIPTION
Shot in the dark to see if we can workaround broken camera state on some Samsung devices.