### PR TITLE
Add multi-attachment support to notes via parent/child relation

### DIFF
--- a/src/core/utils/projectutils.cpp
+++ b/src/core/utils/projectutils.cpp
@@ -19,9 +19,13 @@
 #include "positioningutils.h"
 #include "projectutils.h"
 
+#include <qgsattributeeditorcontainer.h>
+#include <qgsattributeeditorfield.h>
+#include <qgsattributeeditorrelation.h>
 #include <qgsmaplayer.h>
 #include <qgsprojectdisplaysettings.h>
 #include <qgsrasterlayer.h>
+#include <qgsrelationcontext.h>
 #include <qgsvectorfilewriter.h>
 #include <qgsvectorlayer.h>
 #include <qgsvectortilelayer.h>
@@ -136,7 +140,7 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
     notesLayer = new QgsVectorLayer( notesFilepath, tr( "Notes" ) );
     fields = notesLayer->fields();
     LayerUtils::setDefaultRenderer( notesLayer, nullptr,
-                                    options.value( QStringLiteral( "camera_capture" ) ).toBool() ? QStringLiteral( "aggregate('notes_attachments', 'concatenate', \"resource\", \"note_uuid\" = attribute(@parent, 'uuid'), ',', 1)" ) : QString(),
+                                    options.value( QStringLiteral( "camera_capture" ) ).toBool() ? QStringLiteral( "relation_aggregate('notes_attachments_relation', 'max', \"media\")" ) : QString(),
                                     QStringLiteral( "color" ) );
     LayerUtils::setDefaultLabeling( notesLayer );
 
@@ -213,25 +217,6 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
       notesLayer->setFieldAlias( fieldIndex, tr( "Note" ) );
     }
 
-    // if ( options.value( QStringLiteral( "camera_capture" ) ).toBool() )
-    // {
-    //   // Configure camera field
-    //   fieldIndex = fields.indexOf( QStringLiteral( "media" ) );
-    //   if ( fieldIndex >= 0 )
-    //   {
-    //     widgetOptions.clear();
-    //     widgetOptions[QStringLiteral( "DocumentViewer" )] = 1;
-    //     widgetOptions[QStringLiteral( "RelativeStorage" )] = 1;
-    //     widgetOptions[QStringLiteral( "FileWidget" )] = true;
-    //     widgetOptions[QStringLiteral( "FileWidgetButton" )] = true;
-    //     widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "ExternalResource" ), widgetOptions );
-    //     notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
-    //     notesLayer->setFieldAlias( fieldIndex, tr( "Media" ) );
-    //   }
-    // }
-
-    ////////TODO this should be moved to child layer
-
     // Insure the layer is ready cloud-friendly
     notesLayer->setCustomProperty( QStringLiteral( "QFieldSync/cloud_action" ), QStringLiteral( "offline" ) );
     notesLayer->setCustomProperty( QStringLiteral( "QFieldSync/action" ), QStringLiteral( "offline" ) );
@@ -246,8 +231,8 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
       // Second layer in the same notes.gpkg
       QgsFields attachFields;
       attachFields.append( QgsField( QStringLiteral( "note_uuid" ), QMetaType::QString ) );
-      attachFields.append( QgsField( QStringLiteral( "resource" ), QMetaType::QString ) );
-      attachFields.append( QgsField( QStringLiteral( "type" ), QMetaType::QString ) );
+      attachFields.append( QgsField( QStringLiteral( "media" ), QMetaType::QString ) );
+      attachFields.append( QgsField( QStringLiteral( "description" ), QMetaType::QString ) );
       attachFields.append( QgsField( QStringLiteral( "timestamp" ), QMetaType::QDateTime ) );
 
       QgsVectorFileWriter::SaveVectorOptions attachWriterOptions;
@@ -275,14 +260,13 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
         attachmentsLayer->setEditorWidgetSetup( attachFieldIndex, attachWidgetSetup );
       }
 
-      // Hiding note_uuid here, relation editor auto populate the FK
       attachFieldIndex = liveAttachFields.indexOf( QStringLiteral( "note_uuid" ) );
       if ( attachFieldIndex >= 0 )
       {
         attachWidgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), QVariantMap() );
         attachmentsLayer->setEditorWidgetSetup( attachFieldIndex, attachWidgetSetup );
       }
