### PR TITLE
Re-implement audio level feedback when recording audio

### DIFF
--- a/src/core/audiorecorder.cpp
+++ b/src/core/audiorecorder.cpp
@@ -16,11 +16,78 @@
 
 #include "audiorecorder.h"
 
+#include <QMediaDevices>
 #include <QMediaFormat>
+
+
+AudioProbe::AudioProbe( QObject *parent )
+  : QIODevice( parent )
+{
+}
+
+qint64 AudioProbe::readData( char *, qint64 )
+{
+  return 0;
+}
+
+qint64 AudioProbe::writeData( const char *data, qint64 len )
+{
+  const qint16 *samples = reinterpret_cast<const qint16 *>( data );
+  const int sampleCount = len / sizeof( qint16 );
+
+  float maxPeak = 0.0f;
+  for ( int i = 0; i < sampleCount; ++i )
+  {
+    const float amplitude = std::abs( static_cast<float>( samples[i] ) ) / 32768.0f;
+    if ( amplitude > maxPeak )
+    {
+      maxPeak = amplitude;
+    }
+  }
+
+  emit levelCalculated( maxPeak );
+
+  return len;
+}
+
 
 AudioRecorder::AudioRecorder( QObject *parent )
   : QMediaRecorder( parent )
 {
+  mProbe = new AudioProbe( this );
+  mProbe->open( QIODevice::WriteOnly );
+  connect( mProbe, &AudioProbe::levelCalculated, this, [this]( double level ) {
+    mLevel = level;
+    emit levelChanged();
+  } );
+
+  QAudioFormat format;
+  format.setSampleRate( 44100 );
+  format.setChannelCount( 1 );
+  format.setSampleFormat( QAudioFormat::Int16 );
+
+  QAudioDevice defaultMicrophone = QMediaDevices::defaultAudioInput();
+  mAudioSource = new QAudioSource( defaultMicrophone, format, this );
+
+  connect( this, &QMediaRecorder::recorderStateChanged, this, [this]( QMediaRecorder::RecorderState state ) {
+    if ( state == QMediaRecorder::RecordingState )
+    {
+      mAudioSource->start( mProbe );
+      if ( !mHasLevel )
+      {
+        mHasLevel = true;
+        emit hasLevelChanged();
+      }
+    }
+    else
+    {
+      mAudioSource->stop();
+      mLevel = 0.0;
+      emit levelChanged();
+    }
+
+    emit recordingChanged();
+  } );
 }
 
 bool AudioRecorder::recording() const

--- a/src/core/audiorecorder.h
+++ b/src/core/audiorecorder.h
@@ -17,9 +17,27 @@
 #ifndef AUDIORECORDER_H
 #define AUDIORECORDER_H
 
+#include <QAudioSource>
+#include <QIODevice>
 #include <QMediaCaptureSession>
 #include <QMediaRecorder>
 #include <QObject>
+
+
+class AudioProbe : public QIODevice
+{
+    Q_OBJECT
+
+  public:
+    explicit AudioProbe( QObject *parent = nullptr );
+
+    qint64 readData( char *data, qint64 maxlen ) override;
+    qint64 writeData( const char *data, qint64 len ) override;
+
+  signals:
+    void levelCalculated( double level );
+};
+
 
 /**
  * \ingroup core
@@ -77,6 +95,9 @@ class AudioRecorder : public QMediaRecorder
   private:
     bool mHasLevel = false;
     double mLevel = 0.0;
+
+    QAudioSource *mAudioSource = nullptr;
+    AudioProbe *mProbe = nullptr;
 };
 
 #endif // AUDIORECORDER_H

--- a/src/qml/QFieldAudioRecorder.qml
+++ b/src/qml/QFieldAudioRecorder.qml
@@ -167,10 +167,16 @@ QfPopup {
         Rectangle {
           id: levelFeedback
           anchors.centerIn: parent
-          width: 120 + (Math.min(audioFeedback.width, audioFeedback.height) - 120) * 0
+          width: 120 + (Math.min(audioFeedback.width, audioFeedback.height) - 120) * Math.min(1.0, recorder.level * 2)
           height: width
           radius: width / 2
           color: "#44808080"
+
+          Behavior on width {
+            SmoothedAnimation {
+              duration: 200
+            }
+          }
 
           SequentialAnimation {
             NumberAnimation {
@@ -187,7 +193,7 @@ QfPopup {
               duration: 2000
               easing.type: Easing.InOutQuad
             }
-            running: recorder.recorderState === MediaRecorder.RecordingState
+            running: !recorder.hasLevel && recorder.recorderState === MediaRecorder.RecordingState
             loops: Animation.Infinite
           }
 


### PR DESCRIPTION
We had lost this functionality when switching to Qt6 (RIP QAudioProbe). However, things have improved and we can now provide a similar level feedback by using a QAudiSource and write to a QIODevice, which will give us the information we need.

In action:

https://github.com/user-attachments/assets/dc99c8d8-9e37-4f37-af4d-9d3a4b0c1785

