### PR TITLE
Additional gallery relation editor fixes from Indiana Jones testing

### DIFF
--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -370,29 +370,29 @@ void ReferencingFeatureListModelBase::updateAttachmentFieldInfo()
   mAttachmentStorageUrl.clear();
 
   QgsVectorLayer *layer = mRelation.referencingLayer();
-  if ( !layer )
+  if ( layer )
   {
-    return;
-  }
-
-  for ( int i = 0; i < layer->fields().count(); i++ )
-  {
-    if ( layer->editorWidgetSetup( i ).type() == QLatin1String( "ExternalResource" ) )
+    for ( int i = 0; i < layer->fields().count(); i++ )
     {
-      const QVariantMap config = layer->editorWidgetSetup( i ).config();
-      mAttachmentFieldName = layer->fields().at( i ).name();
-      mAttachmentFieldIndex = i;
-      mAttachmentDocumentViewer = config.value( QStringLiteral( "DocumentViewer" ), 0 ).toInt();
-      mAttachmentStorageType = config.value( QStringLiteral( "StorageType" ) ).toString();
-      mAttachmentStorageAuthConfigId = config.value( QStringLiteral( "StorageAuthConfigId" ) ).toString();
-      mAttachmentStorageUrl = config.value( QStringLiteral( "StorageUrl" ) ).toString();
-      if ( !mAttachmentStorageUrl.isEmpty() && !mAttachmentStorageUrl.endsWith( QLatin1Char( '/' ) ) )
+      if ( layer->editorWidgetSetup( i ).type() == QLatin1String( "ExternalResource" ) )
       {
-        mAttachmentStorageUrl.append( QLatin1Char( '/' ) );
+        const QVariantMap config = layer->editorWidgetSetup( i ).config();
+        mAttachmentFieldName = layer->fields().at( i ).name();
+        mAttachmentFieldIndex = i;
+        mAttachmentDocumentViewer = config.value( QStringLiteral( "DocumentViewer" ), 0 ).toInt();
+        mAttachmentStorageType = config.value( QStringLiteral( "StorageType" ) ).toString();
+        mAttachmentStorageAuthConfigId = config.value( QStringLiteral( "StorageAuthConfigId" ) ).toString();
+        mAttachmentStorageUrl = config.value( QStringLiteral( "StorageUrl" ) ).toString();
+        if ( !mAttachmentStorageUrl.isEmpty() && !mAttachmentStorageUrl.endsWith( QLatin1Char( '/' ) ) )
+        {
+          mAttachmentStorageUrl.append( QLatin1Char( '/' ) );
+        }
+        break;
       }
-      break;
     }
   }
+
+  emit attachmentDetailsChanged();
 }
 
 bool ReferencingFeatureListModelBase::checkParentPrimaries()

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -45,11 +45,11 @@ class QFIELD_CORE_EXPORT ReferencingFeatureListModelBase : public QAbstractItemM
     Q_PROPERTY( QString currentNmRelationId WRITE setCurrentNmRelationId READ currentNmRelationId NOTIFY nmRelationChanged )
     Q_PROPERTY( QgsRelation nmRelation WRITE setNmRelation READ nmRelation NOTIFY nmRelationChanged )
     Q_PROPERTY( bool parentPrimariesAvailable WRITE setParentPrimariesAvailable READ parentPrimariesAvailable NOTIFY parentPrimariesAvailableChanged )
-    Q_PROPERTY( QString attachmentFieldName READ attachmentFieldName NOTIFY relationChanged )
-    Q_PROPERTY( int attachmentDocumentViewer READ attachmentDocumentViewer NOTIFY relationChanged )
-    Q_PROPERTY( QString attachmentStorageType READ attachmentStorageType NOTIFY relationChanged )
-    Q_PROPERTY( QString attachmentStorageAuthConfigId READ attachmentStorageAuthConfigId NOTIFY relationChanged )
-    Q_PROPERTY( QString attachmentStorageUrl READ attachmentStorageUrl NOTIFY relationChanged )
+    Q_PROPERTY( QString attachmentFieldName READ attachmentFieldName NOTIFY attachmentDetailsChanged )
+    Q_PROPERTY( int attachmentDocumentViewer READ attachmentDocumentViewer NOTIFY attachmentDetailsChanged )
+    Q_PROPERTY( QString attachmentStorageType READ attachmentStorageType NOTIFY attachmentDetailsChanged )
+    Q_PROPERTY( QString attachmentStorageAuthConfigId READ attachmentStorageAuthConfigId NOTIFY attachmentDetailsChanged )
+    Q_PROPERTY( QString attachmentStorageUrl READ attachmentStorageUrl NOTIFY attachmentDetailsChanged )
 
   public:
     explicit ReferencingFeatureListModelBase( QObject *parent = nullptr );
