### PR TITLE
[Backport release-4_1] Restore QFC pushed change / downloaded project toaster message when user is at the welcome screen

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -5084,7 +5084,7 @@ ApplicationWindow {
       if (hasError) {
         qfieldCloudStatus.refresh();
         displayToast(qsTr("Project %1 failed to download").arg(projectName), 'error');
-      } else if (qfieldCloudScreen.visible || qfieldCloudPopup.visible) {
+      } else if (qfieldCloudScreen.visible || qfieldCloudPopup.visible || welcomeScreen.visible) {
         displayToast(qsTr("Project %1 successfully downloaded, it's now available to open").arg(projectName));
       }
     }
@@ -5095,7 +5095,7 @@ ApplicationWindow {
         displayToast(qsTr("Changes failed to reach QFieldCloud: %1").arg(errorString), 'error');
         return;
       }
-      if (!isDownloadingProject && (qfieldCloudScreen.visible || qfieldCloudPopup.visible)) {
+      if (!isDownloadingProject && (qfieldCloudScreen.visible || qfieldCloudPopup.visible || welcomeScreen.visible)) {
         displayToast(qsTr("Changes successfully pushed to QFieldCloud"));
       }
       if (QFieldCloudUtils.hasPendingAttachments(cloudConnection.username)) {


### PR DESCRIPTION
Backport #7349
 **Authored by:** @nirvn