### PR TITLE
Fix QField's map canvas extent and MUPP on dual monitor systems with different pixel ratios

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -303,6 +303,7 @@ void QgsQuickMapCanvasMap::onScreenChanged( QScreen *screen )
     if ( screen->devicePixelRatio() > 0 )
     {
       mMapSettings->setDevicePixelRatio( screen->devicePixelRatio() );
+      mMapSettings->setOutputSize( size().toSize() );
     }
 
     mMapSettings->setOutputDpi( !qgetenv( "QT_SCALE_FACTOR" ).isEmpty() ? screen->logicalDotsPerInch() : screen->physicalDotsPerInch() );

--- a/src/core/qgsquick/qgsquickmapsettings.cpp
+++ b/src/core/qgsquick/qgsquickmapsettings.cpp
@@ -511,7 +511,13 @@ qreal QgsQuickMapSettings::devicePixelRatio() const
 
 void QgsQuickMapSettings::setDevicePixelRatio( const qreal &devicePixelRatio )
 {
+  if ( mDevicePixelRatio == devicePixelRatio )
+  {
+    return;
+  }
+
   mDevicePixelRatio = devicePixelRatio;
+  emit mapUnitsPerPointChanged();
 }
 
 bool QgsQuickMapSettings::isTemporal() const


### PR DESCRIPTION
Fixes https://github.com/opengisch/QField/issues/7129

