### PR TITLE
Collapse EmptyState whitespace in gallery relation editor

### DIFF
--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -156,17 +156,18 @@ RelationEditorBase {
   readonly property int toggleHeight: 40
   readonly property int gridMargin: 8
 
-  bottomMargin: 10 + toggleHeight
+  bottomMargin: 10 + (itemCount > 0 ? toggleHeight : 0)
 
   height: {
+    const toggleSpace = itemCount > 0 ? toggleHeight : 0;
     if (isGridView) {
       if (itemCount === 0) {
-        return headerEntry.height + 10 + toggleHeight;
+        return headerEntry.height + 10 + toggleSpace;
       }
-      return cardSize + gridMargin * 2 + headerEntry.height + 10 + toggleHeight;
+      return cardSize + gridMargin * 2 + headerEntry.height + 10 + toggleSpace;
     }
     const cappedHeight = !showAllItems && maximumVisibleItems > 0 ? Math.min(maximumVisibleItems * gridView.cellHeight, gridView.contentHeight) : gridView.contentHeight;
-    return cappedHeight + headerEntry.height + 10 + toggleHeight;
+    return cappedHeight + headerEntry.height + 10 + toggleSpace;
   }
 
   gridView.flow: isGridView ? GridView.FlowTopToBottom : GridView.FlowLeftToRight


### PR DESCRIPTION
when the gallery has 0 features, the view toggle is hidden but its 40px slot was still reserved in height and bottomMargin, leaving a whitespace, which is noticed when other fields are below, found while working in project creation pr.
This pr makes the reserved toggle space conditional on itemCount > 0, so the empty state collapses cleanly to just the header. Space is restored automatically when the first item is added

<img width="428" height="840" alt="Screenshot 2026-04-14 at 9 20 05 PM" src="https://github.com/user-attachments/assets/15f6ab45-fdca-4e09-b626-1c22368a8f28" />
<img width="426" height="840" alt="Screenshot 2026-04-14 at 9 18 29 PM" src="https://github.com/user-attachments/assets/45af20fc-39c9-4d7b-8308-594d2de7b5c8" />