-      attachFieldIndex = liveAttachFields.indexOf( QStringLiteral( "resource" ) );
+      attachFieldIndex = liveAttachFields.indexOf( QStringLiteral( "media" ) );
       if ( attachFieldIndex >= 0 )
       {
         attachWidgetOptions.clear();
@@ -294,15 +278,15 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
         attachmentsLayer->setEditorWidgetSetup( attachFieldIndex, attachWidgetSetup );
         attachmentsLayer->setFieldAlias( attachFieldIndex, tr( "Media" ) );
       }
-
-      // Type field should be hidden populated
-      attachFieldIndex = liveAttachFields.indexOf( QStringLiteral( "type" ) );
+      attachFieldIndex = liveAttachFields.indexOf( QStringLiteral( "description" ) );
       if ( attachFieldIndex >= 0 )
       {
-        attachWidgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), QVariantMap() );
+        attachWidgetOptions.clear();
+        attachWidgetOptions[QStringLiteral( "IsMultiline" )] = true;
+        attachWidgetSetup = QgsEditorWidgetSetup( QStringLiteral( "TextEdit" ), attachWidgetOptions );
         attachmentsLayer->setEditorWidgetSetup( attachFieldIndex, attachWidgetSetup );
+        attachmentsLayer->setFieldAlias( attachFieldIndex, tr( "Description" ) );
       }
-
       attachFieldIndex = liveAttachFields.indexOf( QStringLiteral( "timestamp" ) );
       if ( attachFieldIndex >= 0 )
       {
@@ -318,11 +302,35 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
         attachmentsLayer->setFieldAlias( attachFieldIndex, tr( "Time" ) );
       }
 
-      attachmentsLayer->setDisplayExpression( QStringLiteral( "COALESCE(\"resource\", 'Attachment #' || fid)" ) );
+      attachmentsLayer->setDisplayExpression( QStringLiteral( "COALESCE(\"media\", 'Attachment #' || fid)" ) );
+      QgsEditFormConfig attachFormConfig = attachmentsLayer->editFormConfig();
+      attachFormConfig.setSuppress( Qgis::AttributeFormSuppression::On );
+      attachmentsLayer->setEditFormConfig( attachFormConfig );
       attachmentsLayer->setCustomProperty( QStringLiteral( "QFieldSync/cloud_action" ), QStringLiteral( "offline" ) );
       attachmentsLayer->setCustomProperty( QStringLiteral( "QFieldSync/action" ), QStringLiteral( "offline" ) );
-
       createdProjectLayers << attachmentsLayer;
+
+      QgsEditFormConfig notesFormConfig = notesLayer->editFormConfig();
+      notesFormConfig.clearTabs();
+      notesFormConfig.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
+      QgsAttributeEditorContainer *root = notesFormConfig.invisibleRootContainer();
+      QgsAttributeEditorRelation *relationElement = new QgsAttributeEditorRelation( QStringLiteral( "notes_attachments_relation" ), root );
+      root->addChildElement( relationElement );
+      const QStringList orderedFields = {
+        QStringLiteral( "color" ),
+        QStringLiteral( "title" ),
+        QStringLiteral( "note" ),
+        QStringLiteral( "timestamp" ) };
+      for ( const QString &fieldName : orderedFields )
+      {
+        const int idx = notesLayer->fields().indexOf( fieldName );
+        if ( idx >= 0 )
+        {
+          root->addChildElement( new QgsAttributeEditorField( fieldName, idx, root ) );
+        }
+      }
+
+      notesLayer->setEditFormConfig( notesFormConfig );
     }
   }
 
@@ -501,9 +509,6 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
     rel.setReferencingLayer( attachmentsLayer->id() );
     rel.addFieldPair( QStringLiteral( "note_uuid" ), QStringLiteral( "uuid" ) );
     rel.setStrength( Qgis::RelationshipStrength::Association );
