### PR TITLE
Fix expression based visibility of nested feature form containers

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -243,7 +243,7 @@ void AttributeFormModelBase::resetModel()
           QString visibilityExpression;
           if ( container->visibilityExpression().enabled() )
           {
-            visibilityExpression = container->visibilityExpression().data().expression();
+            visibilityExpression = QStringLiteral( "(%1)" ).arg( container->visibilityExpression().data().expression() );
           }
 
           buildForm( container, item, visibilityExpression, containers, currentTab, columnCount );
@@ -513,9 +513,13 @@ void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, 
         if ( innerContainer->visibilityExpression().enabled() )
         {
           if ( visibilityExpression.isNull() )
-            visibilityExpression = innerContainer->visibilityExpression().data().expression();
+          {
+            visibilityExpression = QStringLiteral( "(%1)" ).arg( innerContainer->visibilityExpression().data().expression() );
+          }
           else
-            visibilityExpression += " AND " + innerContainer->visibilityExpression().data().expression();
+          {
+            visibilityExpression += QStringLiteral( " AND (%1)" ).arg( innerContainer->visibilityExpression().data().expression() );
+          }
         }
 
         item->setData( "container", AttributeFormModel::ElementType );
@@ -525,14 +529,18 @@ void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, 
         item->setData( false, AttributeFormModel::AttributeAllowEdit );
         item->setData( element->showLabel() ? innerContainer->name() : QString(), AttributeFormModel::GroupName );
         if ( innerContainer->backgroundColor().isValid() )
+        {
           item->setData( innerContainer->backgroundColor(), AttributeFormModel::GroupColor );
+        }
 
         buildForm( innerContainer, item, visibilityExpression, containers, 0, innerColumnCount );
         parent->appendRow( item );
         containers << item;
 
         if ( !visibilityExpression.isEmpty() )
+        {
           mVisibilityExpressions.append( qMakePair( QgsExpression( visibilityExpression ), item ) );
+        }
         break;
       }
 

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -956,7 +956,7 @@ void MultiFeatureListModelBase::attributeValueChanged( QgsFeatureId fid, int idx
     i++;
   }
 
-  QModelIndex indexChanged = createIndex( i, 1 );
+  QModelIndex indexChanged = createIndex( i, 0 );
   emit dataChanged( indexChanged, indexChanged );
 
   for ( auto &pair : mSelectedFeatures )
@@ -987,7 +987,7 @@ void MultiFeatureListModelBase::geometryChanged( QgsFeatureId fid, const QgsGeom
     i++;
   }
 
-  QModelIndex indexChanged = createIndex( i, 1 );
+  QModelIndex indexChanged = createIndex( i, 0 );
   emit dataChanged( indexChanged, indexChanged, QVector<int>() << MultiFeatureListModel::GeometryRole << MultiFeatureListModel::FeatureSelectedRole );
 
   for ( auto &pair : mSelectedFeatures )


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/7253 

The problem had to do with expression of a parent container using a OR b OR c , which we were gluing together with another expression without adding parenthesis, which resulted in something like a OR b OR c AND d. As a result, ti meant children containers would always visible when the parent was.