### PR TITLE
Provide a mean for users to show the about QField overlay from the welcome screen

### DIFF
--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -15,6 +15,8 @@ Page {
   property bool firstShown: false
 
   property alias model: table.model
+
+  signal showAbout
   signal showLocalDataPicker
   signal showQFieldCloudScreen
   signal showSettings
@@ -79,7 +81,8 @@ Page {
 
       ImageDial {
         id: imageDialLogo
-        value: 1
+
+        property real pressedValue: -1
 
         Layout.margins: 6
         Layout.topMargin: 14 + mainWindow.sceneTopMargin
@@ -90,6 +93,24 @@ Page {
 
         source: "qrc:/images/app_logo.svg"
         rotationOffset: 220
+        value: 1
+
+        onPressedChanged: {
+          if (pressed) {
+            pressedValue = -1;
+          } else {
+            if (pressedValue == -1 || Math.abs(value - pressedValue) < 0.05) {
+              welcomeScreen.showAbout();
+            }
+            pressedValue = -1;
+          }
+        }
+
+        onValueChanged: {
+          if (pressed && pressedValue == -1) {
+            pressedValue = value;
+          }
+        }
       }
 
       SwipeView {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -5017,13 +5017,6 @@ ApplicationWindow {
     }
   }
 
-  About {
-    id: aboutDialog
-    anchors.fill: parent
-
-    Component.onCompleted: focusstack.addFocusTaker(this)
-  }
-
   TrackerSettings {
     id: trackerSettings
     objectName: 'trackerSettings'
@@ -5135,6 +5128,10 @@ ApplicationWindow {
     }
 
     anchors.fill: parent
+
+    onShowAbout: {
+      aboutDialog.visible = true;
+    }
 
     onShowLocalDataPicker: {
       qfieldLocalDataPickerScreen.projectFolderView = false;
@@ -5262,6 +5259,13 @@ ApplicationWindow {
         }
       }
     }
+  }
+
+  About {
+    id: aboutDialog
+    anchors.fill: parent
+
+    Component.onCompleted: focusstack.addFocusTaker(this)
   }
 
   Toast {


### PR DESCRIPTION
This fixes https://github.com/opengisch/QField/issues/7348 by adding an additional interaction to the welcome screen's logo. Upon tapping the logo, the about QField overlay will show up. The shortcut can be a nice shortcut when communicating with users and need to know which version they run on. 

Extra bonus: it is a super useful shortcut for plugin developers looking for the app directory. I've done enough workshops to know people immediately go "why do I need to load a project to get that information?" :slightly_smiling_face: 

Of course, people are still free to enable unicorns by dialing the logo all the way back :)