@@ -203,6 +203,7 @@ class QFIELD_CORE_EXPORT ReferencingFeatureListModelBase : public QAbstractItemM
     void featureChanged();
     void relationChanged();
     void nmRelationChanged();
+    void attachmentDetailsChanged();
     void parentPrimariesAvailableChanged();
     void isLoadingChanged();
     void beforeModelUpdated();

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -24,23 +24,23 @@ EditorWidgetBase {
   property string prefixToRelativePath: {
     if (qgisProject == undefined)
       return "";
-    var path = "";
+    let path = "";
     if (config["RelativeStorage"] === 1 || externalStorage.type != "") {
       path = qgisProject.homePath;
       if (!path.endsWith("/"))
         path = path + "/";
     } else if (config["RelativeStorage"] === 2) {
-      var collection = config["PropertyCollection"];
-      var props = collection["properties"];
+      const collection = config["PropertyCollection"];
+      const props = collection["properties"];
       if (props) {
         if (props["propertyRootPath"]) {
-          var rootPathProps = props["propertyRootPath"];
+          const rootPathProps = props["propertyRootPath"];
           rootPathEvaluator.expressionText = rootPathProps["expression"];
         }
       }
       rootPathEvaluator.feature = currentFeature;
       rootPathEvaluator.layer = currentLayer;
-      var evaluatedFilepath = rootPathEvaluator.evaluate().replace("\\", "/");
+      const evaluatedFilepath = rootPathEvaluator.evaluate().replace("\\", "/");
       if (evaluatedFilepath) {
         path = evaluatedFilepath;
       } else {
@@ -83,7 +83,7 @@ EditorWidgetBase {
   onCurrentValueChanged: {
     if (currentValue != undefined && currentValue !== '') {
       const isHttp = value.startsWith('http://') || value.startsWith('https://');
-      var fullValue = isHttp ? value : prefixToRelativePath + value;
+      const fullValue = isHttp ? value : prefixToRelativePath + value;
       if (!isHttp && !FileUtils.fileExists(fullValue)) {
         prepareValue("");
         if (externalStorage.type != "") {
@@ -115,7 +115,7 @@ EditorWidgetBase {
 
   function prepareValue(fullValue) {
     if (fullValue !== "") {
-      var mimeType = FileUtils.mimeTypeName(fullValue);
+      const mimeType = FileUtils.mimeTypeName(fullValue);
       isImage = !config.UseLink && mimeType.startsWith("image/") && FileUtils.isImageMimeTypeSupported(mimeType);
       isAudio = !config.UseLink && mimeType.startsWith("audio/");
       isVideo = !config.UseLink && mimeType.startsWith("video/");
@@ -553,10 +553,10 @@ EditorWidgetBase {
 
         text: {
           if (player.active && player.item.duration > 0) {
-            var seconds = Math.ceil(player.item.duration / 1000);
-            var hours = Math.floor(seconds / 60 / 60) + '';
+            let seconds = Math.ceil(player.item.duration / 1000);
+            let hours = Math.floor(seconds / 60 / 60) + '';
             seconds -= hours * 60 * 60;
-            var minutes = Math.floor(seconds / 60) + '';
+            let minutes = Math.floor(seconds / 60) + '';
             seconds = (seconds - minutes * 60) + '';
             return hours.padStart(2, '0') + ':' + minutes.padStart(2, '0') + ':' + seconds.padStart(2, '0');
           } else {
@@ -667,9 +667,6 @@ EditorWidgetBase {
 
       onFinished: path => {
         const filepath = StringUtils.replaceFilenameTags(getResourceFilePath(), path);
-        console.log("path " + path);
-        console.log("filepath " + filepath);
-        console.log("prefixToRelativePath + filepath " + prefixToRelativePath + filepath);
         platformUtilities.renameFile(path, prefixToRelativePath + filepath);
         valueChangeRequested(filepath, false);
         close();
@@ -729,7 +726,7 @@ EditorWidgetBase {
     target: __resourceSource
     function onResourceReceived(path) {
       if (path) {
-        var maximumWidhtHeight = iface.readProjectNumEntry("qfieldsync", "maximumImageWidthHeight", 0);
+        const maximumWidhtHeight = iface.readProjectNumEntry("qfieldsync", "maximumImageWidthHeight", 0);
         if (maximumWidhtHeight > 0) {
           FileUtils.restrictImageSize(prefixToRelativePath + path, maximumWidhtHeight);
         }
@@ -744,7 +741,7 @@ EditorWidgetBase {
     function onFinished() {
       if (isImage) {
         // In order to make sure the image shown reflects edits, reset the source
-        var imageSource = image.source;
+        const imageSource = image.source;
         image.source = '';
         image.source = imageSource;
       }
@@ -783,7 +780,7 @@ EditorWidgetBase {
   function attachFile() {
     Qt.inputMethod.hide();
     platformUtilities.requestStoragePermission();
-    var filepath = getResourceFilePath();
+    const filepath = getResourceFilePath();
     if (documentViewer == ExternalResource.DocumentAudio) {
       __resourceSource = platformUtilities.getFile(qgisProject.homePath + '/', filepath, "audio/*", this);
     } else {
@@ -794,7 +791,7 @@ EditorWidgetBase {
   function attachGallery() {
     Qt.inputMethod.hide();
     platformUtilities.requestStoragePermission();
-    var filepath = getResourceFilePath();
+    const filepath = getResourceFilePath();
     if (documentViewer == ExternalResource.DocumentVideo) {
       __resourceSource = platformUtilities.getGalleryVideo(qgisProject.homePath + '/', filepath, this);
     } else {
@@ -805,7 +802,7 @@ EditorWidgetBase {
   function capturePhoto() {
     Qt.inputMethod.hide();
     if (platformUtilities.capabilities & PlatformUtilities.NativeCamera && settings.valueBool("nativeCamera2", true)) {
-      var filepath = getResourceFilePath();
+      let filepath = getResourceFilePath();
       // Pictures taken by cameras will always be JPG
       filepath = filepath.replace('{extension}', 'JPG');
       __resourceSource = platformUtilities.getCameraPicture(qgisProject.homePath + '/', filepath, FileUtils.fileSuffix(filepath), this);
@@ -819,7 +816,7 @@ EditorWidgetBase {
   function captureVideo() {
     Qt.inputMethod.hide();
     if (platformUtilities.capabilities & PlatformUtilities.NativeCamera && settings.valueBool("nativeCamera2", true)) {
-      var filepath = getResourceFilePath();
+      let filepath = getResourceFilePath();
       // Video taken by cameras will always be MP4
       filepath = filepath.replace('{extension}', 'MP4');
       __resourceSource = platformUtilities.getCameraVideo(qgisProject.homePath + '/', filepath, FileUtils.fileSuffix(filepath), this);

--- a/src/qml/editorwidgets/ExternalResourceUtils.js
+++ b/src/qml/editorwidgets/ExternalResourceUtils.js
@@ -7,7 +7,7 @@
  */
 function getAttachmentNaming(layer, fieldName) {
   if (layer && fieldName) {
-    var value;
+    let value;
     if (layer.customProperty('QFieldSync/attachment_naming') !== undefined) {
       value = JSON.parse(layer.customProperty('QFieldSync/attachment_naming'))[fieldName];
       return value !== undefined ? value : '';
@@ -28,10 +28,10 @@ function getAttachmentNaming(layer, fieldName) {
  * (0 = file, 1 = image, 3 = audio, 4 = video).
  */
 function getAttachmentFilePath(evaluatedFilepath, documentViewer, FileUtils) {
-  var filepath = FileUtils.sanitizeFilePath(evaluatedFilepath);
+  let filepath = FileUtils.sanitizeFilePath(evaluatedFilepath);
 
   if (FileUtils.fileSuffix(filepath) === '' && !filepath.endsWith("{extension}") && !filepath.endsWith("{filename}")) {
-    var nowStr = (new Date()).toISOString().replace(/[^0-9]/g, '');
+    let nowStr = (new Date()).toISOString().replace(/[^0-9]/g, '');
 
     if (documentViewer === 1) {
       // DocumentImage

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -431,16 +431,18 @@ RelationEditorBase {
     if (geometry !== undefined) {
       embeddedPopup.applyGeometry(geometry);
     }
-    if (attachmentPath !== undefined && attachmentPath !== "") {
-      if (embeddedPopup.attributeFormModel.featureModel.suppressFeatureForm()) {
-        embeddedPopup.featureModel.resetAttributes();
-        embeddedPopup.attributeFormModel.changeAttribute(referencingFeatureListModel.attachmentFieldName, attachmentPath);
-        embeddedPopup.confirmForm();
-        return;
-      }
+
+    const hasAttachmentPath = attachmentPath !== undefined && attachmentPath !== "";
+    if (hasAttachmentPath && embeddedPopup.attributeFormModel.featureModel.suppressFeatureForm()) {
+      embeddedPopup.featureModel.resetAttributes();
       embeddedPopup.attributeFormModel.changeAttribute(referencingFeatureListModel.attachmentFieldName, attachmentPath);
+      embeddedPopup.confirmForm();
+      return;
     }
     embeddedPopup.open();
+    if (hasAttachmentPath) {
+      embeddedPopup.attributeFormModel.changeAttribute(referencingFeatureListModel.attachmentFieldName, attachmentPath);
+    }
   }
 
   function openFeatureForm(feature, nmFeature) {

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -226,11 +226,6 @@ RelationEditorBase {
     layer: referencingFeatureListModel.relation ? referencingFeatureListModel.relation.referencingLayer : null
     project: qgisProject
     appExpressionContextScopesGenerator: appScopesGenerator
-    expressionText: {
-      let refLayer = referencingFeatureListModel.relation ? referencingFeatureListModel.relation.referencingLayer : null;
-      let fieldName = referencingFeatureListModel.attachmentFieldName;
-      return ExternalResourceUtils.getAttachmentNaming(refLayer, fieldName);
-    }
   }
 
   function capturePhoto() {
@@ -238,6 +233,7 @@ RelationEditorBase {
     Qt.inputMethod.hide();
     prepareFeature();
     platformUtilities.createDir(qgisProject.homePath, 'DCIM');
+    attachmentNamingEvaluator.expressionText = ExternalResourceUtils.getAttachmentNaming(referencingFeatureListModel.relation ? referencingFeatureListModel.relation.referencingLayer : null, referencingFeatureListModel.attachmentFieldName);
     if (platformUtilities.capabilities & PlatformUtilities.NativeCamera && settings.valueBool("nativeCamera2", true)) {
       let filepath = ExternalResourceUtils.getAttachmentFilePath(attachmentNamingEvaluator.evaluate(), documentViewer, FileUtils);
       filepath = filepath.replace('{extension}', 'JPG');
@@ -253,6 +249,7 @@ RelationEditorBase {
     Qt.inputMethod.hide();
     prepareFeature();
     platformUtilities.createDir(qgisProject.homePath, 'DCIM');
+    attachmentNamingEvaluator.expressionText = ExternalResourceUtils.getAttachmentNaming(referencingFeatureListModel.relation ? referencingFeatureListModel.relation.referencingLayer : null, referencingFeatureListModel.attachmentFieldName);
     if (platformUtilities.capabilities & PlatformUtilities.NativeCamera && settings.valueBool("nativeCamera2", true)) {
       let filepath = ExternalResourceUtils.getAttachmentFilePath(attachmentNamingEvaluator.evaluate(), documentViewer, FileUtils);
       filepath = filepath.replace('{extension}', 'MP4');
@@ -267,6 +264,7 @@ RelationEditorBase {
     stopAllMedia();
     Qt.inputMethod.hide();
     prepareFeature();
+    attachmentNamingEvaluator.expressionText = ExternalResourceUtils.getAttachmentNaming(referencingFeatureListModel.relation ? referencingFeatureListModel.relation.referencingLayer : null, referencingFeatureListModel.attachmentFieldName);
     relationAudioRecorderLoader.active = true;
   }
 


### PR DESCRIPTION
Two fixes in there:
- Captured photo/video were not attached to the forms when they were not suppressed
- User-defined expression to determine the attachment filename were ignored

I've converted a bunch of var to let/const too, that's just a bit of housecleaning, nothing more.