### PR TITLE
Inject @cloud_username and @cloud_useremail into the global scope, and protect them from being edited

### DIFF
--- a/src/core/expressionvariablemodel.cpp
+++ b/src/core/expressionvariablemodel.cpp
@@ -14,8 +14,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "expressioncontextutils.h"
 #include "expressionvariablemodel.h"
-#include "utils/expressioncontextutils.h"
 
 #include <QDebug>
 #include <QSettings>
@@ -178,22 +178,24 @@ void ExpressionVariableModel::reloadVariables()
   variableNames.sort();
 
   // Second add user-provided global variables
-  for ( const QString &name : variableNames )
+  for ( const QString &name : std::as_const( variableNames ) )
   {
-    if ( !scope->isReadOnly( name ) )
+    if ( !scope->isReadOnly( name ) && !PROTECTED_GLOBAL_VARIABLE_NAMES.contains( name ) )
     {
       appendVariable( VariableScope::GlobalScope, name, scope->variable( name ).toString(), true );
     }
   }
 
   // Finally, add read-only global variables
-  for ( const QString &name : variableNames )
+  for ( const QString &name : std::as_const( variableNames ) )
   {
-    if ( scope->isReadOnly( name ) )
+    if ( scope->isReadOnly( name ) || PROTECTED_GLOBAL_VARIABLE_NAMES.contains( name ) )
     {
       QVariant varValue = scope->variable( name );
       if ( QString::compare( varValue.toString(), QStringLiteral( "Not available" ) ) == 0 )
+      {
         varValue = QVariant( QT_TR_NOOP( "Not Available" ) );
+      }
 
       appendVariable( VariableScope::GlobalScope, name, varValue.toString(), false );
     }

--- a/src/core/projectinfo.cpp
+++ b/src/core/projectinfo.cpp
@@ -15,7 +15,6 @@
  ***************************************************************************/
 
 
-#include "expressioncontextutils.h"
 #include "projectinfo.h"
 
 #include <QDateTime>
@@ -23,6 +22,7 @@
 #include <QString>
 #include <QTextDocument>
 #include <qgscolorutils.h>
+#include <qgsexpressioncontextutils.h>
 #include <qgslayertree.h>
 #include <qgslayertreemodel.h>
 #include <qgslinesymbol.h>
@@ -318,6 +318,10 @@ void ProjectInfo::setCloudUserInformation( const CloudUserInformation cloudUserI
 
   if ( cloudUserInformation.isEmpty() )
     return;
+
+  // Inject variables into the global scope until we have a better solution upstream
+  QgsExpressionContextUtils::setGlobalVariable( "cloud_username", cloudUserInformation.username );
+  QgsExpressionContextUtils::setGlobalVariable( "cloud_useremail", cloudUserInformation.email );
 
   mSettings.beginGroup( QStringLiteral( "/qgis/projectInfo/%1/cloudUserInfo" ).arg( mFilePath ) );
   mSettings.setValue( QStringLiteral( "json" ), cloudUserInformation.toJson() );
@@ -652,8 +656,13 @@ void ProjectInfo::restoreSettings( QString &projectFilePath, QgsProject *project
   const QStringList variableNames = settings.allKeys();
   for ( const QString &name : variableNames )
   {
-    ExpressionContextUtils::setProjectVariable( project, name, settings.value( name ).toString() );
+    QgsExpressionContextUtils::setProjectVariable( project, name, settings.value( name ).toString() );
   }
+
+  // Inject variables into the global scope until we have a better solution upstream
+  QJsonObject cloudUserInformationObject = QSettings().value( QStringLiteral( "/qgis/projectInfo/%1/cloudUserInfo/json" ).arg( projectFilePath ), QStringLiteral( "{}" ) ).toJsonValue().toObject();
+  QgsExpressionContextUtils::setGlobalVariable( "cloud_username", cloudUserInformationObject.value( "username" ).toString() );
+  QgsExpressionContextUtils::setGlobalVariable( "cloud_useremail", cloudUserInformationObject.value( "email" ).toString() );
 }
 
 QVariantMap ProjectInfo::getTitleDecorationConfiguration()

--- a/src/core/utils/expressioncontextutils.cpp
+++ b/src/core/utils/expressioncontextutils.cpp
@@ -230,6 +230,11 @@ QVariantMap ExpressionContextUtils::globalVariables()
 
 void ExpressionContextUtils::setGlobalVariable( const QString &name, const QVariant &value )
 {
+  if ( PROTECTED_GLOBAL_VARIABLE_NAMES.contains( name ) )
+  {
+    return;
+  }
+
   QgsApplication::setCustomVariable( name, value );
 }
 

--- a/src/core/utils/expressioncontextutils.h
+++ b/src/core/utils/expressioncontextutils.h
@@ -20,10 +20,13 @@
 #define EXPRESSIONCONTEXTUTILS_H
 
 #include "gnsspositioninformation.h"
-#include "qfieldcloudconnection.h"
+#include "qfieldcloudutils.h"
 #include "snappingresult.h"
 
 #include <qgsexpressioncontext.h>
+
+#define PROTECTED_GLOBAL_VARIABLE_NAMES QStringList( { QStringLiteral( "cloud_username" ), QStringLiteral( "cloud_useremail" ) } )
+
 
 /**
  * \ingroup core


### PR DESCRIPTION
This PR adds @cloud_username and @cloud_useremail into the expression engine's global scope. That allows us to do QFieldCloud-driven data-defined symbology properties, use the details in the rule-based renderer, etc.

Some protection was added in relevant classes to insure these variables cannot be changed in the QField variable editor or through plugins.

I consider this a bridge to a proper implementation, which will require some improvements upstream to allow for code to inject and control scopes at the global level. But until then, let's go for this solution, it unlocks too many :candy:  not go for it :)