### PR TITLE
Insure proper permissions set on cloud project files during download / synchronization

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -1476,11 +1476,16 @@ bool QFieldCloudProject::moveDownloadedFilesToPermanentStorage()
 
     // If the file already exists, we need to delete it first, as QT does not support overwriting
     // NOTE: it is possible that someone creates the file in the meantime between this and the next if statement
-    if ( QFile::exists( finalFilePath ) && !QFile::remove( finalFilePath ) )
+    if ( QFile::exists( finalFilePath ) )
     {
-      hasError = true;
-      QgsMessageLog::logMessage( QStringLiteral( "Failed to remove existing file `%1`" ).arg( finalFilePath ) );
-      continue;
+      // Insure correct permissions prior to removing the file
+      QFile::setPermissions( finalFilePath, QFileDevice::ReadUser | QFileDevice::WriteUser | QFileDevice::ReadOwner | QFileDevice::WriteOwner );
+      if ( !QFile::remove( finalFilePath ) )
+      {
+        hasError = true;
+        QgsMessageLog::logMessage( QStringLiteral( "Failed to remove existing file `%1`" ).arg( finalFilePath ) );
+        continue;
+      }
     }
 
     // Rename the .part file to the final file name
@@ -1493,6 +1498,9 @@ bool QFieldCloudProject::moveDownloadedFilesToPermanentStorage()
     {
       QgsLogger::debug( QStringLiteral( "Moved downloaded file `%1` to `%2`" ).arg( fileTransfer.partialFilePath, finalFilePath ) );
     }
+
+    // Insure correct permissions are allowing for user access
+    QFile::setPermissions( finalFilePath, QFileDevice::ReadUser | QFileDevice::WriteUser | QFileDevice::ReadOwner | QFileDevice::WriteOwner );
   }
 
   return !hasError;


### PR DESCRIPTION
This should fix errors on Windows when synchronizing a cloud project already present locally.

The error was:

```
Failed to remove existing file `C:/Users/sam/AppData/Roaming/OPENGIS.ch/QField/cloud_projects/spwoodcock/bccad47a-7149-47f9-9eb3-03e154637925/./data.gpkg`"
": Downloading project `bccad47a-7149-47f9-9eb3-03e154637925` finished with an error: Failed to copy some of the downloaded files on your device. Check your device storage."
```

A failure to remove means the file exists and can't be removed prior to being replaced. Since we do a pretty good job at closing the project and unlocking the .gpkg, I assume it's the Windows permission issue we've hit elsewhere.

@suricactus , this is something we hit on QFS right? 