### PR TITLE
Add a QGIS patch to gain some backward compatibility with QGIS 3.44

### DIFF
--- a/vcpkg/ports/qgis/compatibility.patch
+++ b/vcpkg/ports/qgis/compatibility.patch
@@ -1,0 +1,240 @@
+From 6fb1ff770b8641219702c320dc6eec2e2107a0d8 Mon Sep 17 00:00:00 2001
+From: Mathieu Pellerin <nirvn.asia@gmail.com>
+Date: Sun, 5 Apr 2026 13:50:38 +0700
+Subject: [PATCH] Add a bit of compatibility to avoid completely broken project
+ with QGIS < 4.0
+
+---
+ src/core/project/qgsprojectproperty.cpp | 163 ++++++++++++++++++------
+ 1 file changed, 125 insertions(+), 38 deletions(-)
+
+diff --git a/src/core/project/qgsprojectproperty.cpp b/src/core/project/qgsprojectproperty.cpp
+index 276963ea83b2..4349975431cc 100644
+--- a/src/core/project/qgsprojectproperty.cpp
++++ b/src/core/project/qgsprojectproperty.cpp
+@@ -232,36 +232,72 @@ bool QgsProjectPropertyValue::readXml( const QDomNode &keyNode )
+ // keyElement is created by parent QgsProjectPropertyKey
+ bool QgsProjectPropertyValue::writeXml( QString const &nodeName, QDomElement &keyElement, QDomDocument &document )
+ {
+-  QDomElement valueElement = document.createElement( u"properties"_s );
+-
+-  // remember the type so that we can rebuild it when the project is read in
+-  valueElement.setAttribute( u"name"_s, nodeName );
+-  valueElement.setAttribute( u"type"_s, mValue.typeName() );
+-
+-  // we handle string lists differently from other types in that we
+-  // create a sequence of repeated elements to cover all the string list
+-  // members; each value will be in a <value></value> tag.
+-  // XXX Not the most elegant way to handle string lists?
+-  if ( QMetaType::Type::QStringList == mValue.userType() )
+   {
+-    QStringList sl = mValue.toStringList();
++    QDomElement valueElement = document.createElement( u"properties"_s );
+ 
+-    for ( QStringList::iterator i = sl.begin(); i != sl.end(); ++i )
++    // remember the type so that we can rebuild it when the project is read in
++    valueElement.setAttribute( u"name"_s, nodeName );
++    valueElement.setAttribute( u"type"_s, mValue.typeName() );
++
++    // we handle string lists differently from other types in that we
++    // create a sequence of repeated elements to cover all the string list
++    // members; each value will be in a <value></value> tag.
++    // XXX Not the most elegant way to handle string lists?
++    if ( QMetaType::Type::QStringList == mValue.userType() )
+     {
+-      QDomElement stringListElement = document.createElement( u"value"_s );
+-      QDomText valueText = document.createTextNode( *i );
+-      stringListElement.appendChild( valueText );
++      QStringList sl = mValue.toStringList();
+ 
+-      valueElement.appendChild( stringListElement );
++      for ( QStringList::iterator i = sl.begin(); i != sl.end(); ++i )
++      {
++        QDomElement stringListElement = document.createElement( u"value"_s );
++        QDomText valueText = document.createTextNode( *i );
++        stringListElement.appendChild( valueText );
++
++        valueElement.appendChild( stringListElement );
++      }
++    }
++    else // we just plop the value in as plain ole text
++    {
++      QDomText valueText = document.createTextNode( mValue.toString() );
++      valueElement.appendChild( valueText );
+     }
++
++    keyElement.appendChild( valueElement );
+   }
+-  else // we just plop the value in as plain ole text
++
+   {
+-    QDomText valueText = document.createTextNode( mValue.toString() );
+-    valueElement.appendChild( valueText );
+-  }
++    // retain compatibility with QGIS 3 for the time being
++    QDomElement valueElement = document.createElement( nodeName );
++
++    // remember the type so that we can rebuild it when the project is read in
++    valueElement.setAttribute( u"type"_s, mValue.typeName() );
+ 
+-  keyElement.appendChild( valueElement );
++    // we handle string lists differently from other types in that we
++    // create a sequence of repeated elements to cover all the string list
++    // members; each value will be in a <value></value> tag.
++    // XXX Not the most elegant way to handle string lists?
++    if ( QMetaType::Type::QStringList == mValue.userType() )
++    {
++      QStringList sl = mValue.toStringList();
++
++      for ( QStringList::iterator i = sl.begin(); i != sl.end(); ++i )
++      {
++        QDomElement stringListElement = document.createElement( u"value"_s );
++        QDomText valueText = document.createTextNode( *i );
++        stringListElement.appendChild( valueText );
++
++        valueElement.appendChild( stringListElement );
++      }
++    }
++    else
++    {
++      // we just plop the value in as plain ole text
++      QDomText valueText = document.createTextNode( mValue.toString() );
++      valueElement.appendChild( valueText );
++    }
++
++    keyElement.appendChild( valueElement );
++  }
+ 
+   return true;
+ }
+@@ -346,23 +382,44 @@ void QgsProjectPropertyKey::dump( int tabs ) const
+ 
+ bool QgsProjectPropertyKey::readXml( const QDomNode &keyNode )
+ {
+-  int i = 0;
+   QDomNodeList subkeys = keyNode.childNodes();
++  bool hasModernProperties = false;
++  for ( int i = 0; i < subkeys.count(); i++ )
++  {
++    const QDomNode subkey = subkeys.item( i );
++    if ( subkey.nodeName() == "properties"_L1
++         && subkey.hasAttributes()
++         && // if we have attributes
++         subkey.isElement()
++         &&                                             // and we're an element
++         subkey.toElement().hasAttribute( u"name"_s ) ) // and we have a "name" attribute
++    {
++      hasModernProperties = true;
++    }
++  }
+ 
+-  while ( i < subkeys.count() )
++  for ( int i = 0; i < subkeys.count(); i++ )
+   {
+     const QDomNode subkey = subkeys.item( i );
+-    QString name;
+ 
++    QString name;
+     if ( subkey.nodeName() == "properties"_L1
+          && subkey.hasAttributes()
+          && // if we have attributes
+          subkey.isElement()
+          &&                                             // and we're an element
+          subkey.toElement().hasAttribute( u"name"_s ) ) // and we have a "name" attribute
++    {
+       name = subkey.toElement().attribute( u"name"_s );
++    }
+     else
++    {
++      if ( hasModernProperties )
++      {
++        continue;
++      }
+       name = subkey.nodeName();
++    }
+ 
+     // if the current node is an element that has a "type" attribute,
+     // then we know it's a leaf node; i.e., a subkey _value_, and not
+@@ -374,7 +431,6 @@ bool QgsProjectPropertyKey::readXml( const QDomNode &keyNode )
+          subkey.toElement().hasAttribute( u"type"_s ) ) // and we have a "type" attribute
+     {
+       // then we're a key value
+-      //
+       delete mProperties.take( name );
+       mProperties.insert( name, new QgsProjectPropertyValue );
+ 
+@@ -392,8 +448,6 @@ bool QgsProjectPropertyKey::readXml( const QDomNode &keyNode )
+         QgsDebugError( u"unable to parse subkey %1"_s.arg( name ) );
+       }
+     }
+-
+-    ++i;
+   }
+ 
+   return true;
+@@ -409,22 +463,55 @@ bool QgsProjectPropertyKey::writeXml( QString const &nodeName, QDomElement &elem
+   // If it's an _empty_ node (i.e., one with no properties) we need to emit
+   // an empty place holder; else create new Dom elements as necessary.
+ 
+-  QDomElement keyElement = document.createElement( "properties" ); // Dom element for this property key
+-  keyElement.toElement().setAttribute( u"name"_s, nodeName );
+-
+-  if ( !mProperties.isEmpty() )
+   {
+-    auto keys = mProperties.keys();
+-    std::sort( keys.begin(), keys.end() );
++    QDomElement keyElement = document.createElement( "properties" ); // Dom element for this property key
++    keyElement.toElement().setAttribute( u"name"_s, nodeName );
+ 
+-    for ( const auto &key : std::as_const( keys ) )
++    if ( !mProperties.isEmpty() )
+     {
+-      if ( !mProperties.value( key )->writeXml( key, keyElement, document ) )
+-        QgsMessageLog::logMessage( tr( "Failed to save project property %1" ).arg( key ) );
++      auto keys = mProperties.keys();
++      std::sort( keys.begin(), keys.end() );
++
++      for ( const auto &key : std::as_const( keys ) )
++      {
++        if ( !mProperties.value( key )->writeXml( key, keyElement, document ) )
++          QgsMessageLog::logMessage( tr( "Failed to save project property %1" ).arg( key ) );
++      }
+     }
++
++    element.appendChild( keyElement );
+   }
+ 
+-  element.appendChild( keyElement );
++  {
++    // retain compatibility with QGIS 3 for the time being
++    const bool isRootProperties = element == document.documentElement();
++    QDomElement keyElement;
++    if ( isRootProperties )
++    {
++      keyElement = document.documentElement().firstChildElement( u"properties"_s );
++    }
++    else
++    {
++      keyElement = document.createElement( nodeName ); // Dom element for this property key
++    }
++
++    if ( !mProperties.isEmpty() )
++    {
++      auto keys = mProperties.keys();
++      std::sort( keys.begin(), keys.end() );
++
++      for ( const auto &key : std::as_const( keys ) )
++      {
++        if ( !mProperties.value( key )->writeXml( key, keyElement, document ) )
++          QgsMessageLog::logMessage( tr( "Failed to save project property %1" ).arg( key ) );
++      }
++    }
++
++    if ( !isRootProperties )
++    {
++      element.appendChild( keyElement );
++    }
++  }
+ 
+   return true;
+ }

--- a/vcpkg/ports/qgis/portfile.cmake
+++ b/vcpkg/ports/qgis/portfile.cmake
@@ -15,6 +15,7 @@ vcpkg_from_github(
         processing.patch # Needed to avoid link issue with tinygltf (ATM embedded into QGIS) and _GEOSQueryCallback defined multiple times
         mesh.patch
         legend_crash.patch
+        compatibility.patch
 )
 
 


### PR DESCRIPTION
Background: QGIS 4.0 has introduced a major change in the way project properties are stored, which broke backward compatibility with the current QGIS LTR (3.44).  

It impacts us in one serious way: projects created by users via the QField project creation wizard will be significantly broken when made into a cloud project. Until QFieldCloud updates to QGIS 4.0, that is a pretty bad problem for preexisting and new QField users who rely on the project creation + QFieldCloud.

I've opened a PR upstream to add backward compatibility for project properties. While this is being discussed there, I think we should add that patch on our QGIS port so QField project creation wizard will regain compatibility with QFieldCloud.