### PR TITLE
Introduce an audio analyzer to generate actual audio bars preview

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -67,6 +67,7 @@ set(QFIELD_CORE_SRCS
     appinterface.cpp
     attributeformmodel.cpp
     attributeformmodelbase.cpp
+    audioanalyzer.cpp
     audiorecorder.cpp
     barcodedecoder.cpp
     barcodeimageprovider.cpp
@@ -212,6 +213,7 @@ set(QFIELD_CORE_HDRS
     appinterface.h
     attributeformmodel.h
     attributeformmodelbase.h
+    audioanalyzer.h
     audiorecorder.h
     barcodedecoder.h
     barcodeimageprovider.h

--- a/src/core/audioanalyzer.cpp
+++ b/src/core/audioanalyzer.cpp
@@ -1,0 +1,174 @@
+/***************************************************************************
+ audioanalyzer.cpp - AudioRecorder
+
+ ---------------------
+ begin                : 12.04.2026
+ copyright            : (C) 2026 by Mathieu Pellerin
+ email                : mathieu (at) opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "audioanalyzer.h"
+
+#include <QAudioBuffer>
+#include <QAudioFormat>
+#include <QDebug>
+#include <QEventLoop>
+#include <QUrl>
+#include <QVector>
+
+#include <algorithm>
+#include <cmath>
+
+
+AudioAnalyzer::AudioAnalyzer( QObject *parent )
+  : QObject( parent )
+{
+}
+
+void AudioAnalyzer::analyze( const QUrl &url )
+{
+  if ( mGatherer )
+  {
+    disconnect( mGatherer, &AudioPeaksGatherer::collectedRawPeaks, this, &AudioAnalyzer::finalize );
+    disconnect( mGatherer, &AudioPeaksGatherer::finished, this, &AudioAnalyzer::gathererThreadFinished );
+    connect( mGatherer, &AudioPeaksGatherer::finished, mGatherer, &AudioPeaksGatherer::deleteLater );
+    mGatherer->stop();
+  }
+
+  mGatherer = new AudioPeaksGatherer( url );
+
+  connect( mGatherer, &AudioPeaksGatherer::collectedRawPeaks, this, &AudioAnalyzer::finalize );
+  connect( mGatherer, &AudioPeaksGatherer::finished, this, &AudioAnalyzer::gathererThreadFinished );
+
+  mGatherer->start();
+}
+
+void AudioAnalyzer::finalize()
+{
+  if ( !mGatherer )
+  {
+    emit ready( QList<qreal>() );
+  }
+
+  QList<float> rawPeaks = mGatherer->rawPeaks();
+  if ( rawPeaks.isEmpty() )
+  {
+    emit ready( QList<qreal>() );
+  }
+
+  const int targetBars = 80;
+  QList<qreal> finalBars;
+
+  const float globalMax = 0.9f;
+  const double step = static_cast<double>( rawPeaks.size() ) / targetBars;
+  for ( int i = 0; i < targetBars; i++ )
+  {
+    const qsizetype startIndex = static_cast<qsizetype>( i * step );
+    const qsizetype endIndex = std::min( static_cast<qsizetype>( ( i + 1 ) * step ), rawPeaks.size() );
+
+    float stepAverage = 0.0f;
+    int count = 0;
+    for ( int j = startIndex; j < endIndex; j++ )
+    {
+      stepAverage += rawPeaks[j];
+      count++;
+    }
+    if ( count > 0 )
+    {
+      stepAverage /= count;
+    }
+
+    finalBars.append( stepAverage / globalMax );
+  }
+
+  emit ready( finalBars );
+}
+
+void AudioAnalyzer::gathererThreadFinished()
+{
+  if ( sender() != mGatherer )
+  {
+    return;
+  }
+
+  mGatherer->deleteLater();
+  mGatherer = nullptr;
+}
+
+AudioPeaksGatherer::AudioPeaksGatherer( const QUrl &url )
+{
+  mUrl = url;
+}
+
+void AudioPeaksGatherer::run()
+{
+  mDecoder = new QAudioDecoder();
+
+  QAudioFormat format;
+  format.setChannelCount( 1 );
+  format.setSampleFormat( QAudioFormat::Float );
+  mDecoder->setAudioFormat( format );
+
+  connect( mDecoder, &QAudioDecoder::bufferReady, this, &AudioPeaksGatherer::processBuffer, Qt::DirectConnection );
+  connect( mDecoder, &QAudioDecoder::finished, this, &AudioPeaksGatherer::finalize, Qt::DirectConnection );
+  connect( mDecoder, qOverload<QAudioDecoder::Error>( &QAudioDecoder::error ), this, []( QAudioDecoder::Error error ) {
+    qInfo() << "Audio Analyzer Error:" << error;
+  } );
+
+  mDecoder->setSource( mUrl );
+  mDecoder->start();
+
+  exec();
+
+  delete mDecoder;
+  mDecoder = nullptr;
+}
+
+void AudioPeaksGatherer::stop()
+{
+  if ( mDecoder )
+  {
+    QMetaObject::invokeMethod( mDecoder, "stop", Qt::QueuedConnection );
+  }
+}
+
+void AudioPeaksGatherer::processBuffer()
+{
+  while ( mDecoder->bufferAvailable() )
+  {
+    QAudioBuffer buffer = mDecoder->read();
+
+    // QAudioFormat::Float
+    const float *data = buffer.constData<float>();
+    const int sampleCount = buffer.sampleCount();
+
+    const int windowSize = 512;
+    for ( int i = 0; i < sampleCount; i += windowSize )
+    {
+      float maxPeak = 0.0f;
+      const int end = std::min( i + windowSize, sampleCount );
+      for ( int j = i; j < end; ++j )
+      {
+        const float amplitude = std::abs( data[j] );
+        if ( amplitude > maxPeak )
+        {
+          maxPeak = amplitude;
+        }
+      }
+      mRawPeaks.append( maxPeak );
+    }
+  }
+}
+
+void AudioPeaksGatherer::finalize()
+{
+  emit collectedRawPeaks();
+  quit();
+}

--- a/src/core/audioanalyzer.cpp
+++ b/src/core/audioanalyzer.cpp
@@ -43,7 +43,7 @@ void AudioAnalyzer::setBarCount( int barCount )
   emit barCountChanged();
 }
 
-void AudioAnalyzer::analyze( const QUrl &url )
+void AudioAnalyzer::analyze( const QUrl &source )
 {
   if ( mGatherer )
   {
@@ -53,7 +53,7 @@ void AudioAnalyzer::analyze( const QUrl &url )
     mGatherer->stop();
   }
 
-  mGatherer = new AudioPeaksGatherer( url );
+  mGatherer = new AudioPeaksGatherer( source );
 
   connect( mGatherer, &AudioPeaksGatherer::collectedRawPeaks, this, &AudioAnalyzer::finalize );
   connect( mGatherer, &AudioPeaksGatherer::finished, this, &AudioAnalyzer::gathererThreadFinished );
@@ -117,9 +117,9 @@ void AudioAnalyzer::gathererThreadFinished()
   mGatherer = nullptr;
 }
 
-AudioPeaksGatherer::AudioPeaksGatherer( const QUrl &url )
+AudioPeaksGatherer::AudioPeaksGatherer( const QUrl &source )
+  : mSource( source )
 {
-  mUrl = url;
 }
 
 void AudioPeaksGatherer::run()
@@ -137,7 +137,7 @@ void AudioPeaksGatherer::run()
     qInfo() << "Audio Analyzer Error:" << error;
   } );
 
-  mDecoder->setSource( mUrl );
+  mDecoder->setSource( mSource );
   mDecoder->start();
 
   exec();

--- a/src/core/audioanalyzer.cpp
+++ b/src/core/audioanalyzer.cpp
@@ -66,7 +66,12 @@ void AudioAnalyzer::finalize()
   const int targetBars = 80;
   QList<qreal> finalBars;
 
-  const float globalMax = 0.9f;
+  float globalMax = *std::max_element( rawPeaks.begin(), rawPeaks.end() );
+  if ( globalMax == 0.0f )
+  {
+    globalMax = 1.0f;
+  }
+
   const double step = static_cast<double>( rawPeaks.size() ) / targetBars;
   for ( int i = 0; i < targetBars; i++ )
   {

--- a/src/core/audioanalyzer.cpp
+++ b/src/core/audioanalyzer.cpp
@@ -66,12 +66,14 @@ void AudioAnalyzer::finalize()
   if ( !mGatherer )
   {
     emit ready( QList<qreal>() );
+    return;
   }
 
   QList<float> rawPeaks = mGatherer->rawPeaks();
   if ( rawPeaks.isEmpty() )
   {
     emit ready( QList<qreal>() );
+    return;
   }
 
   QList<qreal> finalBars;
@@ -133,8 +135,9 @@ void AudioPeaksGatherer::run()
 
   connect( mDecoder, &QAudioDecoder::bufferReady, this, &AudioPeaksGatherer::processBuffer, Qt::DirectConnection );
   connect( mDecoder, &QAudioDecoder::finished, this, &AudioPeaksGatherer::finalize, Qt::DirectConnection );
-  connect( mDecoder, qOverload<QAudioDecoder::Error>( &QAudioDecoder::error ), this, []( QAudioDecoder::Error error ) {
+  connect( mDecoder, qOverload<QAudioDecoder::Error>( &QAudioDecoder::error ), this, [this]( QAudioDecoder::Error error ) {
     qInfo() << "Audio Analyzer Error:" << error;
+    finalize();
   } );
 
   mDecoder->setSource( mSource );

--- a/src/core/audioanalyzer.cpp
+++ b/src/core/audioanalyzer.cpp
@@ -32,6 +32,17 @@ AudioAnalyzer::AudioAnalyzer( QObject *parent )
 {
 }
 
+void AudioAnalyzer::setBarCount( int barCount )
+{
+  if ( mBarCount == barCount )
+  {
+    return;
+  }
+
+  mBarCount = barCount;
+  emit barCountChanged();
+}
+
 void AudioAnalyzer::analyze( const QUrl &url )
 {
   if ( mGatherer )
@@ -63,7 +74,6 @@ void AudioAnalyzer::finalize()
     emit ready( QList<qreal>() );
   }
 
-  const int targetBars = 80;
   QList<qreal> finalBars;
 
   float globalMax = *std::max_element( rawPeaks.begin(), rawPeaks.end() );
@@ -72,8 +82,8 @@ void AudioAnalyzer::finalize()
     globalMax = 1.0f;
   }
 
-  const double step = static_cast<double>( rawPeaks.size() ) / targetBars;
-  for ( int i = 0; i < targetBars; i++ )
+  const double step = static_cast<double>( rawPeaks.size() ) / mBarCount;
+  for ( int i = 0; i < mBarCount; i++ )
   {
     const qsizetype startIndex = static_cast<qsizetype>( i * step );
     const qsizetype endIndex = std::min( static_cast<qsizetype>( ( i + 1 ) * step ), rawPeaks.size() );

--- a/src/core/audioanalyzer.h
+++ b/src/core/audioanalyzer.h
@@ -1,0 +1,74 @@
+/***************************************************************************
+ audioanalyzer.h - AudioAnalyzer
+
+ ---------------------
+ begin                : 12.04.2026
+ copyright            : (C) 2026 by Mathieu Pellerin
+ email                : mathieu (at) opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef AUDIOANALYZER_H
+#define AUDIOANALYZER_H
+
+#include <QAudioDecoder>
+#include <QObject>
+#include <QThread>
+#include <QUrl>
+
+class AudioPeaksGatherer : public QThread
+{
+    Q_OBJECT
+
+  public:
+    AudioPeaksGatherer( const QUrl &url );
+
+    void run() override;
+
+    void stop();
+
+    QList<float> rawPeaks() const { return mRawPeaks; }
+
+  signals:
+    void collectedRawPeaks();
+
+  private slots:
+    void processBuffer();
+    void finalize();
+
+  private:
+    QUrl mUrl;
+    QAudioDecoder *mDecoder = nullptr;
+    QVector<float> mRawPeaks;
+};
+
+/**
+ * \ingroup core
+ */
+class AudioAnalyzer : public QObject
+{
+    Q_OBJECT
+
+  public:
+    explicit AudioAnalyzer( QObject *parent = nullptr );
+
+    Q_INVOKABLE void analyze( const QUrl &source );
+
+  signals:
+    void ready( const QList<qreal> &bars );
+
+  private slots:
+    void finalize();
+    void gathererThreadFinished();
+
+  private:
+    AudioPeaksGatherer *mGatherer = nullptr;
+};
+
+#endif // AUDIORECORDER_H

--- a/src/core/audioanalyzer.h
+++ b/src/core/audioanalyzer.h
@@ -55,13 +55,20 @@ class AudioAnalyzer : public QObject
 {
     Q_OBJECT
 
+    Q_PROPERTY( int barCount READ barCount WRITE setBarCount NOTIFY barCountChanged )
+
   public:
     explicit AudioAnalyzer( QObject *parent = nullptr );
+
+    int barCount() const { return mBarCount; }
+
+    void setBarCount( int barCount );
 
     Q_INVOKABLE void analyze( const QUrl &source );
 
   signals:
     void ready( const QList<qreal> &bars );
+    void barCountChanged();
 
   private slots:
     void finalize();
@@ -69,6 +76,8 @@ class AudioAnalyzer : public QObject
 
   private:
     AudioPeaksGatherer *mGatherer = nullptr;
+
+    int mBarCount = 80;
 };
 
 #endif // AUDIORECORDER_H

--- a/src/core/audioanalyzer.h
+++ b/src/core/audioanalyzer.h
@@ -27,7 +27,7 @@ class AudioPeaksGatherer : public QThread
     Q_OBJECT
 
   public:
-    AudioPeaksGatherer( const QUrl &url );
+    AudioPeaksGatherer( const QUrl &source );
 
     void run() override;
 
@@ -43,7 +43,7 @@ class AudioPeaksGatherer : public QThread
     void finalize();
 
   private:
-    QUrl mUrl;
+    QUrl mSource;
     QAudioDecoder *mDecoder = nullptr;
     QVector<float> mRawPeaks;
 };

--- a/src/core/audioanalyzer.h
+++ b/src/core/audioanalyzer.h
@@ -49,6 +49,8 @@ class AudioPeaksGatherer : public QThread
 };
 
 /**
+ * \brief This class analyzes the peaks of audio clips and generate a list of bars
+ * that can be used to visualize the audio's overall texture.
  * \ingroup core
  */
 class AudioAnalyzer : public QObject
