### PR TITLE
Allow photo/video mode toggle in gallery and external resource editors through QFieldCamera

### DIFF
--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -25,6 +25,9 @@ Popup {
 
   property bool allowStateToggle: false
 
+  readonly property int bottomPanelExtra: allowStateToggle ? 70 : 0
+  readonly property int captureClusterOffset: allowStateToggle ? -25 : 0
+
   function requiredPermissionsGranted() {
     if (cameraPermission.status !== Qt.PermissionStatus.Granted) {
       return false;
@@ -432,16 +435,16 @@ Popup {
     }
 
     Rectangle {
-      width: cameraItem.isPortraitMode ? parent.width : 100 + mainWindow.sceneBottomMargin
-      height: cameraItem.isPortraitMode ? 100 + mainWindow.sceneRightMargin : parent.height
+      width: cameraItem.isPortraitMode ? parent.width : 100 + cameraItem.bottomPanelExtra + mainWindow.sceneBottomMargin
+      height: cameraItem.isPortraitMode ? 100 + cameraItem.bottomPanelExtra + mainWindow.sceneRightMargin : parent.height
       x: cameraItem.isPortraitMode ? 0 : parent.width - width
       y: cameraItem.isPortraitMode ? parent.height - height : 0
 
       color: Theme.darkGraySemiOpaque
 
       Rectangle {
-        width: cameraItem.isPortraitMode ? parent.width : 100 + mainWindow.sceneBottomMargin
-        height: cameraItem.isPortraitMode ? 100 + mainWindow.sceneRightMargin : parent.height
+        width: cameraItem.isPortraitMode ? parent.width : 100 + cameraItem.bottomPanelExtra + mainWindow.sceneBottomMargin
+        height: cameraItem.isPortraitMode ? 100 + cameraItem.bottomPanelExtra + mainWindow.sceneRightMargin : parent.height
         x: cameraItem.isPortraitMode ? 0 : parent.width - width
         y: cameraItem.isPortraitMode ? parent.height - height : 0
 
@@ -456,6 +459,7 @@ Popup {
           Rectangle {
             id: captureRing
             anchors.centerIn: parent
+            anchors.verticalCenterOffset: cameraItem.captureClusterOffset
             width: 64
             height: 64
             radius: 32
@@ -522,17 +526,17 @@ Popup {
           QfSwitch {
             id: modeSwitch
 
-            readonly property int slotSize: 32
+            readonly property int slotSize: 36
             readonly property int highlightInset: 1
 
             visible: cameraItem.allowStateToggle && cameraItem.isCapturing && captureLoader.item && captureLoader.item.recorder.recorderState === MediaRecorder.StoppedState
 
             width: slotSize * 2 + 4
-            height: 36
+            height: 40
             padding: 0
 
-            x: cameraItem.isPortraitMode ? captureRing.x + captureRing.width / 2 - width / 2 : captureRing.x + captureRing.width + 12
-            y: cameraItem.isPortraitMode ? captureRing.y + captureRing.height + 12 : captureRing.y + captureRing.height / 2 - height / 2
+            x: captureRing.x + captureRing.width / 2 - width / 2
+            y: captureRing.y + captureRing.height + 10
 
             checked: cameraItem.state == "VideoCapture"
 
@@ -541,7 +545,7 @@ Popup {
               implicitWidth: modeSwitch.slotSize * 2
               x: (modeSwitch.width - implicitWidth) / 2
               radius: 4
-              color: Theme.darkGraySemiOpaque
+              color: "transparent"
               anchors.verticalCenter: parent.verticalCenter
 
               QfToolButton {
@@ -554,7 +558,7 @@ Popup {
                 iconColor: "white"
                 bgcolor: 'transparent'
                 enabled: false
-                opacity: 0.5
+                opacity: 0.35
               }
 
               QfToolButton {
@@ -567,7 +571,7 @@ Popup {
                 iconColor: "white"
                 bgcolor: 'transparent'
                 enabled: false
-                opacity: 0.5
+                opacity: 0.35
               }
 
               Rectangle {
@@ -577,7 +581,9 @@ Popup {
                 width: modeSwitch.slotSize - inset * 2
                 height: modeSwitch.slotSize - inset * 2
                 radius: 3
-                color: Theme.mainColor
+                color: Theme.darkGraySemiOpaque
+                border.color: "#66FFFFFF"
+                border.width: 1
                 clip: true
 
                 QfToolButton {
@@ -611,7 +617,7 @@ Popup {
             visible: cameraItem.isCapturing && captureLoader.item && (captureLoader.item.camera.maximumZoomFactor !== 1.0 || captureLoader.item.camera.minimumZoomFactor !== 1.0)
 
             x: cameraItem.isPortraitMode ? (parent.width / 4) - (width / 2) : (parent.width - width) / 2
-            y: cameraItem.isPortraitMode ? (parent.height - height) / 2 : (parent.height / 4) * 3 - (height / 2)
+            y: cameraItem.isPortraitMode ? (parent.height - height) / 2 + cameraItem.captureClusterOffset : (parent.height / 4) * 3 - (height / 2)
 
             iconColor: Theme.toolButtonColor
             bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
@@ -632,7 +638,7 @@ Popup {
             visible: cameraItem.isCapturing && captureLoader.item && captureLoader.item.camera.isFlashModeSupported(Camera.FlashOn)
 
             x: cameraItem.isPortraitMode ? (parent.width / 4) * 3 - (width / 2) : (parent.width - width) / 2
-            y: cameraItem.isPortraitMode ? (parent.height - height) / 2 : (parent.height / 4) - (height / 2)
+            y: cameraItem.isPortraitMode ? (parent.height - height) / 2 + cameraItem.captureClusterOffset : (parent.height / 4) - (height / 2)
 
             iconSource: {
               if (!captureLoader.item)

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -460,6 +460,7 @@ Popup {
             id: captureRing
             anchors.centerIn: parent
             anchors.verticalCenterOffset: cameraItem.isPortraitMode ? cameraItem.captureClusterOffset : 0
+            anchors.horizontalCenterOffset: !cameraItem.isPortraitMode ? cameraItem.captureClusterOffset : 0
             width: 64
             height: 64
             radius: 32

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -23,10 +23,10 @@ Popup {
 
   property bool captureLoaderActivated: false
 
-  property bool allowStateToggle: false
+  property bool allowCaptureModeToggle: false
 
-  readonly property int bottomPanelExtra: allowStateToggle ? 70 : 0
-  readonly property int captureClusterOffset: allowStateToggle ? -25 : 0
+  readonly property int panelExtraSpace: allowCaptureModeToggle ? 70 : 0
+  readonly property int captureOffset: allowCaptureModeToggle ? -25 : 0
 
   function requiredPermissionsGranted() {
     if (cameraPermission.status !== Qt.PermissionStatus.Granted) {
@@ -435,16 +435,16 @@ Popup {
     }
 
     Rectangle {
-      width: cameraItem.isPortraitMode ? parent.width : 100 + mainWindow.sceneBottomMargin + cameraItem.bottomPanelExtra
-      height: cameraItem.isPortraitMode ? 100 + cameraItem.bottomPanelExtra + mainWindow.sceneRightMargin : parent.height
+      width: cameraItem.isPortraitMode ? parent.width : 100 + mainWindow.sceneBottomMargin + cameraItem.panelExtraSpace
+      height: cameraItem.isPortraitMode ? 100 + cameraItem.panelExtraSpace + mainWindow.sceneRightMargin : parent.height
       x: cameraItem.isPortraitMode ? 0 : parent.width - width
       y: cameraItem.isPortraitMode ? parent.height - height : 0
 
       color: Theme.darkGraySemiOpaque
 
       Rectangle {
-        width: cameraItem.isPortraitMode ? parent.width : 100 + mainWindow.sceneBottomMargin + cameraItem.bottomPanelExtra
-        height: cameraItem.isPortraitMode ? 100 + cameraItem.bottomPanelExtra + mainWindow.sceneRightMargin : parent.height
+        width: cameraItem.isPortraitMode ? parent.width : 100 + mainWindow.sceneBottomMargin + cameraItem.panelExtraSpace
+        height: cameraItem.isPortraitMode ? 100 + cameraItem.panelExtraSpace + mainWindow.sceneRightMargin : parent.height
         x: cameraItem.isPortraitMode ? 0 : parent.width - width
         y: cameraItem.isPortraitMode ? parent.height - height : 0
 
@@ -459,8 +459,8 @@ Popup {
           Rectangle {
             id: captureRing
             anchors.centerIn: parent
-            anchors.verticalCenterOffset: cameraItem.isPortraitMode ? cameraItem.captureClusterOffset : 0
-            anchors.horizontalCenterOffset: !cameraItem.isPortraitMode ? cameraItem.captureClusterOffset : 0
+            anchors.verticalCenterOffset: cameraItem.isPortraitMode ? cameraItem.captureOffset : 0
+            anchors.horizontalCenterOffset: !cameraItem.isPortraitMode ? cameraItem.captureOffset : 0
             width: 64
             height: 64
             radius: 32
@@ -530,7 +530,7 @@ Popup {
             readonly property int slotSize: 36
             readonly property int highlightInset: 1
 
-            visible: cameraItem.allowStateToggle && cameraItem.isCapturing && captureLoader.item && captureLoader.item.recorder.recorderState === MediaRecorder.StoppedState
+            visible: cameraItem.allowCaptureModeToggle && cameraItem.isCapturing && captureLoader.item && captureLoader.item.recorder.recorderState === MediaRecorder.StoppedState
 
             width: slotSize * 2 + 4
             height: 40
@@ -620,10 +620,10 @@ Popup {
 
           QfToolButton {
             id: zoomButton
-            visible: cameraItem.isCapturing && captureLoader.item && (captureLoader.item.camera.maximumZoomFactor !== 1.0 || captureLoader.item.camera.minimumZoomFactor !== 1.0)
+            visible: true//cameraItem.isCapturing && captureLoader.item && (captureLoader.item.camera.maximumZoomFactor !== 1.0 || captureLoader.item.camera.minimumZoomFactor !== 1.0)
 
-            x: cameraItem.isPortraitMode ? (parent.width / 4) - (width / 2) : (parent.width - width) / 2
-            y: cameraItem.isPortraitMode ? (parent.height - height) / 2 + cameraItem.captureClusterOffset : (parent.height / 4) * 3 - (height / 2)
+            x: cameraItem.isPortraitMode ? (parent.width / 4) - (width / 2) : (parent.width - width) / 2 + cameraItem.captureOffset
+            y: cameraItem.isPortraitMode ? (parent.height - height) / 2 + cameraItem.captureOffset : (parent.height / 4) * 3 - (height / 2)
 
             iconColor: Theme.toolButtonColor
             bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
@@ -641,10 +641,10 @@ Popup {
 
           QfToolButton {
             id: flashButton
-            visible: cameraItem.isCapturing && captureLoader.item && captureLoader.item.camera.isFlashModeSupported(Camera.FlashOn)
+            visible: true//cameraItem.isCapturing && captureLoader.item && captureLoader.item.camera.isFlashModeSupported(Camera.FlashOn)
 
-            x: cameraItem.isPortraitMode ? (parent.width / 4) * 3 - (width / 2) : (parent.width - width) / 2
-            y: cameraItem.isPortraitMode ? (parent.height - height) / 2 + cameraItem.captureClusterOffset : (parent.height / 4) - (height / 2)
+            x: cameraItem.isPortraitMode ? (parent.width / 4) * 3 - (width / 2) : (parent.width - width) / 2 + cameraItem.captureOffset
+            y: cameraItem.isPortraitMode ? (parent.height - height) / 2 + cameraItem.captureOffset : (parent.height / 4) - (height / 2)
 
             iconSource: {
               if (!captureLoader.item)

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -23,6 +23,8 @@ Popup {
 
   property bool captureLoaderActivated: false
 
+  property bool allowStateToggle: false
+
   function requiredPermissionsGranted() {
     if (cameraPermission.status !== Qt.PermissionStatus.Granted) {
       return false;
@@ -514,6 +516,93 @@ Popup {
                   cameraItem.finished(currentPath);
                 }
               }
+            }
+          }
+
+          QfSwitch {
+            id: modeSwitch
+
+            readonly property int slotSize: 32
+            readonly property int highlightInset: 1
+
+            visible: cameraItem.allowStateToggle && cameraItem.isCapturing && captureLoader.item && captureLoader.item.recorder.recorderState === MediaRecorder.StoppedState
+
+            width: slotSize * 2 + 4
+            height: 36
+            padding: 0
+
+            x: cameraItem.isPortraitMode ? captureRing.x + captureRing.width / 2 - width / 2 : captureRing.x + captureRing.width + 12
+            y: cameraItem.isPortraitMode ? captureRing.y + captureRing.height + 12 : captureRing.y + captureRing.height / 2 - height / 2
+
+            checked: cameraItem.state == "VideoCapture"
+
+            indicator: Rectangle {
+              implicitHeight: modeSwitch.slotSize
+              implicitWidth: modeSwitch.slotSize * 2
+              x: (modeSwitch.width - implicitWidth) / 2
+              radius: 4
+              color: Theme.darkGraySemiOpaque
+              anchors.verticalCenter: parent.verticalCenter
+
+              QfToolButton {
+                width: modeSwitch.slotSize
+                height: modeSwitch.slotSize
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+                round: false
+                iconSource: Theme.getThemeVectorIcon('ic_camera_photo_black_24dp')
+                iconColor: "white"
+                bgcolor: 'transparent'
+                enabled: false
+                opacity: 0.5
+              }
+
+              QfToolButton {
+                width: modeSwitch.slotSize
+                height: modeSwitch.slotSize
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                round: false
+                iconSource: Theme.getThemeVectorIcon('ic_camera_video_black_24dp')
+                iconColor: "white"
+                bgcolor: 'transparent'
+                enabled: false
+                opacity: 0.5
+              }
+
+              Rectangle {
+                readonly property int inset: modeSwitch.highlightInset
+                x: modeSwitch.checked ? parent.width - width - inset : inset
+                y: inset
+                width: modeSwitch.slotSize - inset * 2
+                height: modeSwitch.slotSize - inset * 2
+                radius: 3
+                color: Theme.mainColor
+                clip: true
+
+                QfToolButton {
+                  width: modeSwitch.slotSize
+                  height: modeSwitch.slotSize
+                  anchors.centerIn: parent
+                  round: false
+                  hoverEnabled: false
+                  iconSource: modeSwitch.checked ? Theme.getThemeVectorIcon('ic_camera_video_black_24dp') : Theme.getThemeVectorIcon('ic_camera_photo_black_24dp')
+                  iconColor: "white"
+                  bgcolor: 'transparent'
+                  enabled: false
+                }
+
+                Behavior on x {
+                  PropertyAnimation {
+                    duration: 100
+                    easing.type: Easing.OutQuart
+                  }
+                }
+              }
+            }
+
+            onClicked: {
+              cameraItem.state = checked ? "VideoCapture" : "PhotoCapture";
             }
           }
 

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -25,8 +25,8 @@ Popup {
 
   property bool allowStateToggle: false
 
-  readonly property int bottomPanelExtra: allowStateToggle && isPortraitMode ? 70 : 0
-  readonly property int captureClusterOffset: allowStateToggle && isPortraitMode ? -25 : 0
+  readonly property int bottomPanelExtra: allowStateToggle ? 70 : 0
+  readonly property int captureClusterOffset: allowStateToggle ? -25 : 0
 
   function requiredPermissionsGranted() {
     if (cameraPermission.status !== Qt.PermissionStatus.Granted) {
@@ -435,7 +435,7 @@ Popup {
     }
 
     Rectangle {
-      width: cameraItem.isPortraitMode ? parent.width : 100 + mainWindow.sceneBottomMargin
+      width: cameraItem.isPortraitMode ? parent.width : 100 + mainWindow.sceneBottomMargin + cameraItem.bottomPanelExtra
       height: cameraItem.isPortraitMode ? 100 + cameraItem.bottomPanelExtra + mainWindow.sceneRightMargin : parent.height
       x: cameraItem.isPortraitMode ? 0 : parent.width - width
       y: cameraItem.isPortraitMode ? parent.height - height : 0
@@ -443,7 +443,7 @@ Popup {
       color: Theme.darkGraySemiOpaque
 
       Rectangle {
-        width: cameraItem.isPortraitMode ? parent.width : 100 + mainWindow.sceneBottomMargin
+        width: cameraItem.isPortraitMode ? parent.width : 100 + mainWindow.sceneBottomMargin + cameraItem.bottomPanelExtra
         height: cameraItem.isPortraitMode ? 100 + cameraItem.bottomPanelExtra + mainWindow.sceneRightMargin : parent.height
         x: cameraItem.isPortraitMode ? 0 : parent.width - width
         y: cameraItem.isPortraitMode ? parent.height - height : 0
@@ -459,7 +459,7 @@ Popup {
           Rectangle {
             id: captureRing
             anchors.centerIn: parent
-            anchors.verticalCenterOffset: cameraItem.captureClusterOffset
+            anchors.verticalCenterOffset: cameraItem.isPortraitMode ? cameraItem.captureClusterOffset : 0
             width: 64
             height: 64
             radius: 32

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -25,8 +25,8 @@ Popup {
 
   property bool allowStateToggle: false
 
-  readonly property int bottomPanelExtra: allowStateToggle ? 70 : 0
-  readonly property int captureClusterOffset: allowStateToggle ? -25 : 0
+  readonly property int bottomPanelExtra: allowStateToggle && isPortraitMode ? 70 : 0
+  readonly property int captureClusterOffset: allowStateToggle && isPortraitMode ? -25 : 0
 
   function requiredPermissionsGranted() {
     if (cameraPermission.status !== Qt.PermissionStatus.Granted) {
@@ -435,7 +435,7 @@ Popup {
     }
 
     Rectangle {
-      width: cameraItem.isPortraitMode ? parent.width : 100 + cameraItem.bottomPanelExtra + mainWindow.sceneBottomMargin
+      width: cameraItem.isPortraitMode ? parent.width : 100 + mainWindow.sceneBottomMargin
       height: cameraItem.isPortraitMode ? 100 + cameraItem.bottomPanelExtra + mainWindow.sceneRightMargin : parent.height
       x: cameraItem.isPortraitMode ? 0 : parent.width - width
       y: cameraItem.isPortraitMode ? parent.height - height : 0
@@ -443,7 +443,7 @@ Popup {
       color: Theme.darkGraySemiOpaque
 
       Rectangle {
-        width: cameraItem.isPortraitMode ? parent.width : 100 + cameraItem.bottomPanelExtra + mainWindow.sceneBottomMargin
+        width: cameraItem.isPortraitMode ? parent.width : 100 + mainWindow.sceneBottomMargin
         height: cameraItem.isPortraitMode ? 100 + cameraItem.bottomPanelExtra + mainWindow.sceneRightMargin : parent.height
         x: cameraItem.isPortraitMode ? 0 : parent.width - width
         y: cameraItem.isPortraitMode ? parent.height - height : 0
@@ -535,8 +535,10 @@ Popup {
             height: 40
             padding: 0
 
-            x: captureRing.x + captureRing.width / 2 - width / 2
-            y: captureRing.y + captureRing.height + 10
+            rotation: cameraItem.isPortraitMode ? 0 : -90
+
+            x: cameraItem.isPortraitMode ? captureRing.x + captureRing.width / 2 - width / 2 : captureRing.x + captureRing.width + 10 - (width - height) / 2
+            y: cameraItem.isPortraitMode ? captureRing.y + captureRing.height + 10 : captureRing.y + captureRing.height / 2 - height / 2
 
             checked: cameraItem.state == "VideoCapture"
 
@@ -559,6 +561,7 @@ Popup {
                 bgcolor: 'transparent'
                 enabled: false
                 opacity: 0.35
+                rotation: cameraItem.isPortraitMode ? 0 : 90
               }
 
               QfToolButton {
@@ -572,6 +575,7 @@ Popup {
                 bgcolor: 'transparent'
                 enabled: false
                 opacity: 0.35
+                rotation: cameraItem.isPortraitMode ? 0 : 90
               }
 
               Rectangle {
@@ -596,6 +600,7 @@ Popup {
                   iconColor: "white"
                   bgcolor: 'transparent'
                   enabled: false
+                  rotation: cameraItem.isPortraitMode ? 0 : 90
                 }
 
                 Behavior on x {

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -689,16 +689,11 @@ EditorWidgetBase {
       id: qfieldCamera
       visible: false
 
-      allowStateToggle: documentViewer === ExternalResource.DocumentImage || documentViewer === ExternalResource.DocumentVideo || documentViewer === ExternalResource.DocumentFile
+      allowCaptureModeToggle: true
 
       Component.onCompleted: {
-        if (isVideo) {
-          qfieldCamera.state = 'VideoCapture';
-          open();
-        } else {
-          qfieldCamera.state = 'PhotoCapture';
-          open();
-        }
+        qfieldCamera.state = isVideo ? 'VideoCapture' : 'PhotoCapture';
+        open();
       }
 
       onFinished: path => {

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -689,6 +689,8 @@ EditorWidgetBase {
       id: qfieldCamera
       visible: false
 
+      allowStateToggle: documentViewer === ExternalResource.DocumentImage || documentViewer === ExternalResource.DocumentVideo || documentViewer === ExternalResource.DocumentFile
+
       Component.onCompleted: {
         if (isVideo) {
           qfieldCamera.state = 'VideoCapture';
@@ -702,7 +704,7 @@ EditorWidgetBase {
       onFinished: path => {
         const filepath = StringUtils.replaceFilenameTags(getResourceFilePath(), path);
         platformUtilities.renameFile(path, prefixToRelativePath + filepath);
-        if (!cameraLoader.isVideo) {
+        if (!FileUtils.mimeTypeName(path).startsWith("video/")) {
           const maximumWidhtHeight = iface.readProjectNumEntry("qfieldsync", "maximumImageWidthHeight", 0);
           if (maximumWidhtHeight > 0) {
             FileUtils.restrictImageSize(prefixToRelativePath + filepath, maximumWidhtHeight);
@@ -712,13 +714,8 @@ EditorWidgetBase {
         close();
       }
 
-      onCanceled: {
-        close();
-      }
-
-      onClosed: {
-        cameraLoader.active = false;
-      }
+      onCanceled: close()
+      onClosed: cameraLoader.active = false
     }
   }
 

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -506,6 +506,7 @@ RelationEditorBase {
     property bool isVideo: false
     sourceComponent: Component {
       QFieldCamera {
+        allowStateToggle: documentViewer === ExternalResource.DocumentImage || documentViewer === ExternalResource.DocumentVideo || documentViewer === ExternalResource.DocumentFile
         Component.onCompleted: {
           state = relationCameraLoader.isVideo ? 'VideoCapture' : 'PhotoCapture';
           open();
@@ -513,7 +514,7 @@ RelationEditorBase {
         onFinished: path => {
           const filepath = StringUtils.replaceFilenameTags(ExternalResourceUtils.getAttachmentFilePath(attachmentNamingEvaluator.evaluate(), documentViewer, FileUtils), path);
           platformUtilities.renameFile(path, imagePrefix + filepath);
-          if (!relationCameraLoader.isVideo) {
+          if (!FileUtils.mimeTypeName(path).startsWith("video/")) {
             let maximumWidthHeight = iface.readProjectNumEntry("qfieldsync", "maximumImageWidthHeight", 0);
             if (maximumWidthHeight > 0) {
               FileUtils.restrictImageSize(imagePrefix + filepath, maximumWidthHeight);

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -506,11 +506,13 @@ RelationEditorBase {
     property bool isVideo: false
     sourceComponent: Component {
       QFieldCamera {
-        allowStateToggle: documentViewer === ExternalResource.DocumentImage || documentViewer === ExternalResource.DocumentVideo || documentViewer === ExternalResource.DocumentFile
+        allowCaptureModeToggle: true
+
         Component.onCompleted: {
           state = relationCameraLoader.isVideo ? 'VideoCapture' : 'PhotoCapture';
           open();
         }
+
         onFinished: path => {
           const filepath = StringUtils.replaceFilenameTags(ExternalResourceUtils.getAttachmentFilePath(attachmentNamingEvaluator.evaluate(), documentViewer, FileUtils), path);
           platformUtilities.renameFile(path, imagePrefix + filepath);


### PR DESCRIPTION
this pr introduces an opt-in allowStateToggle property on QFieldCamera that surfaces a QfSwitch below the capture ring, letting users flip between photo and video capture without leaving the camera. Default is false, so plugins and all other call sites remain photo only
Enabled in the gallery relation editor and the external resource editor when the field's DocumentViewer is Image, Video, or File, capture button still defaults sensibly (photo for image/file fields, video for video fields). Mid recording switching is blocked via recorderState === StoppedState
> Bottom panel grows 70px in portrait to host the toggle with proper safe margins; landscape reuses existing vertical space
> Post-capture image-size restriction is now driven by the produced file mime type rather than the initial mode, so toggling mid session still produces correctly sized output, meaning whether the file is an image or video is determined by looking at the file itself, not by what mode the camera started in

https://github.com/user-attachments/assets/60e76830-bb93-4a18-8188-8cb3d2d7918b