### PR TITLE
Save and restore QFieldCloud server cookies across app launches

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfieldcloudconnection.cpp
@@ -72,6 +72,13 @@ QFieldCloudConnection::QFieldCloudConnection()
                tryFlushQueuedProjectPushes();
              } );
   }
+
+  restoreCookies();
+}
+
+QFieldCloudConnection::~QFieldCloudConnection()
+{
+  saveCookies();
 }
 
 void QFieldCloudConnection::queueProjectPush( const QString &projectId )
@@ -438,7 +445,6 @@ void QFieldCloudConnection::login( const QString &password )
     }
 
     QByteArray token = resp.value( QStringLiteral( "token" ) ).toString().toUtf8();
-
     if ( !token.isEmpty() )
     {
       setToken( token );
@@ -461,6 +467,9 @@ void QFieldCloudConnection::login( const QString &password )
       settings.setValue( QStringLiteral( "/QFieldCloud/urls" ), savedUrls );
       emit urlsChanged();
     }
+
+    saveCookies();
+
     setStatus( ConnectionStatus::LoggedIn );
   } );
 }
@@ -497,6 +506,7 @@ void QFieldCloudConnection::logout()
   {
     QgsNetworkAccessManager::instance()->cookieJar()->deleteCookie( cookie );
   }
+  saveCookies();
 
   setStatus( ConnectionStatus::Disconnected );
 }
@@ -1057,4 +1067,36 @@ void QFieldCloudConnection::processPendingAttachments()
     break;
   }
   return;
+}
+
+void QFieldCloudConnection::restoreCookies()
+{
+  QSettings settings;
+  settings.beginGroup( "/QFieldCloud/cookies" );
+  const QStringList cookieKeys = settings.childKeys();
+  for ( const QString &cookieKey : cookieKeys )
+  {
+    QList<QNetworkCookie> cookies = QNetworkCookie::parseCookies( settings.value( cookieKey ).toByteArray() );
+    if ( !cookies.isEmpty() )
+    {
+      if ( QDateTime::currentSecsSinceEpoch() < cookies[0].expirationDate().toSecsSinceEpoch() )
+      {
+        QgsNetworkAccessManager::instance()->cookieJar()->insertCookie( cookies[0] );
+      }
+    }
+  }
+}
+
+void QFieldCloudConnection::saveCookies()
+{
+  QSettings settings;
+  settings.remove( QStringLiteral( "/QFieldCloud/cookies" ) );
+  const QList<QNetworkCookie> cookies = QgsNetworkAccessManager::instance()->cookieJar()->cookiesForUrl( mUrl );
+  for ( int idx = 0; idx < cookies.count(); idx++ )
+  {
+    if ( !cookies[idx].isSessionCookie() && QDateTime::currentSecsSinceEpoch() < cookies[idx].expirationDate().toSecsSinceEpoch() )
+    {
+      settings.setValue( QStringLiteral( "/QFieldCloud/cookies/%1" ), cookies[idx].toRawForm() );
+    }
+  }
 }

--- a/src/core/qfieldcloud/qfieldcloudconnection.h
+++ b/src/core/qfieldcloud/qfieldcloudconnection.h
@@ -87,7 +87,6 @@ class QFieldCloudConnection : public QObject
     Q_PROPERTY( bool isFetchingAvailableProviders READ isFetchingAvailableProviders NOTIFY isFetchingAvailableProvidersChanged )
     Q_PROPERTY( bool isReachable READ isReachable NOTIFY isReachableChanged )
 
-
   public:
     enum class ConnectionStatus
     {
@@ -123,6 +122,7 @@ class QFieldCloudConnection : public QObject
     };
 
     QFieldCloudConnection();
+    ~QFieldCloudConnection();
 
     //!Returns an error string to be shown to the user if \a reply has an error.
     static QString errorString( QNetworkReply *reply );
@@ -273,6 +273,9 @@ class QFieldCloudConnection : public QObject
     void setToken( const QByteArray &token );
     void invalidateToken();
     void processPendingAttachments();
+
+    void saveCookies();
+    void restoreCookies();
 
     QString mUrl;
 


### PR DESCRIPTION
This PR adds a QFieldCloud server cookies saving/restoring mechanism to insure the crucial sessionid cookie is carried on when restarting QField. This should fix user reporting SSO login issues such as https://github.com/opengisch/QField/issues/7187 .

This lack of cookie saving/restoring (prior to this PR) has implication beyond login too. For e.g., I'm pretty certain attachment uploads would simply _not_ work with SSO.

Overall, glad we've woken up to this!

<img width="480" height="360" alt="giphy" src="https://github.com/user-attachments/assets/88ebf702-40c0-450a-ae36-48809d73ebbe" />

@lukasgraf , as discussed yesterday. 