@@ -60,17 +62,36 @@ class AudioAnalyzer : public QObject
   public:
     explicit AudioAnalyzer( QObject *parent = nullptr );
 
+    /**
+     * Returns the bar count that will be returned upon successful audio clip analysis.
+     */
     int barCount() const { return mBarCount; }
 
+    /**
+     * Sets the bar count that will be returned upon successful audio clip analysis.
+     */
     void setBarCount( int barCount );
 
+    /**
+     * Run an analysis of the audio \a source.
+     */
     Q_INVOKABLE void analyze( const QUrl &source );
 
   signals:
+
+    /**
+     * Emitted when an analysis is over.
+     * \note If the analysis failed, the list will be empty.
+     */
     void ready( const QList<qreal> &bars );
+
+    /**
+     * Emitted when the bar count property has changed.
+     */
     void barCountChanged();
 
   private slots:
+
     void finalize();
     void gathererThreadFinished();
 

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -40,6 +40,7 @@
 #include "appexpressioncontextscopesgenerator.h"
 #include "appinterface.h"
 #include "attributeformmodel.h"
+#include "audioanalyzer.h"
 #include "audiorecorder.h"
 #include "badlayerhandler.h"
 #include "barcodedecoder.h"
@@ -568,6 +569,7 @@ void QgisMobileapp::initDeclarative( QQmlEngine *engine )
   qmlRegisterType<PositioningDeviceModel>( "org.qfield", 1, 0, "PositioningDeviceModel" );
   qmlRegisterType<WebdavConnection>( "org.qfield", 1, 0, "WebdavConnection" );
   qmlRegisterType<AppExpressionContextScopesGenerator>( "org.qfield", 1, 0, "AppExpressionContextScopesGenerator" );
