### PR TITLE
Feature form container visibility does not need to re-evaluate any parent visibilty these days

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -246,18 +246,16 @@ void AttributeFormModelBase::resetModel()
           item->setData( true, AttributeFormModel::ConstraintHardValid );
           item->setData( true, AttributeFormModel::ConstraintSoftValid );
 
-          QString visibilityExpression;
-          if ( container->visibilityExpression().enabled() )
-          {
-            visibilityExpression = QStringLiteral( "(%1)" ).arg( container->visibilityExpression().data().expression() );
-          }
-
-          buildForm( container, item, visibilityExpression, containers, currentTab, columnCount );
+          buildForm( container, item, containers, currentTab, columnCount );
           invisibleRootItem()->appendRow( item );
 
-          if ( !visibilityExpression.isEmpty() )
+          if ( container->visibilityExpression().enabled() )
           {
-            mVisibilityExpressions.append( qMakePair( container->visibilityExpression().data(), item ) );
+            const QString visibilityExpression = container->visibilityExpression().data().expression();
+            if ( !visibilityExpression.isEmpty() )
+            {
+              mVisibilityExpressions.append( qMakePair( container->visibilityExpression().data(), item ) );
+            }
           }
 
           currentTab++;
@@ -266,7 +264,7 @@ void AttributeFormModelBase::resetModel()
     }
     else
     {
-      buildForm( invisibleRootContainer(), invisibleRootItem(), QString(), containers );
+      buildForm( invisibleRootContainer(), invisibleRootItem(), containers );
     }
 
     for ( QStandardItem *container : std::as_const( containers ) )
@@ -504,7 +502,7 @@ void AttributeFormModelBase::updateAttributeValue( QStandardItem *item )
   }
 }
 
-void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, QStandardItem *parent, const QString &parentVisibilityExpressions, QList<QStandardItem *> &containers, int currentTabIndex, int columnCount )
+void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, QStandardItem *parent, QList<QStandardItem *> &containers, int currentTabIndex, int columnCount )
 {
   const QList<QgsAttributeEditorElement *> children { container->children() };
   for ( QgsAttributeEditorElement *element : children )
@@ -528,20 +526,8 @@ void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, 
     {
       case Qgis::AttributeEditorType::Container:
       {
-        QString visibilityExpression = parentVisibilityExpressions;
         QgsAttributeEditorContainer *innerContainer = static_cast<QgsAttributeEditorContainer *>( element );
         const int innerColumnCount = innerContainer->columnCount();
-        if ( innerContainer->visibilityExpression().enabled() )
-        {
-          if ( visibilityExpression.isNull() )
-          {
-            visibilityExpression = QStringLiteral( "(%1)" ).arg( innerContainer->visibilityExpression().data().expression() );
-          }
-          else
-          {
-            visibilityExpression += QStringLiteral( " AND (%1)" ).arg( innerContainer->visibilityExpression().data().expression() );
-          }
-        }
 
         item->setData( "container", AttributeFormModel::ElementType );
         item->setData( element->showLabel() ? innerContainer->name() : QString(), AttributeFormModel::Name );
@@ -554,13 +540,17 @@ void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, 
           item->setData( innerContainer->backgroundColor(), AttributeFormModel::GroupColor );
         }
 
-        buildForm( innerContainer, item, visibilityExpression, containers, 0, innerColumnCount );
+        buildForm( innerContainer, item, containers, 0, innerColumnCount );
         parent->appendRow( item );
         containers << item;
 
-        if ( !visibilityExpression.isEmpty() )
+        if ( innerContainer->visibilityExpression().enabled() )
         {
-          mVisibilityExpressions.append( qMakePair( QgsExpression( visibilityExpression ), item ) );
+          const QString visibilityExpression = innerContainer->visibilityExpression().data().expression();
+          if ( !visibilityExpression.isEmpty() )
+          {
+            mVisibilityExpressions.append( qMakePair( QgsExpression( visibilityExpression ), item ) );
+          }
         }
         break;
       }

--- a/src/core/attributeformmodelbase.h
+++ b/src/core/attributeformmodelbase.h
@@ -118,7 +118,6 @@ class AttributeFormModelBase : public QStandardItemModel
 
     void buildForm( QgsAttributeEditorContainer *container,
                     QStandardItem *parent,
-                    const QString &parentVisibilityExpressions,
                     QList<QStandardItem *> &containers,
                     int currentTabIndex = 0,
                     int columnCount = 1 );


### PR DESCRIPTION
A long time ago, QField was flattening the attributes form configuration. We stopped doing that a while back when we implemented actual container support.

Yet, we still aggregate visibility expression of parent container(s) and when calculating expression for a given child container. It's not needed anymore, let's get rid of this. Two main benefits:

- Speeeed, since we do not duplicate what could be heavy aggregate/relation-based expressions
- We won't fail when a given visibility expression contains SQL comments (i.e. -- comments).

This discovered happened following the reporting by a QField community platform user who mentioned a child container visibility was failing.

The parent tab container had a simple visibility expression - let's assume `"blah" = true` - and the child container has an expression containing a comment - let's say `"bloh" = 2 -- double check` - which once glued would fail.

We glued the above scenario by doing QStringLiteral( "(%1) AND (%2)" ), which meant here `("blah" = true) AND ("bloh" = 2 -- double check)`, i.e. a broken expression since our closing parenthesis is commented out.

