### PR TITLE
 When a cloud project download/synchronization fails due to out of storage error, invite users to upgrade

### DIFF
--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -111,14 +111,11 @@ QString QFieldCloudUtils::userFriendlyErrorString( const QString &errorString )
 
 QString QFieldCloudUtils::documentationFromErrorString( const QString &errorString )
 {
-  QString linkToDocumentation;
-
   if ( errorString.contains( errorCodeOverQuota() ) )
   {
-    linkToDocumentation = "https://docs.qfield.org/get-started/storage-qfc/#adding-qfieldcloud-storage";
+    return QStringLiteral( "https://docs.qfield.org/get-started/storage-qfc/#adding-qfieldcloud-storage" );
   }
-
-  return linkToDocumentation;
+  return QString();
 }
 
 void QFieldCloudUtils::setProjectSetting( const QString &projectId, const QString &setting, const QVariant &value )

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -101,7 +101,7 @@ QString QFieldCloudUtils::userFriendlyErrorString( const QString &errorString )
 {
   QString resultErrorString = errorString.startsWith( "[QF/" ) ? tr( "A server error has occured, please try again." ) : tr( "A network error has occured, please try again." );
 
-  if ( errorString.contains( errorCodeOverQuota ) )
+  if ( errorString.contains( errorCodeOverQuota() ) )
   {
     resultErrorString = tr( "Your account's available storage is full." );
   }
@@ -113,7 +113,7 @@ QString QFieldCloudUtils::documentationFromErrorString( const QString &errorStri
 {
   QString linkToDocumentation;
 
-  if ( errorString.contains( errorCodeOverQuota ) )
+  if ( errorString.contains( errorCodeOverQuota() ) )
   {
     linkToDocumentation = "https://docs.qfield.org/get-started/storage-qfc/#adding-qfieldcloud-storage";
   }

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -115,6 +115,8 @@ class QFieldCloudUtils : public QObject
 {
     Q_OBJECT
 
+    Q_PROPERTY( QString errorCodeOverQuota READ errorCodeOverQuota CONSTANT )
+
   public:
     /**
      * Sets the local cloud directory.
@@ -203,13 +205,11 @@ class QFieldCloudUtils : public QObject
     Q_INVOKABLE static QString subscriptionManagementUrl( const QString &serverUrl, const QString &plan, const QString &projectOwner, const QString &username );
 
   private:
-    static inline const QString errorCodeOverQuota { QStringLiteral( "over_quota" ) };
-
     static void writeToAttachmentsFile( const QString &username, const QString &projectId, const QStringList &fileNames, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck, QFieldCloudConnection *cloudConnection = nullptr );
-
     static void writeFilesFromDirectory( const QString &dirPath, const QString &projectId, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck, QTextStream &attachmentsStream );
-
     static void writeFileDetails( const QString &fileName, const QString &projectId, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck, QTextStream &attachmentsStream );
+
+    static inline const QString errorCodeOverQuota() { return QStringLiteral( "over_quota" ); };
 };
 
 #endif // QFIELDCLOUDUTILS_H

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -763,9 +763,19 @@ Popup {
     }
 
     function onProjectDownloaded(projectId, projectName, hasError, errorString) {
-      transferError.hasError = hasError;
-      if (transferError.visible) {
-        transferError.detailsText = errorString;
+      if (hasError) {
+        if (errorString.indexOf(`"code":"${QFieldCloudUtils.errorCodeOverQuota}"`) >= 0) {
+          // Let the storage meter and the toast message inviting users to upgrade subscription
+          transferError.hasError = false;
+          if (transferError.visible) {
+            transferError.detailsText = "";
+          }
+        } else {
+          transferError.hasError = hasError;
+          if (transferError.visible) {
+            transferError.detailsText = errorString;
+          }
+        }
       }
       const cloudProject = cloudProjectsModel.findProject(projectId);
       if (cloudProject.packagedLayerErrors.length !== 0) {

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -893,6 +893,17 @@ Popup {
   }
 
   function projectPush(shouldDownloadUpdates) {
+    if (shouldDownloadUpdates && storageMeterBar.value >= 1.0) {
+      if (storageMeterBar.relatedUrl != "") {
+        displayToast(qsTr("Project %1 cannot be packaged as your account's available storage is full.").arg(ProjectUtils.title(qgisProject)), 'info', qsTr('Upgrade storage'), function () {
+          Qt.openUrlExternally(storageMeterBar.relatedUrl);
+        });
+      } else {
+        displayToast(qsTr("Project %1 cannot be packaged as your account's available storage is full.").arg(ProjectUtils.title(qgisProject)), 'warning');
+      }
+      return;
+    }
+
     if (cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle) {
       cloudProjectsModel.projectPush(cloudProjectsModel.currentProjectId, shouldDownloadUpdates);
     }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -422,10 +422,10 @@ Page {
                         case QFieldCloudProject.NoErrorStatus:
                           break;
                         case QFieldCloudProject.DownloadErrorStatus:
-                          status = qsTr('Downloading error. ') + ErrorString;
+                          status = qsTr('Downloading error. ') + QFieldCloudUtils.userFriendlyErrorString(ErrorString);
                           break;
                         case QFieldCloudProject.PushErrorStatus:
-                          status = qsTr('Uploading error. ') + ErrorString;
+                          status = qsTr('Uploading error. ') + QFieldCloudUtils.userFriendlyErrorString(ErrorString);
                           break;
                         }
                         if (!status) {
@@ -451,7 +451,7 @@ Page {
                         return str.trim();
                       }
                     }
-                    visible: text != ""
+                    visible: text !== ""
                     font.pointSize: Theme.tipFont.pointSize - 2
                     color: Theme.secondaryTextColor
                     wrapMode: Text.WordWrap

--- a/src/qml/Toast.qml
+++ b/src/qml/Toast.qml
@@ -1,5 +1,7 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
+
 import org.qfield
 import Theme
 
@@ -52,12 +54,19 @@ Popup {
 
   Rectangle {
     id: toastContent
+
+    property int indicatorWidth: toastIndicator.visible ? toastIndicator.width + 10 : 0
+    property int actionWidth: toastAction.visible ? toastAction.width + 10 : 0
+    property int absoluteMessageWidth: toastFontMetrics.boundingRect(toastMessage.text).width + actionWidth + 10
+    property int unrestrainedWidth: 20 + toastFontMetrics.boundingRect(toastMessage.text).width + indicatorWidth + actionWidth + 10
+
     z: 1
-    width: toastRow.width + 20
-    height: toastMessage.contentHeight + 10
+    width: Math.min(unrestrainedWidth, toast.width - 20)
+    height: toastLayout.height + 10
     anchors.centerIn: parent
 
-    color: "#66212121"
+    color: "#CC202020"
+    border.color: "#CC404040"
     radius: 4
     opacity: 0
 
@@ -78,7 +87,7 @@ Popup {
       padding: 2
       anchors.fill: parent
       visible: timeoutFeedback
-      z: toastRow.z - 1
+      z: toastLayout.z - 1
       value: animationTimer.position / toastTimer.interval
 
       background: Item {
@@ -98,43 +107,51 @@ Popup {
       }
     }
 
-    Row {
-      id: toastRow
-      anchors.centerIn: parent
-      spacing: 10
+    GridLayout {
+      id: toastLayout
+      width: parent.width - 20
+      anchors.top: parent.top
+      anchors.left: parent.left
+      anchors.topMargin: 5
+      anchors.leftMargin: 10
+      columnSpacing: 10
+      rowSpacing: 10
+      columns: toastContent.absoluteMessageWidth > mainWindow.width * 1.75 ? 1 : 2
 
-      Rectangle {
-        id: toastIndicator
-        anchors.verticalCenter: parent.verticalCenter
-        width: 10
-        height: 10
-        radius: 5
-        color: toast.type === 'error' ? Theme.errorColor : Theme.warningColor
-        visible: toast.type != 'info'
-      }
+      RowLayout {
+        id: toastMessageLayout
+        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignVCenter
+        spacing: 10
 
-      Text {
-        id: toastMessage
+        Rectangle {
+          id: toastIndicator
+          Layout.alignment: Qt.AlignVCenter
+          Layout.preferredWidth: 10
+          Layout.preferredHeight: 10
+          radius: 5
+          color: toast.type === 'error' ? Theme.errorColor : Theme.warningColor
+          visible: toast.type != 'info'
+        }
 
-        property int absoluteWidth: toastFontMetrics.boundingRect(text).width + 10
+        Text {
+          id: toastMessage
 
-        width: 40 + absoluteWidth + (toastIndicator.visible ? toastIndicator.width + 10 : 0) + (toastAction.visible ? toastAction.width + 10 : 0) > toast.width ? toast.width - (toastIndicator.visible ? toastIndicator.width + 10 : 0) - (toastAction.visible ? toastAction.width + 10 : 0) - 40 : absoluteWidth
-        wrapMode: Text.Wrap
-        topPadding: 3
-        bottomPadding: 3
-        color: Theme.light
+          Layout.fillWidth: true
+          wrapMode: Text.Wrap
+          topPadding: 3
+          bottomPadding: 3
+          color: Theme.light
 
-        font: Theme.defaultFont
-        horizontalAlignment: Text.AlignHCenter
+          font: Theme.defaultFont
+          horizontalAlignment: Text.AlignHCenter
+        }
       }
 
       QfButton {
         id: toastAction
-
+        Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
         visible: text != ''
-        anchors.verticalCenter: parent.verticalCenter
-        height: Math.min(toastActionLabelMetrics.contentHeight + 10, toastMessage.height)
-
         radius: 4
         bgcolor: "#99000000"
         color: Theme.mainColor
@@ -146,14 +163,6 @@ Popup {
           }
           toast.close();
           toastContent.opacity = 0;
-        }
-
-        Text {
-          id: toastActionLabelMetrics
-          visible: false
-          width: toastAction.width - 10
-          font: toastAction.font
-          text: toastAction.text
         }
       }
     }
@@ -221,6 +230,7 @@ Popup {
         }
       }
     }
+
     toastMessage.text = text;
     toast.type = type || 'info';
     if (timeout_feedback !== undefined) {

--- a/src/qml/Toast.qml
+++ b/src/qml/Toast.qml
@@ -132,7 +132,8 @@ Popup {
         id: toastAction
 
         visible: text != ''
-        height: toastMessage.height
+        anchors.verticalCenter: parent.verticalCenter
+        height: Math.min(toastActionLabelMetrics.contentHeight + 10, toastMessage.height)
 
         radius: 4
         bgcolor: "#99000000"
@@ -145,6 +146,14 @@ Popup {
           }
           toast.close();
           toastContent.opacity = 0;
+        }
+
+        Text {
+          id: toastActionLabelMetrics
+          visible: false
+          width: toastAction.width - 10
+          font: toastAction.font
+          text: toastAction.text
         }
       }
     }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -5076,7 +5076,7 @@ ApplicationWindow {
 
     onProjectDownloaded: (projectId, projectName, hasError, errorString) => {
       if (hasError) {
-        if (errorString.indexOf(`"code":"${QFieldCloudUtils.errorCodeOverQuota}"`)) {
+        if (errorString.indexOf(`"code":"${QFieldCloudUtils.errorCodeOverQuota}"`) >= 0) {
           if (true) {//cloudConnection.url == QFieldCloudConnection.defaultUrl) {
             displayToast(qsTr("Project %1 failed to download as your account's available storage is full.").arg(projectName), 'info', qsTr('Upgrade storage'), function () {
               Qt.openUrlExternally('https://app.qfield.cloud/plans');

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -5077,12 +5077,12 @@ ApplicationWindow {
     onProjectDownloaded: (projectId, projectName, hasError, errorString) => {
       if (hasError) {
         if (errorString.indexOf(`"code":"${QFieldCloudUtils.errorCodeOverQuota}"`) >= 0) {
-          if (true) {//cloudConnection.url == QFieldCloudConnection.defaultUrl) {
-            displayToast(qsTr("Project %1 failed to download as your account's available storage is full.").arg(projectName), 'info', qsTr('Upgrade storage'), function () {
+          if (cloudConnection.url == QFieldCloudConnection.defaultUrl) {
+            displayToast(qsTr("Project %1 cannot be packaged as your account's available storage is full.").arg(projectName), 'info', qsTr('Upgrade storage'), function () {
               Qt.openUrlExternally('https://app.qfield.cloud/plans');
             });
           } else {
-            displayToast(qsTr("Project %1 failed to download as your account's available storage is full.").arg(projectName), 'warning');
+            displayToast(qsTr("Project %1 cannot be packaged as your account's available storage is full.").arg(projectName), 'warning');
           }
         } else {
           displayToast(qsTr("Project %1 failed to download").arg(projectName), 'error');

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -5076,8 +5076,18 @@ ApplicationWindow {
 
     onProjectDownloaded: (projectId, projectName, hasError, errorString) => {
       if (hasError) {
-        qfieldCloudStatus.refresh();
-        displayToast(qsTr("Project %1 failed to download").arg(projectName), 'error');
+        if (errorString.indexOf(`"code":"${QFieldCloudUtils.errorCodeOverQuota}"`)) {
+          if (true) {//cloudConnection.url == QFieldCloudConnection.defaultUrl) {
+            displayToast(qsTr("Project %1 failed to download as your account's available storage is full.").arg(projectName), 'info', qsTr('Upgrade storage'), function () {
+              Qt.openUrlExternally('https://app.qfield.cloud/plans');
+            });
+          } else {
+            displayToast(qsTr("Project %1 failed to download as your account's available storage is full.").arg(projectName), 'warning');
+          }
+        } else {
+          displayToast(qsTr("Project %1 failed to download").arg(projectName), 'error');
+          qfieldCloudStatus.refresh();
+        }
       } else if (qfieldCloudScreen.visible || qfieldCloudPopup.visible || welcomeScreen.visible) {
         displayToast(qsTr("Project %1 successfully downloaded, it's now available to open").arg(projectName));
       }


### PR DESCRIPTION
Before :robot: 

<img width="637" height="716" alt="image" src="https://github.com/user-attachments/assets/0aca34eb-cb54-4deb-ab2f-eb792d75851c" />

With PR in :heart_eyes_cat: 

<img width="549" height="986" alt="image" src="https://github.com/user-attachments/assets/73a5a691-1720-418d-8370-001a8798702c" />

We don't need to be obscure when there's a simple (open source project-supportive) solution for a failing download due to lack of storage space.