### PR TITLE
Improve android artifact naming to avoid countless duplicates when downloading artifacts

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -196,14 +196,20 @@ jobs:
           STOREPASS: ${{ secrets.STOREPASS }}
         run: |
           cmake --build  "${{ env.CMAKE_BUILD_DIR }}" --target bundle --config Release
+          if [ -f "${{ env.CMAKE_BUILD_DIR }}/src/app/android-build/build/outputs/apk/release/android-build-release-signed.apk" ]; then
+            cp ${{ env.CMAKE_BUILD_DIR }}/src/app/android-build/build/outputs/apk/release/android-build-release-signed.apk /tmp/${{ env.CI_PACKAGE_NAME }}-${{ env.CI_PACKAGE_FILE_SUFFIX }}-${{ matrix.artifact_name }}.apk
+          fi
+          if [ -f "${{ env.CMAKE_BUILD_DIR }}/src/app/android-build/build/outputs/apk/debug/android-build-debug.apk" ]; then
+            cp ${{ env.CMAKE_BUILD_DIR }}/src/app/android-build/build/outputs/apk/debug/android-build-debug.apk /tmp/${{ env.CI_PACKAGE_NAME }}-${{ env.CI_PACKAGE_FILE_SUFFIX }}-${{ matrix.artifact_name }}-debug.apk
+          fi
 
       - name: 📦 Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ env.APP_PACKAGE_NAME }}-${{ matrix.triplet }}
+          name: ${{ env.CI_PACKAGE_NAME }}-${{ env.CI_PACKAGE_FILE_SUFFIX }}-${{ matrix.artifact_name }}
           path: |
-            ${{ env.CMAKE_BUILD_DIR }}/src/app/android-build/build/outputs/apk/release/android-build-release-signed.apk
-            ${{ env.CMAKE_BUILD_DIR }}/src/app/android-build/build/outputs/apk/debug/android-build-debug.apk
+            /tmp/${{ env.CI_PACKAGE_NAME }}-${{ env.CI_PACKAGE_FILE_SUFFIX }}-${{ matrix.artifact_name }}.apk
+            /tmp/${{ env.CI_PACKAGE_NAME }}-${{ env.CI_PACKAGE_FILE_SUFFIX }}-${{ matrix.artifact_name }}-debug.apk
 
       - name: 🍺 Deploy
         run: |
@@ -296,18 +302,18 @@ jobs:
           marker: android
           body: |
             ### 📱 Android builds
-            Download an [Android arm64 build of this PR for testing](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield${{ env.APP_PACKAGE_NAME_SUFFIX }}-arm64-android.zip).
+            Download an [Android arm64 build of this PR for testing](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm64.zip).
             *(Built from commit ${{ github.event.pull_request.head.sha }})*
             <details>
             <summary>Other Android architectures</summary>
 
-            - [arm-neon](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield${{ env.APP_PACKAGE_NAME_SUFFIX }}-arm-neon-android.zip)
-            - [x64](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield${{ env.APP_PACKAGE_NAME_SUFFIX }}-x64-android.zip)
-            - [x86](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield${{ env.APP_PACKAGE_NAME_SUFFIX }}-x86-android.zip)
-            - [**all access arm64**](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield_all_access${{ env.APP_PACKAGE_NAME_SUFFIX }}-arm64-android.zip)
-            - [all access arm-neon](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield_all_access${{ env.APP_PACKAGE_NAME_SUFFIX }}-arm-neon-android.zip)
-            - [all access x64](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield_all_access${{ env.APP_PACKAGE_NAME_SUFFIX }}-x64-android.zip)
-            - [all access x86](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield_all_access${{ env.APP_PACKAGE_NAME_SUFFIX }}-x86-android.zip)
+            - [arm-neon](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm-neon.zip)
+            - [x64](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x64.zip)
+            - [x86](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x86.zip)
+            - [**all access arm64**](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm64.zip)
+            - [all access arm-neon](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-arm-neon.zip)
+            - [all access x64](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x64.zip)
+            - [all access x86](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/qfield_all_access-${{ env.CI_PACKAGE_FILE_SUFFIX }}-android-x86.zip)
             </details>
           pr: ${{ github.event.number }}
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -195,14 +195,13 @@ jobs:
           cmake --build  "build" --target bundle --config ${{ env.BUILD_TYPE }}
           echo "ARTIFACT_PATHNAME=build/QField-x86_64.AppImage" >> $GITHUB_ENV
           echo "ARTIFACT_NAME=qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-linux-x64.AppImage" >> $GITHUB_ENV
-          echo "ARTIFACT_PACKAGE_NAME=QField-dev-x64-linux-${{ env.BUILD_TYPE }}" >> $GITHUB_ENV
 
       - name: 📦 Upload package
         if: ${{ env.ARTIFACT_NAME != null }}
         uses: actions/upload-artifact@v7
         id: artifact-linux
         with:
