### PR TITLE
Add fix to guard against WebView items stealing focus

### DIFF
--- a/vcpkg/ports/qtbase/portfile.cmake
+++ b/vcpkg/ports/qtbase/portfile.cmake
@@ -27,6 +27,7 @@ set(${PORT}_PATCHES
         fix-libresolv-test.patch
         use_inotify_on_freebsd.patch
         fix-qyieldcpu-apple-clang.patch
+        webviewfocus.patch
 )
  
 if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)

--- a/vcpkg/ports/qtbase/webviewfocus.patch
+++ b/vcpkg/ports/qtbase/webviewfocus.patch
@@ -1,0 +1,47 @@
+From 9b93d2d88e71426529deb3fa11ee7864a54e1c03 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Christian=20Str=C3=B8mme?= <christian.stromme@qt.io>
+Date: Fri, 10 Apr 2026 20:59:45 +0200
+Subject: [PATCH] Android: Don't request focus when raising/lowering windows
+
+These are two different things, so changing the windows z-order should
+not affect which window that has focus. It's for example possible to change
+the order while a window is hidden, causing a hidden window to have
+focus.
+
+Fixes: QTBUG-141450
+Change-Id: Ieffe9f336e62f5de9613bbd93998186367773cc6
+Reviewed-by: Assam Boudjelthia <assam.boudjelthia@qt.io>
+(cherry picked from commit 626d508feb430469d885b12dcf0e995a19905528)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+---
+ .../platforms/android/qandroidplatformwindow.cpp       | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/src/plugins/platforms/android/qandroidplatformwindow.cpp b/src/plugins/platforms/android/qandroidplatformwindow.cpp
+index 36ea443dfb19..7ba82ef766a6 100644
+--- a/src/plugins/platforms/android/qandroidplatformwindow.cpp
++++ b/src/plugins/platforms/android/qandroidplatformwindow.cpp
+@@ -118,7 +118,6 @@ void QAndroidPlatformWindow::raise()
+ {
+     if (m_nativeParentQtWindow.isValid()) {
+         m_nativeParentQtWindow.callMethod<void>("bringChildToFront", nativeViewId());
+-        QWindowSystemInterface::handleFocusWindowChanged(window(), Qt::ActiveWindowFocusReason);
+         return;
+     }
+     updateSystemUiVisibility(window()->windowStates(), window()->flags());
+@@ -240,9 +239,12 @@ void QAndroidPlatformWindow::propagateSizeHints()
+ 
+ void QAndroidPlatformWindow::requestActivateWindow()
+ {
+-    // raise() will handle differences between top level and child windows, and requesting focus
+-    if (!blockedByModal())
+-        raise();
++    if (blockedByModal())
++        return;
++    raise();
++    // For child windows, raise() only updates "Z-order", so focus must be requested explicitly.
++    if (m_nativeParentQtWindow.isValid())
++        QWindowSystemInterface::handleFocusWindowChanged(window(), Qt::ActiveWindowFocusReason);
+ }
+ 
+ void QAndroidPlatformWindow::updateSystemUiVisibility(Qt::WindowStates states, Qt::WindowFlags flags)


### PR DESCRIPTION
Issues spotted in the wild with Samsung users when feature forms include an HTML editor widget:

- https://github.com/opengisch/QField/issues/7216
- https://github.com/opengisch/QField/issues/7243

Basically, the WebView used when adding an HTML editor widget in the feature form steals the focus from anything. This patch applied upstream recently is likely the fix we need.