+  qmlRegisterType<AudioAnalyzer>( "org.qfield", 1, 0, "AudioAnalyzer" );
   qmlRegisterType<AudioRecorder>( "org.qfield", 1, 0, "AudioRecorder" );
   qmlRegisterType<BarcodeDecoder>( "org.qfield", 1, 0, "BarcodeDecoder" );
   qmlRegisterType<CameraPermission>( "org.qfield", 1, 0, "QfCameraPermission" );

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -121,6 +121,7 @@ EditorWidgetBase {
       isVideo = !config.UseLink && mimeType.startsWith("video/");
       image.visible = isImage;
       geoTagBadge.visible = isImage;
+
       if (isImage) {
         mediaFrame.height = 200;
         image.visible = true;
@@ -179,6 +180,13 @@ EditorWidgetBase {
     project: qgisProject
     appExpressionContextScopesGenerator: appScopesGenerator
     expressionText: ExternalResourceUtils.getAttachmentNaming(currentLayer, field.name)
+  }
+
+  AudioAnalyzer {
+    id: audioAnalyzer
+    onReady: bars => {
+      externalWaveformRepeater.model = bars;
+    }
   }
 
   function getResourceFilePath() {
@@ -345,34 +353,30 @@ EditorWidgetBase {
       Row {
         id: audioWaveformBars
         anchors.centerIn: parent
+        width: parent.width
         height: parent.height * 0.65
         spacing: 2
 
+        property int barCount: externalWaveformRepeater.count
+        property int barWidth: (audioWaveformArea.width - (1 * barCount)) / barCount
+
         Repeater {
           id: externalWaveformRepeater
-          model: Math.max(1, Math.floor((audioWaveformArea.width - 24) / 5))
-
-          property int pathHash: ExternalResourceUtils.hashString(audioSourcePath)
+          model: [0]
 
           Rectangle {
-            width: 3
-            height: {
-              const seed = (externalWaveformRepeater.pathHash + index) * 0.3;
-              const h = 0.15 + Math.abs(Math.sin(seed)) * 0.55 + Math.abs(Math.cos(seed * 2.1)) * 0.3;
-              return Math.max(4, audioWaveformBars.height * h);
-            }
+            width: audioWaveformBars.barWidth
+            height: audioWaveformBars.height * modelData
             radius: 1.5
             anchors.verticalCenter: parent.verticalCenter
             color: {
-              const totalBars = Math.max(1, Math.floor((audioWaveformArea.width - 24) / 5));
-              if (player.active && player.item && player.item.duration > 0 && (index / totalBars) < (player.item.position / player.item.duration)) {
+              if (player.active && player.item && player.item.duration > 0 && (index / audioWaveformBars.barCount) < (player.item.position / player.item.duration)) {
                 return Theme.mainColor;
               }
               return Theme.mainTextDisabledColor;
             }
             opacity: {
-              const totalBars = Math.max(1, Math.floor((audioWaveformArea.width - 24) / 5));
-              if (player.active && player.item && player.item.duration > 0 && (index / totalBars) < (player.item.position / player.item.duration)) {
+              if (player.active && player.item && player.item.duration > 0 && (index / audioWaveformBars.barCount) < (player.item.position / player.item.duration)) {
                 return 0.9;
               }
               return 0.35;
@@ -426,6 +430,8 @@ EditorWidgetBase {
             positionSlider.value = 0;
             if (!player.firstFrameDrawn && hasVideo) {
               play();
+            } else if (duration > 0 && !hasAudio) {
+              audioAnalyzer.analyze(player.sourceUrl);
             }
           }
 

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -139,6 +139,7 @@ EditorWidgetBase {
         audioSourcePath = fullValue;
         player.firstFrameDrawn = false;
         player.sourceUrl = UrlUtils.fromString(fullValue);
+        audioAnalyzer.analyze(player.sourceUrl);
       } else if (isVideo) {
         mediaFrame.height = 48;
         image.visible = false;
@@ -431,8 +432,6 @@ EditorWidgetBase {
             positionSlider.value = 0;
             if (!player.firstFrameDrawn && hasVideo) {
               play();
-            } else if (duration > 0 && !hasAudio) {
-              audioAnalyzer.analyze(player.sourceUrl);
             }
           }
 

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -359,7 +359,7 @@ EditorWidgetBase {
         spacing: 2
 
         property int barCount: audioWaveformRepeater.count
-        property int barWidth: (audioWaveformArea.width - (1 * barCount)) / barCount
+        property real barWidth: (audioWaveformArea.width - (spacing * barCount)) / barCount
 
         Repeater {
           id: audioWaveformRepeater
@@ -371,13 +371,13 @@ EditorWidgetBase {
             radius: 1.5
             anchors.verticalCenter: parent.verticalCenter
             color: {
-              if (player.active && player.item && player.item.duration > 0 && (index / audioWaveformBars.barCount) < (player.item.position / player.item.duration)) {
+              if (player.active && player.item && player.item.duration > 0 && index < (player.item.position / player.item.duration * audioWaveformBars.barCount)) {
                 return Theme.mainColor;
               }
               return Theme.mainTextDisabledColor;
             }
             opacity: {
-              if (player.active && player.item && player.item.duration > 0 && (index / audioWaveformBars.barCount) < (player.item.position / player.item.duration)) {
+              if (player.active && player.item && player.item.duration > 0 && index < (player.item.position / player.item.duration * audioWaveformBars.barCount)) {
                 return 0.9;
               }
               return 0.35;

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -184,8 +184,9 @@ EditorWidgetBase {
 
   AudioAnalyzer {
     id: audioAnalyzer
+    barCount: 80
     onReady: bars => {
-      externalWaveformRepeater.model = bars;
+      audioWaveformRepeater.model = bars;
     }
   }
 
@@ -357,11 +358,11 @@ EditorWidgetBase {
         height: parent.height * 0.65
         spacing: 2
 
-        property int barCount: externalWaveformRepeater.count
+        property int barCount: audioWaveformRepeater.count
         property int barWidth: (audioWaveformArea.width - (1 * barCount)) / barCount
 
         Repeater {
-          id: externalWaveformRepeater
+          id: audioWaveformRepeater
           model: [0]
 
           Rectangle {

--- a/src/qml/editorwidgets/ExternalResourceUtils.js
+++ b/src/qml/editorwidgets/ExternalResourceUtils.js
@@ -51,16 +51,3 @@ function getAttachmentFilePath(evaluatedFilepath, documentViewer, FileUtils) {
   filepath = filepath.replace('\\', '/');
   return filepath;
 }
-/**
- * Deterministic hash for unique waveform patterns per audio file (djb2).
- * Used by both the gallery relation editor and the external resource editor
- * to generate decorative waveform bar heights from a file path string.
- */
-function hashString(str) {
-  let hash = 5381;
-  for (let i = 0; i < str.length; i++) {
-    hash = ((hash << 5) + hash) + str.charCodeAt(i);
-    hash = hash | 0;
-  }
-  return Math.abs(hash);
-}

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -678,7 +678,7 @@ RelationEditorBase {
               visible: attachmentIsAudio
 
               property int barCount: listWaveformRepeater.count
-              property int barWidth: (listWaveformBars.width - (1 * barCount)) / barCount
+              property real barWidth: (listWaveformBars.width - (spacing * barCount)) / barCount
 
               Repeater {
                 id: listWaveformRepeater
@@ -1029,7 +1029,7 @@ RelationEditorBase {
             spacing: 2
 
             property int barCount: gridWaveformRepeater.count
-            property int barWidth: (gridWaveformBars.width - (1 * barCount)) / barCount
+            property real barWidth: (gridWaveformBars.width - (spacing * barCount)) / barCount
 
             Repeater {
               id: gridWaveformRepeater

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -88,6 +88,7 @@ RelationEditorBase {
   QtObject {
     id: dummyTarget
   }
+
   Connections {
     id: cloudProjectConnection
     ignoreUnknownSignals: true
@@ -131,6 +132,40 @@ RelationEditorBase {
         relationEditor.processNextFetch();
       }
       displayToast(lastError, 'error');
+    }
+  }
+
+  AudioAnalyzer {
+    id: audioAnalyzer
+
+    property var queue: []
+    property string currentProcess: ""
+    property var availableBars: ({})
+
+    barCount: isGridView ? 40 : 20
+
+    onBarCountChanged: {
+      availableBars = {};
+    }
+
+    onReady: bars => {
+      availableBars[currentProcess] = bars;
+      availableBarsChanged();
+      processQueue();
+    }
+
+    function enqueue(audioPath) {
+      if (!(audioPath in queue) && !(audioPath in availableBars)) {
+        queue.push(audioPath);
+        processQueue();
+      }
+    }
+
+    function processQueue() {
+      if (queue.length > 0) {
+        currentProcess = queue.shift();
+        audioAnalyzer.analyze(UrlUtils.fromString(currentProcess));
+      }
     }
   }
 
@@ -426,10 +461,16 @@ RelationEditorBase {
       return path;
     }
     if (FileUtils.fileExists(path)) {
+      if (FileUtils.mimeTypeName(path).startsWith("audio/")) {
+        audioAnalyzer.enqueue(path);
+      }
       return path;
     }
     const fullPath = imagePrefix + path;
     if (FileUtils.fileExists(fullPath)) {
+      if (FileUtils.mimeTypeName(fullPath).startsWith("audio/")) {
+        audioAnalyzer.enqueue(fullPath);
+      }
       return fullPath;
     }
     if (fetchedPaths.hasOwnProperty(path)) {
@@ -629,27 +670,27 @@ RelationEditorBase {
             }
 
             Row {
+              id: listWaveformBars
               anchors.centerIn: parent
-              spacing: 1
+              spacing: 2
+              width: 56
+              height: 56
               visible: attachmentIsAudio
+
+              property int barCount: listWaveformRepeater.count
+              property int barWidth: (listWaveformBars.width - (1 * barCount)) / barCount
 
               Repeater {
                 id: listWaveformRepeater
-                model: 18
-
-                property int pathHash: ExternalResourceUtils.hashString(attachmentFullPath)
+                model: attachmentFullPath in audioAnalyzer.availableBars ? audioAnalyzer.availableBars[attachmentFullPath] : [0]
 
                 Rectangle {
-                  width: 2
-                  height: {
-                    const seed = (listWaveformRepeater.pathHash + index) * 0.3;
-                    const h = 8 + Math.abs(Math.sin(seed)) * 28 + Math.abs(Math.cos(seed * 2.1)) * 12;
-                    return Math.min(h, 44);
-                  }
-                  radius: 1
+                  width: listWaveformBars.barWidth
+                  height: listWaveformBars.height * modelData
+                  radius: 1.5
                   anchors.verticalCenter: parent.verticalCenter
-                  color: Theme.mainColor
-                  opacity: 0.4
+                  color: Theme.mainTextDisabledColor
+                  opacity: 0.35
                 }
               }
             }
@@ -975,44 +1016,39 @@ RelationEditorBase {
         }
 
         Item {
-          id: audioWaveformArea
           anchors.fill: parent
           anchors.bottomMargin: detailsBar.height
           visible: attachmentIsAudio
           clip: true
 
           Row {
-            id: waveformBars
+            id: gridWaveformBars
             anchors.centerIn: parent
+            width: parent.width
             height: parent.height * 0.7
             spacing: 2
+
+            property int barCount: gridWaveformRepeater.count
+            property int barWidth: (gridWaveformBars.width - (1 * barCount)) / barCount
 
             Repeater {
               id: gridWaveformRepeater
 
-              model: Math.max(1, Math.floor((audioWaveformArea.width - 24) / 5))
-
-              property int pathHash: ExternalResourceUtils.hashString(attachmentFullPath)
+              model: attachmentFullPath in audioAnalyzer.availableBars ? audioAnalyzer.availableBars[attachmentFullPath] : [0]
 
               Rectangle {
-                width: 3
-                height: {
-                  const seed = (gridWaveformRepeater.pathHash + index) * 0.3;
-                  const h = 0.15 + Math.abs(Math.sin(seed)) * 0.55 + Math.abs(Math.cos(seed * 2.1)) * 0.3;
-                  return Math.max(4, waveformBars.height * h);
-                }
+                width: gridWaveformBars.barWidth
+                height: gridWaveformBars.height * modelData
                 radius: 1.5
                 anchors.verticalCenter: parent.verticalCenter
                 color: {
-                  const totalBars = Math.max(1, Math.floor((audioWaveformArea.width - 24) / 5));
-                  if (audioPlayerLoader.active && (index / totalBars) < audioPlayerLoader.progress) {
+                  if (audioPlayerLoader.active && (index / gridWaveformBars.barCount) < audioPlayerLoader.progress) {
                     return Theme.mainColor;
                   }
                   return Theme.mainTextDisabledColor;
                 }
                 opacity: {
-                  const totalBars = Math.max(1, Math.floor((audioWaveformArea.width - 24) / 5));
-                  if (audioPlayerLoader.active && (index / totalBars) < audioPlayerLoader.progress) {
+                  if (audioPlayerLoader.active && (index / gridWaveformBars.barCount) < audioPlayerLoader.progress) {
                     return 0.9;
                   }
                   return 0.35;
@@ -1023,7 +1059,7 @@ RelationEditorBase {
 
           Rectangle {
             visible: audioPlayerLoader.active && audioPlayerLoader.progress > 0
-            x: waveformBars.x + waveformBars.width * audioPlayerLoader.progress
+            x: gridWaveformBars.x + gridWaveformBars.width * audioPlayerLoader.progress
             y: 0
             width: 2
             height: parent.height


### PR DESCRIPTION
This PR introduces a proper audio analyzer that enables us to offer a visual preview of an audio clip peaks. This is a super important functionality when dealing with long and/or multiple audio clips in providing a quick way to identify key moments in a clip (e.g).

The audio analyzer is used in our gallery editor widget:

<img width="1501" height="710" alt="image" src="https://github.com/user-attachments/assets/2663e9cf-bd1c-4a5c-9fa7-ab164fffc843" />

as well as our attachment editor widget:

<img width="1076" height="640" alt="image" src="https://github.com/user-attachments/assets/4481abe3-a706-4e91-aef0-ccaf0a1f70eb" />

It's something I've added in the TODO list since the days we implemented audio attachments to begin with. Thanks to Qt6's recent versions, it's now possible across all platforms.