### PR TITLE
Expose QFieldCloud's model and connection objects through objectName

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -5041,6 +5041,7 @@ ApplicationWindow {
 
   QFieldCloudConnection {
     id: cloudConnection
+    objectName: "cloudConnection"
 
     property int previousStatus: QFieldCloudConnection.Disconnected
 
@@ -5074,6 +5075,8 @@ ApplicationWindow {
 
   QFieldCloudProjectsModel {
     id: cloudProjectsModel
+    objectName: "cloudProjectsModel"
+
     cloudConnection: cloudConnection
     layerObserver: layerObserverAlias
     gpkgFlusher: gpkgFlusherAlias


### PR DESCRIPTION
This enables plugins to build custom UI and logic to deal with cloud projects, including the currently opened cloud project.