### PR TITLE
Further align QField's handling of display format vs field format with that of QGIS

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -398,6 +398,21 @@ void AttributeFormModelBase::updateAttributeValue( QStandardItem *item )
   {
     int fieldIndex = item->data( AttributeFormModel::FieldIndex ).toInt();
     QVariant attributeValue = mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::AttributeValue );
+
+    if ( attributeValue.userType() == QMetaType::QDate )
+    {
+      // if the field is a QDate, the automatic conversion to JS date [1]
+      // leads to the creation of date time object with the time zone.
+      // For instance shapefiles has support for dates but not date/time or time.
+      // So a date coming from a shapefile as 2001-01-01 will become 2000-12-31 19:00:00 -05 in QML/JS (in the carribeans).
+      // And when formatting this with the display format, this is shown as 2000-12-31.
+      // So we detect if the field is a date only and revert the time zone offset.
+      // [1] http://doc.qt.io/qt-5/qtqml-cppintegration-data.html#basic-qt-data-types
+
+      const QDate d = attributeValue.toDate();
+      attributeValue = QDateTime( d, QTime() );
+    }
+
     item->setData( attributeValue.isNull() ? QVariant() : attributeValue, AttributeFormModel::AttributeValue );
     item->setData( mFeatureModel->data( mFeatureModel->index( fieldIndex ), FeatureModel::AttributeAllowEdit ), AttributeFormModel::AttributeAllowEdit );
     // set item editable state to false in case it's a linked attribute

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -149,11 +149,7 @@ EditorWidgetBase {
         let newDate = Date.fromLocaleString(Qt.locale(), label.text, !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['display_format']);
         if (newDate.toLocaleString() !== "") {
           if (!main.isDateTimeType) {
-            let dateFormat = config['field_format'] !== undefined ? config['field_format'] : 'yyyy-MM-dd';
-            if (!!config['field_format_overwrite']) {
-              dateFormat = !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['field_format'];
-            }
-            newDate = Qt.formatDateTime(newDate, dateFormat);
+            newDate = convertDateToFieldFormattedString(newDate);
           }
           valueChangeRequested(newDate, newDate === undefined);
         } else {
@@ -215,11 +211,7 @@ EditorWidgetBase {
         if (main.isDateTimeType) {
           valueChangeRequested(currentDate, false);
         } else {
-          let dateFormat = config['field_format'] !== undefined ? config['field_format'] : 'yyyy-MM-dd';
-          if (!!config['field_format_overwrite']) {
-            dateFormat = !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['field_format'];
-          }
-          const textDate = Qt.formatDateTime(currentDate, dateFormat);
+          const textDate = convertDateToFieldFormattedString(currentDate);
           valueChangeRequested(textDate, false);
         }
         displayToast(qsTr('Date value set to today.'));
@@ -256,13 +248,17 @@ EditorWidgetBase {
       if (main.isDateTimeType) {
         valueChangeRequested(date, date === undefined);
       } else {
-        let dateFormat = config['field_format'] !== undefined ? config['field_format'] : 'yyyy-MM-dd';
-        if (!!config['field_format_overwrite']) {
-          dateFormat = !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['field_format'];
-        }
-        const textDate = Qt.formatDateTime(date, dateFormat);
+        const textDate = convertDateToFieldFormattedString(date);
         valueChangeRequested(textDate, date === undefined);
       }
     }
+  }
+
+  function convertDateToFieldFormattedString(date) {
+    let dateFormat = config['field_format'] !== undefined ? config['field_format'] : 'yyyy-MM-dd';
+    if (!!config['field_format_overwrite']) {
+      dateFormat = !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['field_format'];
+    }
+    return Qt.formatDateTime(date, dateFormat);
   }
 }

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -133,7 +133,11 @@ EditorWidgetBase {
             usedDate = value;
           }
           if (!(usedDate instanceof Date)) {
-            usedDate = Date.fromLocaleString(Qt.locale(), label.text, !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['display_format']);
+            let dateFormat = config['field_format'] !== undefined ? config['field_format'] : 'yyyy-MM-dd';
+            if (!!config['field_format_overwrite']) {
+              dateFormat = !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['field_format'];
+            }
+            usedDate = Date.fromLocaleString(Qt.locale(), value, dateFormat);
           }
           todayButton.forceActiveFocus();
           calendarPanel.selectedDate = usedDate;
@@ -145,7 +149,11 @@ EditorWidgetBase {
         let newDate = Date.fromLocaleString(Qt.locale(), label.text, !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['display_format']);
         if (newDate.toLocaleString() !== "") {
           if (!main.isDateTimeType) {
-            newDate = Qt.formatDateTime(newDate, !!config['field_iso_format'] ? Qt.ISODate : config['field_format']);
+            let dateFormat = config['field_format'] !== undefined ? config['field_format'] : 'yyyy-MM-dd';
+            if (!!config['field_format_overwrite']) {
+              dateFormat = !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['field_format'];
+            }
+            newDate = Qt.formatDateTime(newDate, dateFormat);
           }
           valueChangeRequested(newDate, newDate === undefined);
         } else {
@@ -207,7 +215,7 @@ EditorWidgetBase {
         if (main.isDateTimeType) {
           valueChangeRequested(currentDate, false);
         } else {
-          let dateFormat = config['display_format'] !== undefined ? config['display_format'] : '';
+          let dateFormat = config['field_format'] !== undefined ? config['field_format'] : 'yyyy-MM-dd';
           if (!!config['field_format_overwrite']) {
             dateFormat = !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['field_format'];
           }
@@ -226,14 +234,29 @@ EditorWidgetBase {
 
   QfCalendarPanel {
     id: calendarPanel
-    showTimePicker: main.fieldIsDateTime || main.fieldIsTime || (main.fieldIsString && config['field_format_overwrite'] && (config['field_format'].includes("HH:mm") || !!config['field_iso_format'])) || (main.fieldIsString && !config['field_format_overwrite'])
-    showDatePicker: main.fieldIsDate || main.fieldIsDateTime || (main.fieldIsString && config['field_format_overwrite'] && (config['field_format'].includes("yyyy-MM") || config['field_format'].includes("yyyy.MM") || !!config['field_iso_format'])) || (main.fieldIsString && !config['field_format_overwrite'])
+
+    showTimePicker: {
+      if (main.fieldIsDateTime || main.fieldIsTime) {
+        return true;
+      } else if (main.fieldIsString && !!config['field_format_overwrite'] && (config['field_format'].includes("HH:mm") || !!config['field_iso_format'])) {
+        return true;
+      }
+      return false;
+    }
+    showDatePicker: {
+      if (main.fieldIsTime) {
+        return false;
+      } else if (main.fieldIsString && !!config['field_format_overwrite'] && !config['field_format'].includes("yyyy-MM") && !config['field_format'].includes("yyyy.MM") && !config['field_iso_format']) {
+        return false;
+      }
+      return true;
+    }
 
     onDateTimePicked: date => {
       if (main.isDateTimeType) {
         valueChangeRequested(date, date === undefined);
       } else {
-        let dateFormat = config['display_format'] !== undefined ? config['display_format'] : '';
+        let dateFormat = config['field_format'] !== undefined ? config['field_format'] : 'yyyy-MM-dd';
         if (!!config['field_format_overwrite']) {
           dateFormat = !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['field_format'];
         }

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -57,19 +57,7 @@ EditorWidgetBase {
         }
       }
       if (main.isDateTimeType) {
-        // if the field is a QDate, the automatic conversion to JS date [1]
-        // leads to the creation of date time object with the time zone.
-        // For instance shapefiles has support for dates but not date/time or time.
-        // So a date coming from a shapefile as 2001-01-01 will become 2000-12-31 19:00:00 -05 in QML/JS (in the carribeans).
-        // And when formatting this with the display format, this is shown as 2000-12-31.
-        // So we detect if the field is a date only and revert the time zone offset.
-        // [1] http://doc.qt.io/qt-5/qtqml-cppintegration-data.html#basic-qt-data-types
-        if (main.fieldIsDate) {
-          const date = new Date(value);
-          return Qt.formatDateTime(new Date(date.getTime() + date.getTimezoneOffset() * 60000), displayFormat);
-        } else {
-          return Qt.formatDateTime(value, displayFormat);
-        }
+        return Qt.formatDateTime(value, displayFormat);
       } else {
         let dateFormat = config['display_format'] !== undefined ? config['display_format'] : '';
         if (!!config['field_format_overwrite']) {


### PR DESCRIPTION
When a date/time editor widget is tied to a string field, and the field overwrite format is not enabled, display format is _not_ used but instead a default yyy-MM-dd is applied. 

The fix also improves the logic determining whether to show the time control when opening the calendar popup. In some cases, we were showing it even though it was not needed.