### PR TITLE
Allow configuring location arrow and coordinate cursor

### DIFF
--- a/src/qml/3d/MapCanvas3D.qml
+++ b/src/qml/3d/MapCanvas3D.qml
@@ -23,6 +23,8 @@ Item {
   property var gnssPosition: null
   property real gnssSpeed: -1
   property real gnssDirection: -1
+  property color gnssMarkerColor: "#2060ff"
+  property color gnssMarkerSemiOpaqueColor: Qt.hsla(gnssMarkerColor.hslHue, gnssMarkerColor.hslSaturation, gnssMarkerColor.hslLightness, 0.4)
 
   property TrackingModel trackingModel: null
 
@@ -145,7 +147,7 @@ Item {
         pickable: true
 
         materials: PrincipledMaterial {
-          baseColor: "#4080ff"
+          baseColor: mapArea.gnssMarkerSemiOpaqueColor
           opacity: 0.4
           alphaMode: PrincipledMaterial.Blend
         }
@@ -180,7 +182,7 @@ Item {
           pickable: true
 
           materials: PrincipledMaterial {
-            baseColor: "#2060ff"
+            baseColor: mapArea.gnssMarkerColor
             metalness: 0.7
             roughness: 0.1
           }
@@ -194,7 +196,7 @@ Item {
           pickable: true
 
           materials: PrincipledMaterial {
-            baseColor: "#2060ff"
+            baseColor: mapArea.gnssMarkerColor
             metalness: 0.6
             roughness: 0.2
           }
@@ -208,7 +210,7 @@ Item {
           pickable: true
 
           materials: PrincipledMaterial {
-            baseColor: "#4080ff"
+            baseColor: mapArea.gnssMarkerSemiOpaqueColor
             metalness: 0.5
             roughness: 0.3
           }
@@ -223,7 +225,7 @@ Item {
         pickable: true
 
         materials: PrincipledMaterial {
-          baseColor: "#2060ff"
+          baseColor: mapArea.gnssMarkerColor
           metalness: 0.6
           roughness: 0.2
         }

--- a/src/qml/CoordinateLocator.qml
+++ b/src/qml/CoordinateLocator.qml
@@ -17,6 +17,7 @@ Item {
   property color cursorFillColor: "#000000"
   property color cursorOutlineColor: "#FFFFFF"
   property real cursorSizeScale: 1.0
+  readonly property real crossHalfLength: cursorSizeScale >= 2.0 ? 16 : cursorSizeScale >= 1.5 ? 14 : 8
 
   /**
    * Set the current layer on which snapping should be performed.
@@ -275,18 +276,18 @@ Item {
       }
       PathMove {
         x: crosshairCircle.halfWidth
-        y: crosshairCircle.halfWidth - 8
+        y: crosshairCircle.halfWidth - locator.crossHalfLength
       }
       PathLine {
         x: crosshairCircle.halfWidth
-        y: crosshairCircle.halfWidth + 8
+        y: crosshairCircle.halfWidth + locator.crossHalfLength
       }
       PathMove {
-        x: crosshairCircle.halfWidth - 8
+        x: crosshairCircle.halfWidth - locator.crossHalfLength
         y: crosshairCircle.halfWidth
       }
       PathLine {
-        x: crosshairCircle.halfWidth + 8
+        x: crosshairCircle.halfWidth + locator.crossHalfLength
         y: crosshairCircle.halfWidth
       }
     }

--- a/src/qml/CoordinateLocator.qml
+++ b/src/qml/CoordinateLocator.qml
@@ -14,6 +14,9 @@ Item {
   property MapSettings mapSettings
   property color mainColor: "#CFD8DC"
   property color highlightColor: "#263238"
+  property color cursorFillColor: "#000000"
+  property color cursorOutlineColor: "#FFFFFF"
+  property real cursorSizeScale: 1.0
 
   /**
    * Set the current layer on which snapping should be performed.
@@ -199,7 +202,7 @@ Item {
     property real halfWidth: width / 2
     property real arcSpacing: isSnapped ? 0 : 20
 
-    width: isSnapped ? 32 : 48
+    width: (isSnapped ? 32 : 48) * locator.cursorSizeScale
     height: width
 
     x: displayPosition.x - halfWidth
@@ -227,14 +230,14 @@ Item {
 
     ShapePath {
       id: crosshairPathBuffer
-      strokeColor: "#FFFFFF"
+      strokeColor: locator.cursorOutlineColor
       strokeWidth: crosshairPath.strokeWidth + 2
       fillColor: "transparent"
     }
 
     ShapePath {
       id: crosshairPath
-      strokeColor: !!overrideLocation && overrideLocation.x ? Theme.positionColor : "#000000"
+      strokeColor: !!overrideLocation && overrideLocation.x ? Theme.positionColor : locator.cursorFillColor
       strokeWidth: 2
       fillColor: "transparent"
 

--- a/src/qml/CoordinateLocator.qml
+++ b/src/qml/CoordinateLocator.qml
@@ -238,7 +238,7 @@ Item {
 
     ShapePath {
       id: crosshairPath
-      strokeColor: !!overrideLocation && overrideLocation.x ? Theme.positionColor : locator.cursorFillColor
+      strokeColor: !!overrideLocation && overrideLocation.x ? Qt.darker(Theme.positionColor, 1.25) : locator.cursorFillColor
       strokeWidth: 2
       fillColor: "transparent"
 

--- a/src/qml/LocationMarker.qml
+++ b/src/qml/LocationMarker.qml
@@ -29,6 +29,7 @@ Item {
   property real speed: -1 // A -1 value indicates absence of speed information
   property real orientation: -1 // A -1 value indicates absence of compass orientation
 
+  property real sizeScale: 1.0
   property color strokeColor: "white"
   property color color: Qt.darker(Theme.positionColor, 1.25)
   property color semiOpaqueColor: Qt.hsla(color.hslHue, color.hslSaturation, color.hslLightness, 0.1)
@@ -62,6 +63,7 @@ Item {
     visible: orientation > -1
     width: 48
     height: 48
+    scale: locationMarker.sizeScale
     opacity: 0.6
 
     x: screenLocation.x - width / 2
@@ -214,6 +216,7 @@ Item {
     visible: speed > 0 && isOnMapCanvas
     width: 26
     height: 26
+    scale: locationMarker.sizeScale
 
     x: screenLocation.x - width / 2
     y: screenLocation.y - height / 2
@@ -261,8 +264,8 @@ Item {
     id: positionMarker
     visible: !movementMarker.visible && isOnMapCanvas
 
-    width: 14
-    height: 14
+    width: 14 * locationMarker.sizeScale
+    height: 14 * locationMarker.sizeScale
 
     x: screenLocation.x - width / 2
     y: screenLocation.y - height / 2
@@ -288,6 +291,7 @@ Item {
     visible: !isOnMapCanvas
     width: 20
     height: 24
+    scale: locationMarker.sizeScale
 
     x: Math.min(mapCanvas.width - width, Math.max(0, screenLocation.x - width / 2))
     y: Math.min(mapCanvas.height - width, Math.max(0, screenLocation.y - width / 2))

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4861,6 +4861,65 @@ ApplicationWindow {
       layoutListInstantiator.model.reloadModel();
       geofencer.applyProjectSettings(qgisProject);
       positioningSettings.geofencingPreventDigitizingDuringAlert = iface.readProjectBoolEntry("qfieldsync", "/geofencingShouldPreventDigitizing", false);
+
+      // Location arrow customization
+      const locationArrowFillColor = iface.readProjectEntry("qfieldsync", "/locationArrowFillColor", "");
+      if (locationArrowFillColor !== "") {
+        locationMarker.color = locationArrowFillColor;
+      } else {
+        locationMarker.color = Qt.darker(Theme.positionColor, 1.25);
+      }
+      const locationArrowOutlineColor = iface.readProjectEntry("qfieldsync", "/locationArrowOutlineColor", "");
+      if (locationArrowOutlineColor !== "") {
+        locationMarker.strokeColor = locationArrowOutlineColor;
+      } else {
+        locationMarker.strokeColor = "white";
+      }
+      const locationArrowSize = iface.readProjectEntry("qfieldsync", "/locationArrowSize", "normal");
+      switch (locationArrowSize) {
+      case "tiny":
+        locationMarker.sizeScale = 0.7;
+        break;
+      case "big":
+        locationMarker.sizeScale = 1.5;
+        break;
+      case "biggest":
+        locationMarker.sizeScale = 2.0;
+        break;
+      default:
+        locationMarker.sizeScale = 1.0;
+        break;
+      }
+
+      // Coordinate cursor customization
+      const coordinateCursorFillColor = iface.readProjectEntry("qfieldsync", "/coordinateCursorFillColor", "");
+      if (coordinateCursorFillColor !== "") {
+        coordinateLocator.cursorFillColor = coordinateCursorFillColor;
+      } else {
+        coordinateLocator.cursorFillColor = "#000000";
+      }
+      const coordinateCursorOutlineColor = iface.readProjectEntry("qfieldsync", "/coordinateCursorOutlineColor", "");
+      if (coordinateCursorOutlineColor !== "") {
+        coordinateLocator.cursorOutlineColor = coordinateCursorOutlineColor;
+      } else {
+        coordinateLocator.cursorOutlineColor = "#FFFFFF";
+      }
+      const coordinateCursorSize = iface.readProjectEntry("qfieldsync", "/coordinateCursorSize", "normal");
+      switch (coordinateCursorSize) {
+      case "tiny":
+        coordinateLocator.cursorSizeScale = 0.7;
+        break;
+      case "big":
+        coordinateLocator.cursorSizeScale = 1.5;
+        break;
+      case "biggest":
+        coordinateLocator.cursorSizeScale = 2.0;
+        break;
+      default:
+        coordinateLocator.cursorSizeScale = 1.0;
+        break;
+      }
+
       mapCanvasTour.startOnFreshRun();
     }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -748,6 +748,7 @@ ApplicationWindow {
         item.gnssPosition = Qt.binding(() => positionSource.projectedPosition);
         item.gnssSpeed = Qt.binding(() => positionSource.positionInformation && positionSource.positionInformation.speedValid ? positionSource.positionInformation.speed : -1);
         item.gnssDirection = Qt.binding(() => positionSource.positionInformation && positionSource.positionInformation.directionValid ? positionSource.positionInformation.direction : -1);
+        item.gnssMarkerColor = Qt.binding(() => locationMarker.color);
 
         // Connect camera interaction signal to deactivate soft lock
         item.cameraInteractionDetected.connect(function () {


### PR DESCRIPTION
### 🚀 Description
Users can now customize the appearance of the location arrow and coordinate locator cursor by setting specific project entries. Supported customizations include fill colors, outline colors, and size scales (tiny, normal, big, biggest).

### ✨ Key Changes

| Setting | Key | Values |
|---|---|---|
| Location arrow fill color | `locationArrowFillColor` | Any color string |
| Location arrow outline color | `locationArrowOutlineColor` | Any color string |
| Location arrow size | `locationArrowSize` | `tiny`, `normal`, `big`, `biggest` |
| Coordinate cursor fill color | `coordinateCursorFillColor` | Any color string |
| Coordinate cursor outline color | `coordinateCursorOutlineColor` | Any color string |
| Coordinate cursor size | `coordinateCursorSize` | `tiny`, `normal`, `big`, `biggest` |

Settings are read from the `qfieldsync` entries and applied when the project is loaded. Projects without these settings behave exactly as before.


### QFS Controlling panel

<img width="1280" height="539" alt="telegram-cloud-photo-size-4-5987937817067195404-y" src="https://github.com/user-attachments/assets/31a986e0-0a70-43b3-b9f4-740bd6835553" />

### Screenshots
Biggest -> Big -> normal (with default colors) -> Tiny

<img width="1280" height="592" alt="telegram-cloud-photo-size-4-5987937817067195403-y" src="https://github.com/user-attachments/assets/5e19aad9-2f24-4ad8-af4c-bdc195c547a0" />
   
--- 

### Instruction to test

To test this, you'll need to install a development version of QFieldSync. To do so, follow these steps:

1. Download the qfieldsync plugin artifact at the bottom of this page (https://github.com/opengisch/qfieldsync/actions/runs/25201125217)
2. Launch QGIS and open the plugin manager
3. Go to the install from ZIP panel, select the ZIP downloaded in step 1, and click on the install button

You'll be able to configure the location marker and cursor coordinate by opening the project properties dialog, going to the QField panel, and clicking on the customize map overlay elements' settings button.

_Note: once tested, it is advised to downgrade the qfieldsync plugin back to a release version, which can be done in the plugin manager by selecting QFieldSync and hitting the downgrade button_