-
-    qDebug() << "Relation valid?" << rel.isValid() << "validation error:" << rel.validationError();
-
     if ( rel.isValid() )
     {
       createdProject->relationManager()->addRelation( rel );

--- a/src/core/utils/projectutils.cpp
+++ b/src/core/utils/projectutils.cpp
@@ -115,6 +115,7 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
 
   // Notes layer
   QgsVectorLayer *notesLayer = nullptr;
+  QgsVectorLayer *attachmentsLayer = nullptr;
   if ( options.value( QStringLiteral( "notes" ) ).toBool() )
   {
     createdProject->writeEntry( QStringLiteral( "qfieldsync" ), QStringLiteral( "initialMapMode" ), QStringLiteral( "digitize" ) );
@@ -122,10 +123,7 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
     const QString notesFilepath = QStringLiteral( "%1/notes.gpkg" ).arg( createdProjectDir );
 
     QgsFields fields;
-    if ( options.value( QStringLiteral( "camera_capture" ) ).toBool() )
-    {
-      fields.append( QgsField( QStringLiteral( "media" ), QMetaType::QString ) );
-    }
+    fields.append( QgsField( QStringLiteral( "uuid" ), QMetaType::QString ) );
     fields.append( QgsField( QStringLiteral( "color" ), QMetaType::QString ) );
     fields.append( QgsField( QStringLiteral( "title" ), QMetaType::QString ) );
     fields.append( QgsField( QStringLiteral( "note" ), QMetaType::QString ) );
@@ -137,7 +135,9 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
 
     notesLayer = new QgsVectorLayer( notesFilepath, tr( "Notes" ) );
     fields = notesLayer->fields();
-    LayerUtils::setDefaultRenderer( notesLayer, nullptr, options.value( QStringLiteral( "camera_capture" ) ).toBool() ? QStringLiteral( "media" ) : QString(), QStringLiteral( "color" ) );
+    LayerUtils::setDefaultRenderer( notesLayer, nullptr,
+                                    options.value( QStringLiteral( "camera_capture" ) ).toBool() ? QStringLiteral( "aggregate('notes_attachments', 'concatenate', \"resource\", \"note_uuid\" = attribute(@parent, 'uuid'), ',', 1)" ) : QString(),
+                                    QStringLiteral( "color" ) );
     LayerUtils::setDefaultLabeling( notesLayer );
 
     // Set a nice display expression for the feature list
@@ -153,6 +153,16 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
     {
       widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), widgetOptions );
       notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
+    }
+
+    // Configure uuid field (referenced key for relations)
+    fieldIndex = fields.indexOf( QStringLiteral( "uuid" ) );
+    if ( fieldIndex >= 0 )
+    {
+      widgetOptions.clear();
+      widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), widgetOptions );
+      notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
+      notesLayer->setDefaultValueDefinition( fieldIndex, QgsDefaultValue( QStringLiteral( "uuid()" ), false ) );
     }
 
     // Configure time field
@@ -203,22 +213,24 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
       notesLayer->setFieldAlias( fieldIndex, tr( "Note" ) );
     }
 
-    if ( options.value( QStringLiteral( "camera_capture" ) ).toBool() )
-    {
-      // Configure camera field
-      fieldIndex = fields.indexOf( QStringLiteral( "media" ) );
-      if ( fieldIndex >= 0 )
-      {
-        widgetOptions.clear();
-        widgetOptions[QStringLiteral( "DocumentViewer" )] = 1;
-        widgetOptions[QStringLiteral( "RelativeStorage" )] = 1;
-        widgetOptions[QStringLiteral( "FileWidget" )] = true;
-        widgetOptions[QStringLiteral( "FileWidgetButton" )] = true;
-        widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "ExternalResource" ), widgetOptions );
-        notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
-        notesLayer->setFieldAlias( fieldIndex, tr( "Media" ) );
-      }
-    }
+    // if ( options.value( QStringLiteral( "camera_capture" ) ).toBool() )
+    // {
+    //   // Configure camera field
+    //   fieldIndex = fields.indexOf( QStringLiteral( "media" ) );
+    //   if ( fieldIndex >= 0 )
+    //   {
+    //     widgetOptions.clear();
+    //     widgetOptions[QStringLiteral( "DocumentViewer" )] = 1;
+    //     widgetOptions[QStringLiteral( "RelativeStorage" )] = 1;
+    //     widgetOptions[QStringLiteral( "FileWidget" )] = true;
+    //     widgetOptions[QStringLiteral( "FileWidgetButton" )] = true;
+    //     widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "ExternalResource" ), widgetOptions );
+    //     notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
+    //     notesLayer->setFieldAlias( fieldIndex, tr( "Media" ) );
+    //   }
+    // }
+
+    ////////TODO this should be moved to child layer
 
     // Insure the layer is ready cloud-friendly
     notesLayer->setCustomProperty( QStringLiteral( "QFieldSync/cloud_action" ), QStringLiteral( "offline" ) );
@@ -227,6 +239,91 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
     notesLayer->setDisplayExpression( QStringLiteral( "\"title\"" ) );
 
     createdProjectLayers << notesLayer;
