### PR TITLE
 Insure that the parent feature is prepared to receive the child when using the capture photo/video/audio button

### DIFF
--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -146,8 +146,8 @@ EditorWidgetBase {
             return;
           }
 
-          displayToast(qsTr('Adding child feature in layer %1').arg(relationEditorModel.relation.referencingLayer.name));
           if (relationEditorModel.relation.referencingLayer.geometryType() !== Qgis.GeometryType.Null) {
+            displayToast(qsTr('Adding child feature in layer %1').arg(relationEditorModel.relation.referencingLayer.name));
             requestGeometry(relationEditor, relationEditorModel.relation.referencingLayer);
             return;
           }

--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -142,28 +142,16 @@ EditorWidgetBase {
         repeat: false
 
         onTriggered: {
-          let saved = form.state === 'Add' ? !form.setupOnly && save() : true;
-          if (ProjectUtils.transactionMode(qgisProject) !== Qgis.TransactionMode.Disabled) {
-            // When a transaction mode is enabled, we must fallback to saving the parent feature to have provider-side issues
-            if (!saved) {
-              addingIndicator.running = false;
-              displayToast(qsTr('Cannot add child feature: insure the parent feature meets all constraints and can be saved'), 'warning');
-              return;
-            }
+          if (!prepareParent()) {
+            return;
           }
 
-          //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
-          if (relationEditorModel.parentPrimariesAvailable) {
-            displayToast(qsTr('Adding child feature in layer %1').arg(relationEditorModel.relation.referencingLayer.name));
-            if (relationEditorModel.relation.referencingLayer.geometryType() !== Qgis.GeometryType.Null) {
-              requestGeometry(relationEditor, relationEditorModel.relation.referencingLayer);
-              return;
-            }
-            showAddFeaturePopup();
-          } else {
-            addingIndicator.running = false;
-            displayToast(qsTr('Cannot add child feature: attribute value linking parent and children is not set'), 'warning');
+          displayToast(qsTr('Adding child feature in layer %1').arg(relationEditorModel.relation.referencingLayer.name));
+          if (relationEditorModel.relation.referencingLayer.geometryType() !== Qgis.GeometryType.Null) {
+            requestGeometry(relationEditor, relationEditorModel.relation.referencingLayer);
+            return;
           }
+          showAddFeaturePopup();
         }
       }
     }
@@ -494,5 +482,26 @@ EditorWidgetBase {
     }
     embeddedPopup.open();
     embeddedPopup.attributeFormModel.applyParentDefaultValues();
+  }
+
+  function prepareParent() {
+    let saved = form.state === 'Add' ? !form.setupOnly && save() : true;
+    if (ProjectUtils.transactionMode(qgisProject) !== Qgis.TransactionMode.Disabled) {
+      // When a transaction mode is enabled, we must fallback to saving the parent feature to have provider-side issues
+      if (!saved) {
+        addingIndicator.running = false;
+        displayToast(qsTr('Cannot add child feature: insure the parent feature meets all constraints and can be saved'), 'warning');
+        return false;
+      }
+    }
+
+    //this has to be checked after buffering because the primary could be a value that has been created on creating featurer (e.g. fid)
+    if (!relationEditorModel.parentPrimariesAvailable) {
+      addingIndicator.running = false;
+      displayToast(qsTr('Cannot add child feature: attribute value linking parent and children is not set'), 'warning');
+      return false;
+    }
+
+    return true;
   }
 }

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -314,6 +314,10 @@ RelationEditorBase {
       iconColor: Theme.mainTextColor
       bgcolor: 'transparent'
       onClicked: {
+        if (!prepareParent()) {
+          return;
+        }
+
         switch (documentViewer) {
         case ExternalResource.DocumentVideo:
           captureVideo();


### PR DESCRIPTION
This PR insures that a child feature added via our new gallery editor widget's capture button prepare the parent the same way we have been doing when using the [+] add child button in our other relationship editor widgets.

There's an important check here for parentPrimariesAvailable. If that check fails, children _cannot_ be added. We were failing to safeguard us from that, leading to photos taken but never added as a complete child feature.