-          name: ${{ env.ARTIFACT_PACKAGE_NAME }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.ARTIFACT_PATHNAME }}
 
       - name: 🧫 Test
@@ -296,6 +295,6 @@ jobs:
           marker: linux
           body: |
             ### 🐧 Linux AppImage builds
-            Download a [Linux AppImage build of this PR for testing](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/${{ env.ARTIFACT_PACKAGE_NAME }}.zip).
+            Download a [Linux AppImage build of this PR for testing](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/${{ env.ARTIFACT_NAME }}.zip).
             *(Built from commit ${{ github.event.pull_request.head.sha }})*
           pr: ${{ github.event.number }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -196,7 +196,7 @@ jobs:
           echo "ARTIFACT_PATHNAME=build/QField-x86_64.AppImage" >> $GITHUB_ENV
           echo "ARTIFACT_NAME=qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-linux-x64.AppImage" >> $GITHUB_ENV
 
-      - name: 📦 Upload package
+      - name: 📦 Upload artifacts
         if: ${{ env.ARTIFACT_NAME != null }}
         uses: actions/upload-artifact@v7
         id: artifact-linux

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -219,7 +219,7 @@ jobs:
 
           echo "ARTIFACT_PACKAGE_NAME=qfield-dmg" >> $GITHUB_ENV
 
-      - name: 📤 Upload app
+      - name: 📦 Upload artifacts
         uses: actions/upload-artifact@v7
         id: artifact-macos
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -143,7 +143,6 @@ jobs:
           ARTIFACT_NAME=$(basename $ARTIFACT_PATHNAME)
           echo "ARTIFACT_PATHNAME=${ARTIFACT_PATHNAME}" >> $GITHUB_ENV
           echo "ARTIFACT_NAME=qfield-${{ env.CI_PACKAGE_FILE_SUFFIX }}-windows-x64.${INSTALLER_SUFFIX}" >> $GITHUB_ENV
-          echo "ARTIFACT_PACKAGE_NAME=QField-dev-x64-windows-static-${{ env.BUILD_TYPE }}" >> $GITHUB_ENV
 
           echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
 
@@ -172,12 +171,12 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
 
-      - name: 📦 Upload package
+      - name: 📦 Upload artifacts
         if: ${{ env.ARTIFACT_NAME != null }}
         uses: actions/upload-artifact@v7
         id: artifact-windows
         with:
-          name: ${{ env.ARTIFACT_PACKAGE_NAME }}
+          name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.ARTIFACT_PATHNAME }}
 
       - name: 📊 Upload test report
@@ -227,7 +226,7 @@ jobs:
           marker: windows
           body: |
             ### 🪟 Windows builds
-            Download a [Windows build of this PR for testing](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/${{ env.ARTIFACT_PACKAGE_NAME }}.zip).
+            Download a [Windows build of this PR for testing](https://nightly.link/opengisch/QField/actions/runs/${{ github.run_id }}/${{ env.ARTIFACT_NAME }}.zip).
             *(Built from commit ${{ github.event.pull_request.head.sha }})*
           pr: ${{ github.event.number }}
 

--- a/scripts/ci/upload_artifacts.sh
+++ b/scripts/ci/upload_artifacts.sh
@@ -17,7 +17,9 @@ if [[ "${S3CFG}" ]]; then
 	#s3cmd modify --add-header=content-type:application/octet-stream s3://qfieldapks/ci-builds/${FILENAME_AAB}
 	#echo -e "\e[31mcontent-type modified \e[0m"
 
-	mv ${CMAKE_BUILD_DIR}/src/app/android-build/build/outputs/apk/release/android-build-release-signed.apk /tmp/${FILENAME_APK}
+	# APK already copied to /tmp/
+	#mv ${CMAKE_BUILD_DIR}/src/app/android-build/build/outputs/apk/release/android-build-release-signed.apk /tmp/${FILENAME_APK}
+
 	echo "${S3CFG}" >~/.s3cfg
 	s3cmd put --acl-public -m 'application/vnd.android.package-archive' /tmp/${FILENAME_APK} s3://qfieldapks/ci-builds/${FILENAME_APK}
 	echo -e "\e[31mUploaded to https://sos-ch-dk-2.exo.io/qfieldapks/ci-builds/${FILENAME_APK} \e[0m"


### PR DESCRIPTION
This aims at fixing one of the few usability regression following our move to serving APKs through github artifacts: the artifact / APK filename.

Our artifacts had hyper-generic filenames shared across all PRs. This meant that if you download an artifact, you have no clue what commit it is tied to until you install the APK and go to the About QField overlay. It also resulted in a download directory that looked like this:

qfield-dev.zip
qfield-dev(1).zip
qfield-dev(2).zip
qfield-dev(3).zip
qfield-dev(4).zip
...

Let's fix that :)