### PR TITLE
Refresh Toast appearance UI

### DIFF
--- a/src/qml/Toast.qml
+++ b/src/qml/Toast.qml
@@ -58,10 +58,9 @@ Popup {
     property int contentPadding: 20
     property int topPadding: toastLayout.columns === 1 ? 8 : 10
     property int bottomPadding: toastLayout.columns === 1 ? 12 : 10
-    property int indicatorWidth: toastIndicator.visible ? toastIndicator.width : 0
     property int actionWidth: toastAction.visible ? toastAction.width + 10 : 0
     property int absoluteMessageWidth: toastFontMetrics.boundingRect(toastMessage.text).width + actionWidth + 10
-    property int unrestrainedWidth: contentPadding * 2 + toastFontMetrics.boundingRect(toastMessage.text).width + indicatorWidth + actionWidth + 10
+    property int unrestrainedWidth: contentPadding * 2 + toastFontMetrics.boundingRect(toastMessage.text).width + actionWidth + 10
 
     z: 1
     width: Math.min(unrestrainedWidth, toast.width - 20)
@@ -126,11 +125,11 @@ Popup {
 
     GridLayout {
       id: toastLayout
-      width: parent.width - toastContent.contentPadding * 2 - toastContent.indicatorWidth
+      width: parent.width - toastContent.contentPadding * 2
       anchors.top: parent.top
       anchors.left: parent.left
       anchors.topMargin: toastContent.topPadding
-      anchors.leftMargin: toastContent.contentPadding + toastContent.indicatorWidth
+      anchors.leftMargin: toastContent.contentPadding
       columnSpacing: 10
       rowSpacing: 12
       columns: toastContent.absoluteMessageWidth > mainWindow.width * 1.75 ? 1 : 2

--- a/src/qml/Toast.qml
+++ b/src/qml/Toast.qml
@@ -56,6 +56,8 @@ Popup {
     id: toastContent
 
     property int contentPadding: 20
+    property int topPadding: toastLayout.columns === 1 ? 8 : 10
+    property int bottomPadding: toastLayout.columns === 1 ? 12 : 10
     property int indicatorWidth: toastIndicator.visible ? toastIndicator.width : 0
     property int actionWidth: toastAction.visible ? toastAction.width + 10 : 0
     property int absoluteMessageWidth: toastFontMetrics.boundingRect(toastMessage.text).width + actionWidth + 10
@@ -63,7 +65,7 @@ Popup {
 
     z: 1
     width: Math.min(unrestrainedWidth, toast.width - 20)
-    height: toastLayout.height + 10
+    height: toastLayout.height + topPadding + bottomPadding
     anchors.centerIn: parent
 
     color: "#CC202020"
@@ -127,10 +129,10 @@ Popup {
       width: parent.width - toastContent.contentPadding * 2 - toastContent.indicatorWidth
       anchors.top: parent.top
       anchors.left: parent.left
-      anchors.topMargin: 5
+      anchors.topMargin: toastContent.topPadding
       anchors.leftMargin: toastContent.contentPadding + toastContent.indicatorWidth
       columnSpacing: 10
-      rowSpacing: 10
+      rowSpacing: 12
       columns: toastContent.absoluteMessageWidth > mainWindow.width * 1.75 ? 1 : 2
 
       Text {
@@ -145,10 +147,10 @@ Popup {
 
       QfButton {
         id: toastAction
-        Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+        Layout.alignment: (toastLayout.columns === 1 ? Qt.AlignLeft : Qt.AlignHCenter) | Qt.AlignVCenter
         visible: text != ''
         radius: 4
-        bgcolor: "#99000000"
+        bgcolor: "#00000000"
         color: Theme.mainColor
         font.pointSize: Theme.tipFont.pointSize
 

--- a/src/qml/Toast.qml
+++ b/src/qml/Toast.qml
@@ -55,10 +55,11 @@ Popup {
   Rectangle {
     id: toastContent
 
-    property int indicatorWidth: toastIndicator.visible ? toastIndicator.width + 10 : 0
+    property int contentPadding: 20
+    property int indicatorWidth: toastIndicator.visible ? toastIndicator.width : 0
     property int actionWidth: toastAction.visible ? toastAction.width + 10 : 0
     property int absoluteMessageWidth: toastFontMetrics.boundingRect(toastMessage.text).width + actionWidth + 10
-    property int unrestrainedWidth: 20 + toastFontMetrics.boundingRect(toastMessage.text).width + indicatorWidth + actionWidth + 10
+    property int unrestrainedWidth: contentPadding * 2 + toastFontMetrics.boundingRect(toastMessage.text).width + indicatorWidth + actionWidth + 10
 
     z: 1
     width: Math.min(unrestrainedWidth, toast.width - 20)
@@ -107,45 +108,39 @@ Popup {
       }
     }
 
+    Rectangle {
+      id: toastIndicator
+      anchors.left: parent.left
+      anchors.top: parent.top
+      anchors.bottom: parent.bottom
+      width: 5
+      topLeftRadius: toastContent.radius
+      bottomLeftRadius: toastContent.radius
+      topRightRadius: 0
+      bottomRightRadius: 0
+      color: toast.type === 'error' ? Theme.errorColor : Theme.warningColor
+      visible: toast.type != 'info'
+    }
+
     GridLayout {
       id: toastLayout
-      width: parent.width - 20
+      width: parent.width - toastContent.contentPadding * 2 - toastContent.indicatorWidth
       anchors.top: parent.top
       anchors.left: parent.left
       anchors.topMargin: 5
-      anchors.leftMargin: 10
+      anchors.leftMargin: toastContent.contentPadding + toastContent.indicatorWidth
       columnSpacing: 10
       rowSpacing: 10
       columns: toastContent.absoluteMessageWidth > mainWindow.width * 1.75 ? 1 : 2
 
-      RowLayout {
-        id: toastMessageLayout
+      Text {
+        id: toastMessage
         Layout.fillWidth: true
-        Layout.alignment: Qt.AlignVCenter
-        spacing: 10
+        wrapMode: Text.Wrap
+        color: Theme.light
 
-        Rectangle {
-          id: toastIndicator
-          Layout.alignment: Qt.AlignVCenter
-          Layout.preferredWidth: 10
-          Layout.preferredHeight: 10
-          radius: 5
-          color: toast.type === 'error' ? Theme.errorColor : Theme.warningColor
-          visible: toast.type != 'info'
-        }
-
-        Text {
-          id: toastMessage
-
-          Layout.fillWidth: true
-          wrapMode: Text.Wrap
-          topPadding: 3
-          bottomPadding: 3
-          color: Theme.light
-
-          font: Theme.defaultFont
-          horizontalAlignment: Text.AlignHCenter
-        }
+        font: Theme.defaultFont
+        horizontalAlignment: Text.AlignLeft
       }
 
       QfButton {


### PR DESCRIPTION
Four small UI improvements to the Toast component:

- Side bar instead of circular indicator replaces the 10×10 dot with a 5px vertical bar anchored to the toast's left edge (rounded left corners, sharp right). Hidden for info toasts, similar behaviour to how it was before.
- Left-aligned message and symmetric spacing, text switches to AlignLeft. Horizontal padding centralized via a contentPadding property (20px), with indicatorWidth visibility aware so info toasts and warning/error toasts both have symmetric gaps
- Outlined action button by setting bgcolor to #00000000 triggers QfButtons existing transparentbg branch, rendering a green border plus green text on transparent fill instead
- Button placement when wrapped so when the message wraps and the button drops to its own row, it now left aligns under the text. Vertical padding adapts: 10/10 symmetric in single-row mode, 8/12 when wrapped (more room below the button). rowSpacing bumped to 12

## DEMO of the some versions

<img width="3445" height="1854" alt="toastTest" src="https://github.com/user-attachments/assets/930bcd0b-2dfa-4fbe-9496-3da8e42e0d57" />
