### PR TITLE
Hide attachment child layer from the legend

### DIFF
--- a/src/core/utils/projectutils.cpp
+++ b/src/core/utils/projectutils.cpp
@@ -308,6 +308,9 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
       attachmentsLayer->setEditFormConfig( attachFormConfig );
       attachmentsLayer->setCustomProperty( QStringLiteral( "QFieldSync/cloud_action" ), QStringLiteral( "offline" ) );
       attachmentsLayer->setCustomProperty( QStringLiteral( "QFieldSync/action" ), QStringLiteral( "offline" ) );
+
+      attachmentsLayer->setFlags( attachmentsLayer->flags() | QgsMapLayer::Private );
+
       createdProjectLayers << attachmentsLayer;
 
       QgsEditFormConfig notesFormConfig = notesLayer->editFormConfig();


### PR DESCRIPTION
As the title suggests, here the notes_attachments layer is backing storage for the gallery relation editor, not a user facing dataset. Setting QgsMapLayer::Private hides it from the layer tree and legend while keeping it fully functional through the relation manager