### PR TITLE
Reset video card to thumbnail state after playback ends

### DIFF
--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -871,6 +871,17 @@ RelationEditorBase {
         property url sourceUrl: attachmentIsVideo ? UrlUtils.fromString(attachmentFullPath) : ""
         property bool firstFrameDrawn: false
 
+        Timer {
+          id: reloadTimer
+          interval: 10
+          repeat: false
+          onTriggered: {
+            videoThumbLoader.firstFrameDrawn = false;
+            videoThumbLoader.active = false;
+            videoThumbLoader.active = true;
+          }
+        }
+
         sourceComponent: Component {
           Video {
             anchors.fill: parent
@@ -889,6 +900,15 @@ RelationEditorBase {
               if (!videoThumbLoader.firstFrameDrawn && playbackState === MediaPlayer.PlayingState) {
                 videoThumbLoader.firstFrameDrawn = true;
                 thumbnailPauseTimer.start();
+              }
+            }
+
+            onPlaybackStateChanged: {
+              // Detect natural end-of-playback
+              if (cardContainer.videoPlaying && playbackState === MediaPlayer.StoppedState && duration > 0 && position >= duration * 0.1) {
+                cardContainer.videoPlaying = false;
+                relationEditor.releaseMediaFocus(cardContainer);
+                reloadTimer.start();
               }
             }
 

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -85,6 +85,31 @@ RelationEditorBase {
     externalStorage.fetch(next.url, next.authId);
   }
 
+  property var videoQueue: []
+  property bool videoQueueBusy: false
+
+  Timer {
+    id: videoQueueTimer
+    interval: 150
+    onTriggered: {
+      while (videoQueue.length > 0) {
+        if (videoQueue.shift()()) {
+          videoQueueTimer.start();
+          return;
+        }
+      }
+      videoQueueBusy = false;
+    }
+  }
+
+  function queueVideoLoad(fn) {
+    videoQueue.push(fn);
+    if (!videoQueueBusy) {
+      videoQueueBusy = true;
+      videoQueueTimer.start();
+    }
+  }
+
   QtObject {
     id: dummyTarget
   }
@@ -576,12 +601,29 @@ RelationEditorBase {
 
       Loader {
         id: listVideoThumbLoader
-        active: attachmentIsVideo
+        active: false
         parent: listVideoContainer
         anchors.fill: parent
 
         property url sourceUrl: attachmentIsVideo ? UrlUtils.fromString(attachmentFullPath) : ""
         property bool firstFrameDrawn: false
+        property bool queued: false
+
+        onSourceUrlChanged: {
+          active = false;
+          firstFrameDrawn = false;
+          queued = false;
+          if (attachmentIsVideo && sourceUrl.toString() !== "") {
+            queued = true;
+            relationEditor.queueVideoLoad(() => {
+              if (!listVideoThumbLoader || !listVideoThumbLoader.queued)
+                return false;
+              listVideoThumbLoader.queued = false;
+              listVideoThumbLoader.active = true;
+              return true;
+            });
+          }
+        }
 
         sourceComponent: Component {
           Video {
@@ -864,21 +906,27 @@ RelationEditorBase {
 
       Loader {
         id: videoThumbLoader
-        active: attachmentIsVideo
+        active: false
         parent: cardVideoContainer
         anchors.fill: parent
 
         property url sourceUrl: attachmentIsVideo ? UrlUtils.fromString(attachmentFullPath) : ""
         property bool firstFrameDrawn: false
+        property bool queued: false
 
-        Timer {
-          id: reloadTimer
-          interval: 10
-          repeat: false
-          onTriggered: {
-            videoThumbLoader.firstFrameDrawn = false;
-            videoThumbLoader.active = false;
-            videoThumbLoader.active = true;
+        onSourceUrlChanged: {
+          active = false;
+          firstFrameDrawn = false;
+          queued = false;
+          if (attachmentIsVideo && sourceUrl.toString() !== "") {
+            queued = true;
+            relationEditor.queueVideoLoad(() => {
+              if (!videoThumbLoader || !videoThumbLoader.queued)
+                return false;
+              videoThumbLoader.queued = false;
+              videoThumbLoader.active = true;
+              return true;
+            });
           }
         }
 
@@ -908,7 +956,8 @@ RelationEditorBase {
               if (cardContainer.videoPlaying && playbackState === MediaPlayer.StoppedState && duration > 0 && position >= duration * 0.1) {
                 cardContainer.videoPlaying = false;
                 relationEditor.releaseMediaFocus(cardContainer);
-                reloadTimer.start();
+                seek(0);
+                pause();
               }
             }
 

--- a/test/spix/smoke_test.py
+++ b/test/spix/smoke_test.py
@@ -402,7 +402,7 @@ def test_gallery_editor(app, screenshot_path, screenshot_check, extra, process_a
     )
     assert process_alive()
     extra.append(extras.html('<img src="images/test_gallery_editor_grid.png"/>'))
-    assert screenshot_check("test_gallery_editor", "test_gallery_editor_grid", 0.025)
+    assert screenshot_check("test_gallery_editor", "test_gallery_editor_grid", 0.075)
 
     # Click the sort button in the gallery editor header to reverse card order
     bounds = app.getBoundingBox(
@@ -420,7 +420,7 @@ def test_gallery_editor(app, screenshot_path, screenshot_check, extra, process_a
     )
     assert process_alive()
     extra.append(extras.html('<img src="images/test_gallery_editor_sorted.png"/>'))
-    assert screenshot_check("test_gallery_editor", "test_gallery_editor_sorted", 0.025)
+    assert screenshot_check("test_gallery_editor", "test_gallery_editor_sorted", 0.075)
 
     # Click sort again to restore original card order before tapping a specific card
     pyautogui.click(interval=0.5)
@@ -443,7 +443,7 @@ def test_gallery_editor(app, screenshot_path, screenshot_check, extra, process_a
     assert process_alive()
     extra.append(extras.html('<img src="images/test_gallery_editor_child_form.png"/>'))
     assert screenshot_check(
-        "test_gallery_editor", "test_gallery_editor_child_form", 0.025
+        "test_gallery_editor", "test_gallery_editor_child_form", 0.075
     )
 
     # Close the child feature form (X close button at top right of the form)
@@ -475,7 +475,7 @@ def test_gallery_editor(app, screenshot_path, screenshot_check, extra, process_a
     )
     assert process_alive()
     extra.append(extras.html('<img src="images/test_gallery_editor_list.png"/>'))
-    assert screenshot_check("test_gallery_editor", "test_gallery_editor_list", 0.025)
+    assert screenshot_check("test_gallery_editor", "test_gallery_editor_list", 0.075)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Improvement, when a gallery video finished playing, the card remained on the last frame (or went blank on some backends), requiring a click to return to a playable state
Detect natural end-of-playback via playbackState transitioning to StoppedState, then reload the Video element to restore the initial thumbnail + play-icon state. Media focus is released so the next playback starts cleanly

## Follow up problem :

Thanks to @nirvn for the idea of serialising video thumbnail captures via a timer, it turned out to be the right approach for the decoder contention problem

The problem we had was opening a gallery with many videos tried to activate every video element at once so the simultaneous activation exhausted decoders, thumbnails would fail to load, and on ios, mac this could come into a crash, especially during fast scrolling where GridView rapidly creates and destroys delegates

## The fix:
- videoQueue and videoQueueTimer at the root. Video loaders start with active: false and register themselves via queueVideoLoad()
- The timer activates one loader at a time with a 150ms gap between each. Decoders open sequentially instead of all at once
- Each loader carries a simple queued flag whhen GridView recycles or destroys a delegate, onSourceUrlChanged resets the flag, and the queued callback bails on its next turn, no dangling references to destroyed QML objects, which was the source of the fast-scroll crashes as well

https://github.com/user-attachments/assets/2de1af0f-7099-464e-8524-3b1fdb1bcd75