+
+    // Attachments child layer (when camera capture is enabled)
+    if ( options.value( QStringLiteral( "camera_capture" ) ).toBool() )
+    {
+      // Second layer in the same notes.gpkg
+      QgsFields attachFields;
+      attachFields.append( QgsField( QStringLiteral( "note_uuid" ), QMetaType::QString ) );
+      attachFields.append( QgsField( QStringLiteral( "resource" ), QMetaType::QString ) );
+      attachFields.append( QgsField( QStringLiteral( "type" ), QMetaType::QString ) );
+      attachFields.append( QgsField( QStringLiteral( "timestamp" ), QMetaType::QDateTime ) );
+
+      QgsVectorFileWriter::SaveVectorOptions attachWriterOptions;
+      attachWriterOptions.layerName = QStringLiteral( "notes_attachments" );
+      attachWriterOptions.actionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
+      QgsVectorFileWriter *attachWriter = QgsVectorFileWriter::create(
+        notesFilepath, attachFields, Qgis::WkbType::NoGeometry,
+        QgsCoordinateReferenceSystem(),
+        createdProject->transformContext(), attachWriterOptions );
+      delete attachWriter;
+
+      const QString attachUri = QStringLiteral( "%1|layername=notes_attachments" ).arg( notesFilepath );
+      attachmentsLayer = new QgsVectorLayer( attachUri, tr( "Note attachments" ) );
+      QgsFields liveAttachFields = attachmentsLayer->fields();
+
+      int attachFieldIndex;
+      QVariantMap attachWidgetOptions;
+      QgsEditorWidgetSetup attachWidgetSetup;
+
+      // Hide fid
+      attachFieldIndex = liveAttachFields.indexOf( QStringLiteral( "fid" ) );
+      if ( attachFieldIndex >= 0 )
+      {
+        attachWidgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), QVariantMap() );
+        attachmentsLayer->setEditorWidgetSetup( attachFieldIndex, attachWidgetSetup );
+      }
+
+      // Hiding note_uuid here, relation editor auto populate the FK
+      attachFieldIndex = liveAttachFields.indexOf( QStringLiteral( "note_uuid" ) );
+      if ( attachFieldIndex >= 0 )
+      {
+        attachWidgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), QVariantMap() );
+        attachmentsLayer->setEditorWidgetSetup( attachFieldIndex, attachWidgetSetup );
+      }
+      attachFieldIndex = liveAttachFields.indexOf( QStringLiteral( "resource" ) );
+      if ( attachFieldIndex >= 0 )
+      {
+        attachWidgetOptions.clear();
+        attachWidgetOptions[QStringLiteral( "DocumentViewer" )] = 1;
+        attachWidgetOptions[QStringLiteral( "RelativeStorage" )] = 1;
+        attachWidgetOptions[QStringLiteral( "FileWidget" )] = true;
+        attachWidgetOptions[QStringLiteral( "FileWidgetButton" )] = true;
+        attachWidgetSetup = QgsEditorWidgetSetup( QStringLiteral( "ExternalResource" ), attachWidgetOptions );
+        attachmentsLayer->setEditorWidgetSetup( attachFieldIndex, attachWidgetSetup );
+        attachmentsLayer->setFieldAlias( attachFieldIndex, tr( "Media" ) );
+      }
+
+      // Type field should be hidden populated
+      attachFieldIndex = liveAttachFields.indexOf( QStringLiteral( "type" ) );
+      if ( attachFieldIndex >= 0 )
+      {
+        attachWidgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), QVariantMap() );
+        attachmentsLayer->setEditorWidgetSetup( attachFieldIndex, attachWidgetSetup );
+      }
+
+      attachFieldIndex = liveAttachFields.indexOf( QStringLiteral( "timestamp" ) );
+      if ( attachFieldIndex >= 0 )
+      {
+        attachWidgetOptions.clear();
+        attachWidgetOptions[QStringLiteral( "display_format" )] = QStringLiteral( "yyyy-MM-dd HH:mm" );
+        attachWidgetOptions[QStringLiteral( "field_format" )] = QStringLiteral( "yyyy-MM-dd HH:mm" );
+        attachWidgetOptions[QStringLiteral( "field_format_overwrite" )] = true;
+        attachWidgetOptions[QStringLiteral( "allow_null" )] = true;
+        attachWidgetOptions[QStringLiteral( "calendar_popup" )] = true;
+        attachWidgetSetup = QgsEditorWidgetSetup( QStringLiteral( "DateTime" ), attachWidgetOptions );
+        attachmentsLayer->setEditorWidgetSetup( attachFieldIndex, attachWidgetSetup );
+        attachmentsLayer->setDefaultValueDefinition( attachFieldIndex, QgsDefaultValue( QStringLiteral( "now()" ), false ) );
+        attachmentsLayer->setFieldAlias( attachFieldIndex, tr( "Time" ) );
+      }
+
+      attachmentsLayer->setDisplayExpression( QStringLiteral( "COALESCE(\"resource\", 'Attachment #' || fid)" ) );
+      attachmentsLayer->setCustomProperty( QStringLiteral( "QFieldSync/cloud_action" ), QStringLiteral( "offline" ) );
+      attachmentsLayer->setCustomProperty( QStringLiteral( "QFieldSync/action" ), QStringLiteral( "offline" ) );
+
+      createdProjectLayers << attachmentsLayer;
+    }
   }
 
   // Tracks layer
