### PR TITLE
Signal fixes and significant optimization of the ReferencingFeatureListModel

### DIFF
--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -101,6 +101,7 @@ void ReferencingFeatureListModelBase::setFeature( const QgsFeature &feature )
   }
 
   mFeature = feature;
+  emit featureChanged();
 
   if ( mRelation.isValid() && mFeature.isValid() && !mLastGathererFeaturesFilter.isEmpty() )
   {

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -101,6 +101,16 @@ void ReferencingFeatureListModelBase::setFeature( const QgsFeature &feature )
   }
 
   mFeature = feature;
+
+  if ( mRelation.isValid() && mFeature.isValid() && !mLastGathererFeaturesFilter.isEmpty() )
+  {
+    // The updated feature did not change the related features filter, skip reload
+    if ( mLastGathererFeaturesFilter == mRelation.getRelatedFeaturesFilter( mFeature ) )
+    {
+      return;
+    }
+  }
+
   reload();
 }
 
@@ -114,6 +124,7 @@ void ReferencingFeatureListModelBase::setRelation( const QgsRelation &relation )
   mRelation = relation;
   emit relationChanged();
 
+  mLastGathererFeaturesFilter.clear();
   updateAttachmentFieldInfo();
 
   reload();
@@ -144,6 +155,7 @@ void ReferencingFeatureListModelBase::setNmRelation( const QgsRelation &relation
   mNmRelation = relation;
   emit nmRelationChanged();
 
+  mLastGathererFeaturesFilter.clear();
   updateAttachmentFieldInfo();
 
   reload();
@@ -229,6 +241,7 @@ void ReferencingFeatureListModelBase::reload()
     }
 
     mGatherer = new FeatureGatherer( mFeature, mRelation, mNmRelation );
+    mLastGathererFeaturesFilter = mRelation.getRelatedFeaturesFilter( mFeature );
 
     connect( mGatherer, &FeatureGatherer::collectedValues, this, &ReferencingFeatureListModelBase::updateModel );
     connect( mGatherer, &FeatureGatherer::finished, this, &ReferencingFeatureListModelBase::gathererThreadFinished );

--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -112,7 +112,10 @@ QgsFeature ReferencingFeatureListModelBase::feature() const
 void ReferencingFeatureListModelBase::setRelation( const QgsRelation &relation )
 {
   mRelation = relation;
+  emit relationChanged();
+
   updateAttachmentFieldInfo();
+
   reload();
 }
 
@@ -133,16 +136,16 @@ void ReferencingFeatureListModelBase::setCurrentRelationId( const QString &relat
     return;
   }
 
-  mRelation = QgsProject::instance()->relationManager()->relation( relationId );
-  updateAttachmentFieldInfo();
-
-  emit relationChanged();
-  reload();
+  setRelation( QgsProject::instance()->relationManager()->relation( relationId ) );
 }
 
 void ReferencingFeatureListModelBase::setNmRelation( const QgsRelation &relation )
 {
   mNmRelation = relation;
+  emit nmRelationChanged();
+
+  updateAttachmentFieldInfo();
+
   reload();
 }
 
@@ -163,8 +166,7 @@ void ReferencingFeatureListModelBase::setCurrentNmRelationId( const QString &nmR
     return;
   }
 
-  mNmRelation = QgsProject::instance()->relationManager()->relation( nmRelationId );
-  reload();
+  setNmRelation( QgsProject::instance()->relationManager()->relation( nmRelationId ) );
 }
 
 void ReferencingFeatureListModelBase::setParentPrimariesAvailable( const bool parentPrimariesAvailable )

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -244,6 +244,7 @@ class QFIELD_CORE_EXPORT ReferencingFeatureListModelBase : public QAbstractItemM
     QString mAttachmentStorageUrl;
 
     FeatureGatherer *mGatherer = nullptr;
+    QString mLastGathererFeaturesFilter;
 
     //! Refreshes the cached attachment field info from the current relation's referencing layer
     void updateAttachmentFieldInfo();


### PR DESCRIPTION
While polishing our new gallery editor widget, I came to the realization we were reloading the model every time we were editing any of the the parent feature's attributes. That means _one reload per key stroke_ when editing a text field. 

This was happening before, but the list of children would re-populate in an instance. With the gallery editor widget, getting videos to reload at every key stroke meant any ongoing video playback would break.

Nice collateral finding. This can have a significant impact on large datasets, even those on disk.