### PR TITLE
Compensate for incorrect camera orientation on affected iOS and Android devices

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -74,6 +74,7 @@ set(QFIELD_CORE_SRCS
     badlayerhandler.cpp
     bookmarkmodel.cpp
     clipboardmanager.cpp
+    cameraorientationnormalizer.cpp
     changelogcontents.cpp
     digitizinglogger.cpp
     distancearea.cpp
@@ -220,6 +221,7 @@ set(QFIELD_CORE_HDRS
     badlayerhandler.h
     bookmarkmodel.h
     clipboardmanager.h
+    cameraorientationnormalizer.h
     changelogcontents.h
     digitizinglogger.h
     distancearea.h

--- a/src/core/cameraorientationnormalizer.cpp
+++ b/src/core/cameraorientationnormalizer.cpp
@@ -1,0 +1,140 @@
+/***************************************************************************
+  cameraorientationnormalizer.cpp - CameraOrientationNormalizer
+
+ ---------------------
+ begin                : 16.4.2026
+ copyright            : (C) 2026 by Kaustuv Pokharel
+ email                : kaustuv@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "cameraorientationnormalizer.h"
+
+#include <QGuiApplication>
+#include <QImage>
+#include <QImageReader>
+#include <QImageWriter>
+#include <QScreen>
+#include <QTransform>
+
+CameraOrientationNormalizer::CameraOrientationNormalizer( QObject *parent )
+  : QObject( parent )
+{
+  QScreen *screen = QGuiApplication::primaryScreen();
+  if ( screen )
+  {
+    mCurrentOrientation = screen->orientation();
+    connect( screen, &QScreen::orientationChanged, this, &CameraOrientationNormalizer::handleScreenOrientationChanged );
+  }
+}
+
+int CameraOrientationNormalizer::previewRotation() const
+{
+  return mPreviewRotation;
+}
+
+void CameraOrientationNormalizer::setCamera( const QCameraDevice &device )
+{
+  mCameraDevice = device;
+  mIsFrontCamera = !device.isNull() && device.position() == QCameraDevice::FrontFace;
+  mSensorAngle = device.isNull() ? 0 : static_cast<int>( device.correctionAngle() );
+  updatePreviewRotation();
+}
+
+void CameraOrientationNormalizer::recordCaptureOrientation()
+{
+  QScreen *screen = QGuiApplication::primaryScreen();
+  mCaptureOrientation = screen ? screen->orientation() : Qt::PortraitOrientation;
+}
+
+bool CameraOrientationNormalizer::normalizeImageOrientation( const QString &path )
+{
+  if ( path.isEmpty() )
+  {
+    return false;
+  }
+
+  QImageReader reader( path );
+  reader.setAutoTransform( false );
+  const QImageIOHandler::Transformations exifTransform = reader.transformation();
+  QImage image = reader.read();
+  if ( image.isNull() )
+  {
+    return false;
+  }
+
+  const bool capturedInLandscape = ( mCaptureOrientation == Qt::LandscapeOrientation || mCaptureOrientation == Qt::InvertedLandscapeOrientation );
+  const bool pixelsAreLandscape = image.width() > image.height();
+  const bool needsRotation = ( capturedInLandscape != pixelsAreLandscape );
+  const bool hasExifTag = ( exifTransform != QImageIOHandler::TransformationNone );
+
+  if ( !needsRotation && !hasExifTag )
+  {
+    return false;
+  }
+
+  if ( needsRotation )
+  {
+    QTransform transform;
+    transform.rotate( pixelsAreLandscape ? 90 : 270 );
+    image = image.transformed( transform, Qt::SmoothTransformation );
+  }
+
+  QImageWriter writer( path );
+  writer.setTransformation( QImageIOHandler::TransformationNone );
+  writer.setQuality( 95 );
+  return writer.write( image );
+}
+
+void CameraOrientationNormalizer::handleScreenOrientationChanged( Qt::ScreenOrientation orientation )
+{
+  if ( mCurrentOrientation == orientation )
+  {
+    return;
+  }
+
+  mCurrentOrientation = orientation;
+  updatePreviewRotation();
+}
+
+void CameraOrientationNormalizer::updatePreviewRotation()
+{
+#if defined( Q_OS_ANDROID ) || defined( Q_OS_IOS )
+  const QScreen *screen = QGuiApplication::primaryScreen();
+  if ( !screen )
+  {
+    return;
+  }
+
+  const int screenAngle = screen->angleBetween( screen->nativeOrientation(), mCurrentOrientation );
+  int rotation = 0;
+
+  if ( mSensorAngle == 0 )
+  {
+    // iOS: AVFoundation reports sensorAngle 0 and handles rotation
+    // internally, but produces an inverted preview in landscape
+    const bool isLandscape = ( screenAngle == 90 || screenAngle == 270 );
+    rotation = isLandscape ? 180 : 0;
+  }
+  else if ( mIsFrontCamera )
+  {
+    rotation = ( 360 - mSensorAngle + screenAngle ) % 360;
+  }
+  else
+  {
+    rotation = ( mSensorAngle - screenAngle + 360 ) % 360;
+  }
+
+  if ( rotation != mPreviewRotation )
+  {
+    mPreviewRotation = rotation;
+    emit previewRotationChanged();
+  }
+#endif
+}

--- a/src/core/cameraorientationnormalizer.cpp
+++ b/src/core/cameraorientationnormalizer.cpp
@@ -47,6 +47,7 @@ void CameraOrientationNormalizer::recordCaptureOrientation()
 
 bool CameraOrientationNormalizer::normalizeImageOrientation( const QString &path )
 {
+#if defined( Q_OS_IOS ) || defined( Q_OS_WIN )
   if ( path.isEmpty() )
   {
     return false;
@@ -82,6 +83,10 @@ bool CameraOrientationNormalizer::normalizeImageOrientation( const QString &path
   writer.setTransformation( QImageIOHandler::TransformationNone );
   writer.setQuality( 95 );
   return writer.write( image );
+#else
+  Q_UNUSED( path )
+  return false;
+#endif
 }
 
 void CameraOrientationNormalizer::handleScreenOrientationChanged( Qt::ScreenOrientation orientation )
@@ -97,7 +102,7 @@ void CameraOrientationNormalizer::handleScreenOrientationChanged( Qt::ScreenOrie
 
 void CameraOrientationNormalizer::updatePreviewRotation()
 {
-#if defined( Q_OS_IOS )
+#if defined( Q_OS_IOS ) || defined( Q_OS_WIN )
   const QScreen *screen = QGuiApplication::primaryScreen();
   if ( !screen )
   {

--- a/src/core/cameraorientationnormalizer.cpp
+++ b/src/core/cameraorientationnormalizer.cpp
@@ -39,14 +39,6 @@ int CameraOrientationNormalizer::previewRotation() const
   return mPreviewRotation;
 }
 
-void CameraOrientationNormalizer::setCamera( const QCameraDevice &device )
-{
-  mCameraDevice = device;
-  mIsFrontCamera = !device.isNull() && device.position() == QCameraDevice::FrontFace;
-  mSensorAngle = device.isNull() ? 0 : static_cast<int>( device.correctionAngle() );
-  updatePreviewRotation();
-}
-
 void CameraOrientationNormalizer::recordCaptureOrientation()
 {
   QScreen *screen = QGuiApplication::primaryScreen();
@@ -105,7 +97,7 @@ void CameraOrientationNormalizer::handleScreenOrientationChanged( Qt::ScreenOrie
 
 void CameraOrientationNormalizer::updatePreviewRotation()
 {
-#if defined( Q_OS_ANDROID ) || defined( Q_OS_IOS )
+#if defined( Q_OS_IOS )
   const QScreen *screen = QGuiApplication::primaryScreen();
   if ( !screen )
   {
@@ -113,23 +105,8 @@ void CameraOrientationNormalizer::updatePreviewRotation()
   }
 
   const int screenAngle = screen->angleBetween( screen->nativeOrientation(), mCurrentOrientation );
-  int rotation = 0;
-
-  if ( mSensorAngle == 0 )
-  {
-    // iOS: AVFoundation reports sensorAngle 0 and handles rotation
-    // internally, but produces an inverted preview in landscape
-    const bool isLandscape = ( screenAngle == 90 || screenAngle == 270 );
-    rotation = isLandscape ? 180 : 0;
-  }
-  else if ( mIsFrontCamera )
-  {
-    rotation = ( 360 - mSensorAngle + screenAngle ) % 360;
-  }
-  else
-  {
-    rotation = ( mSensorAngle - screenAngle + 360 ) % 360;
-  }
+  const bool isLandscape = ( screenAngle == 90 || screenAngle == 270 );
+  const int rotation = isLandscape ? 180 : 0;
 
   if ( rotation != mPreviewRotation )
   {

--- a/src/core/cameraorientationnormalizer.h
+++ b/src/core/cameraorientationnormalizer.h
@@ -1,0 +1,85 @@
+/***************************************************************************
+  cameraorientationnormalizer.h - CameraOrientationNormalizer
+
+---------------------
+begin                : 16.4.2026
+copyright            : (C) 2026 by Kaustuv Pokharel
+email                : kaustuv@opengis.ch
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef CAMERAORIENTATIONNORMALIZER_H
+#define CAMERAORIENTATIONNORMALIZER_H
+
+#include <QCameraDevice>
+#include <QObject>
+
+/**
+ * \brief Camera orientation normalizer for preview and captured photos.
+ *
+ * On iOS and certain Android devices, Qt Multimedia's backend produces
+ * rotated camera preview and writes captured images with incorrect
+ * orientation. This class provides:
+ *
+ *  \a previewRotation for correcting the live VideoOutput orientation
+ *  \a normalizeImageOrientation() for correcting saved JPEG files
+ *
+ * \ingroup core
+ */
+class CameraOrientationNormalizer : public QObject
+{
+  Q_OBJECT
+
+  Q_PROPERTY( int previewRotation READ previewRotation NOTIFY previewRotationChanged )
+
+public:
+  explicit CameraOrientationNormalizer( QObject *parent = nullptr );
+
+  int previewRotation() const;
+
+  /**
+   * Sets the active camera device. Call when the camera is first
+   * activated and when the user switches cameras.
+   */
+  Q_INVOKABLE void setCamera( const QCameraDevice &device );
+
+  /**
+   * Records the current screen orientation. Call at shutter press
+   * so that normalizeImageOrientation() has a ground-truth reference.
+   */
+  Q_INVOKABLE void recordCaptureOrientation();
+
+  /**
+   * Ensures the JPEG at \a path has pixels matching the orientation
+   * recorded by recordCaptureOrientation(). Rotates the image if
+   * pixel dimensions contradict the capture orientation and strips
+   * any non-identity EXIF orientation tag.
+   *
+   * Returns false without touching the file when no correction is needed.
+   */
+  Q_INVOKABLE bool normalizeImageOrientation( const QString &path );
+
+signals:
+  void previewRotationChanged();
+
+private slots:
+  void handleScreenOrientationChanged( Qt::ScreenOrientation orientation );
+
+private:
+  void updatePreviewRotation();
+
+  QCameraDevice mCameraDevice;
+  int mSensorAngle = 0;
+  bool mIsFrontCamera = false;
+  Qt::ScreenOrientation mCurrentOrientation = Qt::PortraitOrientation;
+  Qt::ScreenOrientation mCaptureOrientation = Qt::PortraitOrientation;
+  int mPreviewRotation = 0;
+};
+
+#endif // CAMERAORIENTATIONNORMALIZER_H

--- a/src/core/cameraorientationnormalizer.h
+++ b/src/core/cameraorientationnormalizer.h
@@ -17,13 +17,12 @@ email                : kaustuv@opengis.ch
 #ifndef CAMERAORIENTATIONNORMALIZER_H
 #define CAMERAORIENTATIONNORMALIZER_H
 
-#include <QCameraDevice>
 #include <QObject>
 
 /**
- * \brief Compensates for incorrect camera orientation on iOS devices.
+ * \brief Compensates for incorrect camera orientation on iOS and Windows.
  *
- * On iOS, Qt Multimedia's AVFoundation backend produces an inverted
+ * On iOS and Windows, Qt Multimedia's backend produces an inverted
  * camera preview in landscape mode and writes captured photos with
  * incorrect orientation or bogus EXIF tags (QTBUG-118594).
  *

--- a/src/core/cameraorientationnormalizer.h
+++ b/src/core/cameraorientationnormalizer.h
@@ -34,28 +34,28 @@ email                : kaustuv@opengis.ch
  */
 class CameraOrientationNormalizer : public QObject
 {
-  Q_OBJECT
+    Q_OBJECT
 
-  Q_PROPERTY( int previewRotation READ previewRotation NOTIFY previewRotationChanged )
+    Q_PROPERTY( int previewRotation READ previewRotation NOTIFY previewRotationChanged )
 
-public:
-  explicit CameraOrientationNormalizer( QObject *parent = nullptr );
+  public:
+    explicit CameraOrientationNormalizer( QObject *parent = nullptr );
 
-  int previewRotation() const;
+    int previewRotation() const;
 
-  /**
+    /**
    * Sets the active camera device. Call when the camera is first
    * activated and when the user switches cameras.
    */
-  Q_INVOKABLE void setCamera( const QCameraDevice &device );
+    Q_INVOKABLE void setCamera( const QCameraDevice &device );
 
-  /**
+    /**
    * Records the current screen orientation. Call at shutter press
    * so that normalizeImageOrientation() has a ground-truth reference.
    */
-  Q_INVOKABLE void recordCaptureOrientation();
+    Q_INVOKABLE void recordCaptureOrientation();
 
-  /**
+    /**
    * Ensures the JPEG at \a path has pixels matching the orientation
    * recorded by recordCaptureOrientation(). Rotates the image if
    * pixel dimensions contradict the capture orientation and strips
@@ -63,23 +63,23 @@ public:
    *
    * Returns false without touching the file when no correction is needed.
    */
-  Q_INVOKABLE bool normalizeImageOrientation( const QString &path );
+    Q_INVOKABLE bool normalizeImageOrientation( const QString &path );
 
-signals:
-  void previewRotationChanged();
+  signals:
+    void previewRotationChanged();
 
-private slots:
-  void handleScreenOrientationChanged( Qt::ScreenOrientation orientation );
+  private slots:
+    void handleScreenOrientationChanged( Qt::ScreenOrientation orientation );
 
-private:
-  void updatePreviewRotation();
+  private:
+    void updatePreviewRotation();
 
-  QCameraDevice mCameraDevice;
-  int mSensorAngle = 0;
-  bool mIsFrontCamera = false;
-  Qt::ScreenOrientation mCurrentOrientation = Qt::PortraitOrientation;
-  Qt::ScreenOrientation mCaptureOrientation = Qt::PortraitOrientation;
-  int mPreviewRotation = 0;
+    QCameraDevice mCameraDevice;
+    int mSensorAngle = 0;
+    bool mIsFrontCamera = false;
+    Qt::ScreenOrientation mCurrentOrientation = Qt::PortraitOrientation;
+    Qt::ScreenOrientation mCaptureOrientation = Qt::PortraitOrientation;
+    int mPreviewRotation = 0;
 };
 
 #endif // CAMERAORIENTATIONNORMALIZER_H

--- a/src/core/cameraorientationnormalizer.h
+++ b/src/core/cameraorientationnormalizer.h
@@ -21,12 +21,13 @@ email                : kaustuv@opengis.ch
 #include <QObject>
 
 /**
- * \brief Camera orientation normalizer for preview and captured photos.
+ * \brief Compensates for incorrect camera orientation on iOS devices.
  *
- * On iOS and certain Android devices, Qt Multimedia's backend produces
- * rotated camera preview and writes captured images with incorrect
- * orientation. This class provides:
+ * On iOS, Qt Multimedia's AVFoundation backend produces an inverted
+ * camera preview in landscape mode and writes captured photos with
+ * incorrect orientation or bogus EXIF tags (QTBUG-118594).
  *
+ * This class provides:
  *  \a previewRotation for correcting the live VideoOutput orientation
  *  \a normalizeImageOrientation() for correcting saved JPEG files
  *
@@ -44,25 +45,19 @@ class CameraOrientationNormalizer : public QObject
     int previewRotation() const;
 
     /**
-   * Sets the active camera device. Call when the camera is first
-   * activated and when the user switches cameras.
-   */
-    Q_INVOKABLE void setCamera( const QCameraDevice &device );
-
-    /**
-   * Records the current screen orientation. Call at shutter press
-   * so that normalizeImageOrientation() has a ground-truth reference.
-   */
+     * Records the current screen orientation. Call at shutter press
+     * so that normalizeImageOrientation() has a ground-truth reference.
+     */
     Q_INVOKABLE void recordCaptureOrientation();
 
     /**
-   * Ensures the JPEG at \a path has pixels matching the orientation
-   * recorded by recordCaptureOrientation(). Rotates the image if
-   * pixel dimensions contradict the capture orientation and strips
-   * any non-identity EXIF orientation tag.
-   *
-   * Returns false without touching the file when no correction is needed.
-   */
+     * Ensures the JPEG at \a path has pixels matching the orientation
+     * recorded by recordCaptureOrientation(). Rotates the image if
+     * pixel dimensions contradict the capture orientation and strips
+     * any non-identity EXIF orientation tag.
+     *
+     * Returns false without touching the file when no correction is needed.
+     */
     Q_INVOKABLE bool normalizeImageOrientation( const QString &path );
 
   signals:
@@ -73,10 +68,6 @@ class CameraOrientationNormalizer : public QObject
 
   private:
     void updatePreviewRotation();
-
-    QCameraDevice mCameraDevice;
-    int mSensorAngle = 0;
-    bool mIsFrontCamera = false;
     Qt::ScreenOrientation mCurrentOrientation = Qt::PortraitOrientation;
     Qt::ScreenOrientation mCaptureOrientation = Qt::PortraitOrientation;
     int mPreviewRotation = 0;

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -45,6 +45,7 @@
 #include "badlayerhandler.h"
 #include "barcodedecoder.h"
 #include "barcodeimageprovider.h"
+#include "cameraorientationnormalizer.h"
 #include "changelogcontents.h"
 #include "cogoexecutor.h"
 #include "cogooperation.h"
@@ -497,6 +498,7 @@ void QgisMobileapp::initDeclarative( QQmlEngine *engine )
   qmlRegisterType<ProjectSource>( "org.qfield", 1, 0, "ProjectSource" );
   qmlRegisterType<ViewStatus>( "org.qfield", 1, 0, "ViewStatus" );
   qmlRegisterType<GridModel>( "org.qfield", 1, 0, "GridModel" );
+  qmlRegisterType<CameraOrientationNormalizer>( "org.qfield", 1, 0, "CameraOrientationNormalizer" );
   qmlRegisterUncreatableType<GridAnnotation>( "org.qfield", 1, 0, "gridAnnotation", "Used for property values" );
   qmlRegisterUncreatableMetaObject( GridAnnotation::staticMetaObject, "org.qfield", 1, 0, "GridAnnotation", "Used to access enum values" );
 

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -169,12 +169,18 @@ Popup {
           property alias camera: camera
           property alias imageCapture: imageCapture
           property alias recorder: recorder
-          property alias videoOutput: videoOutput   // expose it
+          property alias videoOutput: videoOutput
+          property alias orientationNormalizer: orientationNormalizer
+
+          CameraOrientationNormalizer {
+            id: orientationNormalizer
+          }
 
           VideoOutput {
             id: videoOutput
             anchors.fill: parent
             visible: cameraItem.state == "PhotoCapture" || cameraItem.state == "VideoCapture"
+            orientation: orientationNormalizer.previewRotation
           }
 
           CaptureSession {
@@ -231,12 +237,12 @@ Popup {
 
               onImageSaved: (requestId, path) => {
                 currentPath = path;
+                orientationNormalizer.normalizeImageOrientation(currentPath);
+                photoPreview.source = "file://" + currentPath;
               }
 
               onPreviewChanged: {
                 cameraItem.state = "PhotoPreview";
-                photoPreview.source = "";
-                Qt.callLater(() => photoPreview.source = imageCapture.preview);
               }
             }
 
@@ -271,6 +277,7 @@ Popup {
           item.camera.cameraDevice = mediaDevices.defaultVideoInput;
         }
         item.camera.applyCameraFormat();
+        item.orientationNormalizer.setCamera(item.camera.cameraDevice);
       }
     }
 
@@ -375,7 +382,6 @@ Popup {
       id: photoPreview
 
       visible: cameraItem.state == "PhotoPreview"
-
       anchors.fill: parent
       cache: false
       fillMode: Image.PreserveAspectFit
@@ -487,6 +493,7 @@ Popup {
                   platformUtilities.createDir(qgisProject.homePath, 'DCIM');
                   captureLoader.item.imageCapture.captureToFile(qgisProject.homePath + '/DCIM/');
                   captureFlashAnimation.start();
+                  captureLoader.item.orientationNormalizer.recordCaptureOrientation();
                   if (positionSource.active) {
                     currentPosition = positionSource.positionInformation;
                     currentProjectedPosition = positionSource.projectedPosition;
@@ -882,6 +889,7 @@ Popup {
               if (captureLoader.item) {
                 captureLoader.item.camera.cameraDevice = modelData;
                 captureLoader.item.camera.applyCameraFormat();
+                captureLoader.item.orientationNormalizer.setCamera(modelData);
               }
             }
           }

--- a/src/qml/QFieldCamera.qml
+++ b/src/qml/QFieldCamera.qml
@@ -277,7 +277,6 @@ Popup {
           item.camera.cameraDevice = mediaDevices.defaultVideoInput;
         }
         item.camera.applyCameraFormat();
-        item.orientationNormalizer.setCamera(item.camera.cameraDevice);
       }
     }
 
@@ -889,7 +888,6 @@ Popup {
               if (captureLoader.item) {
                 captureLoader.item.camera.cameraDevice = modelData;
                 captureLoader.item.camera.applyCameraFormat();
-                captureLoader.item.orientationNormalizer.setCamera(modelData);
               }
             }
           }


### PR DESCRIPTION
On some iOS and Android devices, Qt Multimedia's produces wrong orientation when the device is held in landscape.

This PR introduces a CameraOrientationNormalizer object that lives inside the camera's capture loader and handles two things-

**Preview correction**: Computes a previewRotation value bound to VideoOutput.orientation. On iOS (where correctionAngle() returns 0, consistent with Qt's [documentation](https://doc.qt.io/qt-6/qml-cameradevice.html) noting the correction angle is non-zero mostly on Android), it applies 180° in landscape to compensate for the AVFoundation inversion

**Captured image normalization**: At shutter press, the current screen orientation is recorded. When the JPEG is saved, normalizeImageOrientation() compares the pixel dimensions against the recorded orientation, if the user captured in landscape but the pixels are portrait (or vice versa), it rotates them. Any non-identity EXIF tag is stripped by re-saving with EXIF reset to identity. If everything already matches, the file is not touched. The corrected image is then shown as the photo preview, so the user sees the right orientation before accepting.

On devices where the backend already produces correct output, previewRotation is 0 in portrait (no change) and the image normalization returns false without modifying the file, should not regression.

> Video capture orientation is not addressed. The `MediaRecorder` receives frames directly from the capture session's internal pipeline, not from the `VideoOutput`, so the `orientation` property does not affect recorded video.


THIS NEEDS TESTING ON FEW DEVICES 