@@ -392,6 +489,22 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
                                                                                                                 << "files" );
 
   createdProject->addMapLayers( createdProjectLayers );
+
+  // Register the notes
+  if ( notesLayer && attachmentsLayer )
+  {
+    QgsRelation rel;
+    rel.setId( QStringLiteral( "notes_attachments_relation" ) );
+    rel.setName( tr( "Attachments" ) );
+    rel.setReferencedLayer( notesLayer->id() );
+    rel.setReferencingLayer( attachmentsLayer->id() );
+    rel.addFieldPair( QStringLiteral( "note_uuid" ), QStringLiteral( "uuid" ) );
+    rel.setStrength( Qgis::RelationshipStrength::Association );
+    if ( rel.isValid() )
+    {
+      createdProject->relationManager()->addRelation( rel );
+    }
+  }
 
   connect( createdProject, &QgsProject::writeProject, [createdProject, createdProjectExtent, positionInformation]( QDomDocument &document ) {
     QDomNodeList nodes = document.elementsByTagName( "qgis" );

--- a/src/core/utils/projectutils.cpp
+++ b/src/core/utils/projectutils.cpp
@@ -493,13 +493,17 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
   // Register the notes
   if ( notesLayer && attachmentsLayer )
   {
-    QgsRelation rel;
+    QgsRelationContext relationContext( createdProject );
+    QgsRelation rel( relationContext );
     rel.setId( QStringLiteral( "notes_attachments_relation" ) );
     rel.setName( tr( "Attachments" ) );
     rel.setReferencedLayer( notesLayer->id() );
     rel.setReferencingLayer( attachmentsLayer->id() );
     rel.addFieldPair( QStringLiteral( "note_uuid" ), QStringLiteral( "uuid" ) );
     rel.setStrength( Qgis::RelationshipStrength::Association );
+
+    qDebug() << "Relation valid?" << rel.isValid() << "validation error:" << rel.validationError();
+
     if ( rel.isValid() )
     {
       createdProject->relationManager()->addRelation( rel );


### PR DESCRIPTION
This pr provides a feature when users enable "Take notes" with "image and video attachments" in the project creation, the generated project now supports multiple attachments per note via parentchild relation (which uses gallery editor automatically), replacing the previous single media field

Before: one note could hold exactly one attachment (stored as a text path in a media field on the notes layer)
Now: one note can hold any number of image, video, or audio attachments, each as a row in a child notes_attachments table linked by foreign key.

### Changed made to the Schema

**Parent notes layer** (notes.gpkg layer Notes)
- Added the new uuid field (QString, hidden, default uuid()) which is referenced key for the relation
- Removed the existing media field, so that the attachments now live on the child

**New child attachments layer** (notes.gpkg layer notes_attachments, non-spatial)
- note_uuid (hidden) as foreign key
- resource as file path with ExternalResource widget
- type (hidden) as placeholder for future image/video/audio classification
- timestamp which defaults to now()

**Relation**
- notes_attachments_relation, referenced uuid -> referencing note_uuid, Association 

### How the gallery editor gets used

This PR provides the data plumbing only. The gallery relation editor (separate feature already added) renders the ui. they compose automatically via existing logic in attributeformmodelbase:

1. When the notes feature form is built, generateRootContainer() walks referencedRelations(notesLayer) and appends a QgsAttributeEditorRelation for each registered relation
2. In buildForm() case Relation, qfield inspects the referencing layers fields, finding the ExternalResource widget on resource, it promotes the relation widget type from relation_editor to our gallery_relation_editor.

## Demo

https://github.com/user-attachments/assets/eba2dad5-ab28-4173-8b18-2e0b65b7a231

