### PR TITLE
Fix proxy type combo box not reflecting saved setting on startup

### DIFF
--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -210,21 +210,6 @@ void AppInterface::setScreenDimmerTimeout( int timeoutSeconds )
 
 void AppInterface::setupNetworkProxy() const
 {
-  // The QML layer stores excluded URLs as a plain comma-separated string to
-  // avoid passing JS arrays across the QML/C++ boundary (Qt 6 serialization
-  // limitation).  Parse and re-write as QStringList so that
-  // setupDefaultProxyAndCache() can read it correctly via QgsSettings.
-  QSettings settings;
-  const QString raw = settings.value( QStringLiteral( "proxy/proxyExcludedUrls" ) ).toString();
-  if ( !raw.isEmpty() )
-  {
-    const QStringList parts = raw.split( QLatin1Char( ',' ), Qt::SkipEmptyParts );
-    QStringList trimmed;
-    for ( const QString &part : parts )
-      trimmed.append( part.trimmed() );
-    settings.setValue( QStringLiteral( "proxy/proxyExcludedUrls" ), trimmed );
-  }
-
   QgsNetworkAccessManager::instance()->setupDefaultProxyAndCache();
 }
 

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -43,6 +43,45 @@ Page {
   property string proxyPassword: ""
   property string proxyExcludedUrls: ""
 
+  // Guard to avoid writing back to QSettings during the initial load from QSettings.
+  property bool proxySettingsLoaded: false
+
+  onProxyEnabledChanged: {
+    if (proxySettingsLoaded) {
+      settings.setValue('proxy/proxy-enabled', proxyEnabled);
+    }
+  }
+  onProxyTypeChanged: {
+    if (proxySettingsLoaded) {
+      settings.setValue('proxy/proxy-type', proxyType);
+    }
+  }
+  onProxyHostChanged: {
+    if (proxySettingsLoaded) {
+      settings.setValue('proxy/proxy-host', proxyHost);
+    }
+  }
+  onProxyPortChanged: {
+    if (proxySettingsLoaded) {
+      settings.setValue('proxy/proxy-port', proxyPort);
+    }
+  }
+  onProxyUserChanged: {
+    if (proxySettingsLoaded) {
+      settings.setValue('proxy/proxy-user', proxyUser);
+    }
+  }
+  onProxyPasswordChanged: {
+    if (proxySettingsLoaded) {
+      settings.setValue('proxy/proxy-password', proxyPassword);
+    }
+  }
+  onProxyExcludedUrlsChanged: {
+    if (proxySettingsLoaded) {
+      settings.setValue('proxy/proxy-excluded-urls', proxyExcludedUrls);
+    }
+  }
+
   leftPadding: mainWindow.sceneLeftMargin
   rightPadding: mainWindow.sceneRightMargin
 
@@ -54,14 +93,17 @@ Page {
       // a crash occured while the native camera was launched, disable it
       nativeCamera2 = false;
     }
-    proxyEnabled = settings.valueBool('proxy/proxyEnabled', false);
-    proxyType = settings.value('proxy/proxyType', 'DefaultProxy');
-    proxyHost = settings.value('proxy/proxyHost', '');
-    proxyPort = settings.valueInt('proxy/proxyPort', 0);
-    proxyUser = settings.value('proxy/proxyUser', '');
-    proxyPassword = settings.value('proxy/proxyPassword', '');
-    const excludedRaw = settings.value('proxy/proxyExcludedUrls', '');
+    proxyEnabled = settings.valueBool('proxy/proxy-enabled', false);
+    proxyType = settings.value('proxy/proxy-type', 'DefaultProxy');
+    proxyHost = settings.value('proxy/proxy-host', '');
+    proxyPort = settings.valueInt('proxy/proxy-port', 0);
+    proxyUser = settings.value('proxy/proxy-user', '');
+    proxyPassword = settings.value('proxy/proxy-password', '');
+    const excludedRaw = settings.value('proxy/proxy-excluded-urls', '');
     proxyExcludedUrls = Array.isArray(excludedRaw) ? excludedRaw.join(', ') : (excludedRaw || '');
+    const typeIdx = proxyTypeComboBox.indexOfValue(proxyType);
+    proxyTypeComboBox.currentIndex = typeIdx >= 0 ? typeIdx : 0;
+    proxySettingsLoaded = true;
   }
 
   function reset() {
@@ -69,13 +111,6 @@ Page {
   }
 
   function applyProxySettings() {
-    settings.setValue('proxy/proxyEnabled', proxyEnabled);
-    settings.setValue('proxy/proxyType', proxyType);
-    settings.setValue('proxy/proxyHost', proxyHost);
-    settings.setValue('proxy/proxyPort', proxyPort);
-    settings.setValue('proxy/proxyUser', proxyUser);
-    settings.setValue('proxy/proxyPassword', proxyPassword);
-    settings.setValue('proxy/proxyExcludedUrls', proxyExcludedUrls);
     iface.setupNetworkProxy();
   }
 


### PR DESCRIPTION
Fix proxy settings not persisting and not displaying correctly on startup
- Save each proxy setting immediately when changed so settings survive app close via the window X button, not only via the explicit back button
- Sync the proxy type combo box currentIndex after loading from QSettings so the correct type is displayed on App restart
- Apply qmlformat

GIF shows
 a) Proxy settings visible on startup
 b) changing proxy settigns + immidiate closing via "X" + reopening -> settings got saved

<img width="1237" height="721" alt="QFieldCloud_Proxy" src="https://github.com/user-attachments/assets/12c26d73-61f5-48bd-b997-f30f0b49ccb4" />

AI disclaimer: Found & Fixed with ClaudeAI