### PR TITLE
Implement mechanism to provide translation support for plugins

### DIFF
--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -18,6 +18,7 @@
 #include "pluginmanager.h"
 #include "qgsziputils.h"
 
+#include <QCoreApplication>
 #include <QDir>
 #include <QFileInfo>
 #include <QQmlApplicationEngine>
@@ -78,6 +79,20 @@ void PluginManager::loadPlugin( const QString &pluginPath, const QString &plugin
     unloadPlugin( pluginPath );
   }
 
+  // Load translation file for current language locale is present
+  QFileInfo pluginFileInfo( pluginPath );
+  const QString languageCode = QLocale().name();
+  QTranslator *languageTranslator = new QTranslator();
+  if ( languageTranslator->load( QStringLiteral( "%1%2%3" ).arg( pluginFileInfo.fileName().chopped( 4 ), pluginFileInfo.fileName() == QStringLiteral( "main.qml" ) ? "" : QStringLiteral( "-plugin_" ), languageCode ), pluginFileInfo.absolutePath(), "_" ) )
+  {
+    QCoreApplication::installTranslator( languageTranslator );
+    mLoadedPluginTranslators.insert( pluginPath, languageTranslator );
+  }
+  else
+  {
+    languageTranslator->deleteLater();
+  }
+
   // Bypass caching to insure updated QML content is loaded
   QUrl url = QUrl::fromLocalFile( pluginPath );
   url.setQuery( QStringLiteral( "t=%1" ).arg( QDateTime::currentSecsSinceEpoch() ) );
@@ -125,6 +140,12 @@ void PluginManager::unloadPlugin( const QString &pluginPath )
 
     // Clear QML components cache of dynamically loaded items
     mEngine->clearComponentCache();
+  }
+  if ( mLoadedPluginTranslators.contains( pluginPath ) )
+  {
+    QCoreApplication::removeTranslator( mLoadedPluginTranslators[pluginPath] );
+    mLoadedPluginTranslators[pluginPath]->deleteLater();
+    mLoadedPluginTranslators.remove( pluginPath );
   }
 }
 

--- a/src/core/pluginmanager.h
+++ b/src/core/pluginmanager.h
@@ -21,6 +21,7 @@
 
 #include <QObject>
 #include <QQmlEngine>
+#include <QTranslator>
 
 /**
  * \ingroup core
@@ -204,6 +205,7 @@ class PluginManager : public QObject
   private:
     QQmlEngine *mEngine = nullptr;
     QMap<QString, QPointer<QObject>> mLoadedPlugins;
+    QMap<QString, QTranslator *> mLoadedPluginTranslators;
 
     QString mPermissionRequestPluginPath;
 


### PR DESCRIPTION
This PR adds a mechanism to our plugin framework to enable UI translations by shipping .qm sidecar files alongside the main plugin .qml file.

For project plugins, the sidecar file(s) looks like this:

<project directory>/project.qgs
<project directory>/project.qml
<project directory>/project-plugin_en.qm
<project directory>/project-plugin_fr.qm
<project directory>/project-plugin_de.qm
...

Since QGIS projects already use project_[language code].qm to do project translations, we have to add an arbitrary prefix to the language code, hence the -plugin part.

For app plugins, the sidecar file(s) looks like this:

<plugin directory>/main.qml
<plugin directory>/main_en.qm
<plugin directory>/main_fr.qm
<plugin directory>/main_de.qm

The language picked when loading a plugin will match the QField language user setting (which defaults to system locale). 

On the plugin side of things, each .qml source file can contain a pragma statement _at the top of the file_ to define the translation context, e.g.:

```
pragma Translation: MyPlugin
import QtQuick

Item {
}
```

To use translatable strings in the plugin, authors can use qsTranslate(context, string). E.g.:

```
pragma Translation: MyPlugin
import QtQuick

Item {
  Label {
    text: qsTranslate("MyPlugin", "This is a label")
  }
}
```

> [!NOTE]
> On my machine, using qsTr("") was not reliable, hence why it's suggested to use qsTranslate with an explicit context parameter.

To generate the .ts translation files to use with Qt Linguist, authors can type:

`lupdate main.qml -ts main_en.ts`

That will give authors the source translation file needed. The rest is essentially the same as QGIS project translation (https://www.opengis.ch/2018/09/11/qgis-speaks-a-lot-of-languages/).