### PR TITLE
tests to cover plugin QML invokables and properties

### DIFF
--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -29,10 +29,12 @@
 #include <QCoreApplication>
 #include <QDirIterator>
 #include <QFileInfo>
+#include <QGuiApplication>
 #include <QImageReader>
 #include <QLocale>
 #include <QQmlApplicationEngine>
 #include <QQuickItem>
+#include <QQuickWindow>
 #include <QSettings>
 #include <QTemporaryFile>
 #include <QTranslator>
@@ -63,7 +65,23 @@ QObject *AppInterface::rootObject() const
   {
     return appEngine->rootObjects().isEmpty() ? nullptr : appEngine->rootObjects().at( 0 );
   }
-  // engine-only path, findChild() walks whatever QQuickTest has parented to the engine
+
+  // Engine only path (eg. QtQuickTest harness) the test window is not
+  // necessarily parented under the engine, so locate it via the application's
+  // top-level windows and match it back to mEngine through its content item
+  if ( mEngine )
+  {
+    const QList<QWindow *> windows = QGuiApplication::topLevelWindows();
+    for ( QWindow *window : windows )
+    {
+      QQuickWindow *quickWindow = qobject_cast<QQuickWindow *>( window );
+      if ( quickWindow && quickWindow->contentItem() && qmlEngine( quickWindow->contentItem() ) == mEngine )
+      {
+        return quickWindow->contentItem();
+      }
+    }
+  }
+
   return mEngine;
 }
 

--- a/test/qml/tst_plugin_functionalities.qml
+++ b/test/qml/tst_plugin_functionalities.qml
@@ -1,0 +1,195 @@
+import QtQuick
+import QtTest
+import org.qfield
+import org.qgis
+import Theme
+
+TestCase {
+  id: testCase
+  name: "PluginFunctionalities"
+
+  Item {
+    id: dashBoardStub
+    objectName: "dashBoard"
+
+    property var activeLayer: null
+  }
+
+  Item {
+    id: pluginsToolbarStub
+
+    property var addedItems: []
+  }
+
+  property var ifaceStub: ({
+      "mainWindow": function () {
+        return testCase;
+      },
+      "findItemByObjectName": function (name) {
+        return name === "dashBoard" ? dashBoardStub : null;
+      },
+      "addItemToPluginsToolbar": function (item) {
+        pluginsToolbarStub.addedItems.push(item);
+      }
+    })
+
+  function init() {
+    dashBoardStub.activeLayer = null;
+    pluginsToolbarStub.addedItems = [];
+  }
+
+  function makeMemoryLayer(name) {
+    const existing = qgisProject.mapLayersByName(name);
+    if (existing.length > 0) {
+      return existing[0];
+    }
+    const fields = FeatureUtils.createFields([FeatureUtils.createField("id", FeatureUtils.Int)]);
+    const layer = LayerUtils.createMemoryLayer(name, fields, Qgis.WkbType.Point, CoordinateReferenceSystemUtils.wgs84Crs());
+    ProjectUtils.addMapLayer(qgisProject, layer);
+    return layer;
+  }
+
+  // Bees-Focus
+
+  Component {
+    id: beesFocusToolButton
+
+    QfToolButton {
+      text: "A"
+      iconColor: Theme.toolButtonColor
+      bgcolor: Theme.toolButtonBackgroundColor
+      round: true
+    }
+  }
+
+  Component {
+    id: beesFocusPlugin
+
+    Item {
+      id: plugin
+
+      property var iface
+      property var qgisProject
+      property var mainWindow: iface ? iface.mainWindow() : null
+      property var dashBoard: iface ? iface.findItemByObjectName("dashBoard") : null
+      property string apiaryLayerName: "BeesFocusApiary"
+      property string tracksLayerName: "BeesFocusTracks"
+
+      function activateLayerByName(name) {
+        const layers = ProjectUtils.mapLayers(qgisProject);
+        for (const layerId in layers) {
+          if (layers[layerId].name === name) {
+            dashBoard.activeLayer = layers[layerId];
+            break;
+          }
+        }
+      }
+
+      Component.onCompleted: {
+        iface.addItemToPluginsToolbar(apiaryButton);
+        iface.addItemToPluginsToolbar(tracksButton);
+      }
+
+      QfToolButton {
+        id: apiaryButton
+
+        text: "A"
+        iconColor: Theme.toolButtonColor
+        bgcolor: Theme.toolButtonBackgroundColor
+        round: true
+
+        onClicked: plugin.activateLayerByName(plugin.apiaryLayerName)
+      }
+
+      QfToolButton {
+        id: tracksButton
+
+        text: "T"
+        iconColor: Theme.toolButtonColor
+        bgcolor: Theme.toolButtonBackgroundColor
+        round: true
+
+        onClicked: plugin.activateLayerByName(plugin.tracksLayerName)
+      }
+    }
+  }
+
+  function test_beesFocus_01_projectUtilsMapLayersReturnsLayer() {
+    const layer = makeMemoryLayer("BeesFocusMapLayersTest");
+    const layers = ProjectUtils.mapLayers(qgisProject);
+    verify(typeof layers === "object" && layers !== null);
+    verify(layer.id in layers);
+    compare(layers[layer.id].id, layer.id);
+  }
+
+  function test_beesFocus_02_mapLayerExposesNameProperty() {
+    const layer = makeMemoryLayer("BeesFocusNameTest");
+    const layers = ProjectUtils.mapLayers(qgisProject);
+    compare(layers[layer.id].name, "BeesFocusNameTest");
+  }
+
+  function test_beesFocus_03_qfToolButtonAcceptsPluginProperties() {
+    const btn = createTemporaryObject(beesFocusToolButton, testCase);
+    verify(btn !== null);
+    compare(btn.text, "A");
+    compare(btn.round, true);
+    compare(btn.iconColor, Theme.toolButtonColor);
+    compare(btn.bgcolor, Theme.toolButtonBackgroundColor);
+  }
+
+  function test_beesFocus_04_qfToolButtonClickedTriggersHandler() {
+    const btn = createTemporaryObject(beesFocusToolButton, testCase);
+    let fired = 0;
+    btn.clicked.connect(function () {
+      fired += 1;
+    });
+    btn.clicked();
+    compare(fired, 1);
+  }
+
+  function test_beesFocus_05_pluginCompletionRegistersBothButtons() {
+    const plugin = createTemporaryObject(beesFocusPlugin, testCase, {
+      "iface": ifaceStub,
+      "qgisProject": qgisProject
+    });
+    verify(plugin !== null);
+    compare(pluginsToolbarStub.addedItems.length, 2);
+    compare(pluginsToolbarStub.addedItems[0].text, "A");
+    compare(pluginsToolbarStub.addedItems[1].text, "T");
+  }
+
+  function test_beesFocus_06_pluginResolvesIfaceProperties() {
+    const plugin = createTemporaryObject(beesFocusPlugin, testCase, {
+      "iface": ifaceStub,
+      "qgisProject": qgisProject
+    });
+    verify(plugin !== null);
+    compare(plugin.mainWindow, testCase);
+    compare(plugin.dashBoard, dashBoardStub);
+  }
+
+  function test_beesFocus_07_buttonClickActivatesMatchingLayer() {
+    makeMemoryLayer("BeesFocusApiary");
+    makeMemoryLayer("BeesFocusTracks");
+    const plugin = createTemporaryObject(beesFocusPlugin, testCase, {
+      "iface": ifaceStub,
+      "qgisProject": qgisProject
+    });
+    verify(plugin !== null);
+    pluginsToolbarStub.addedItems[0].clicked();
+    verify(dashBoardStub.activeLayer !== null);
+    compare(dashBoardStub.activeLayer.name, "BeesFocusApiary");
+    pluginsToolbarStub.addedItems[1].clicked();
+    compare(dashBoardStub.activeLayer.name, "BeesFocusTracks");
+  }
+
+  function test_beesFocus_08_missingLayerNameLeavesActiveLayerUntouched() {
+    const plugin = createTemporaryObject(beesFocusPlugin, testCase, {
+      "iface": ifaceStub,
+      "qgisProject": qgisProject
+    });
+    verify(plugin !== null);
+    plugin.activateLayerByName("BeesFocusDoesNotExist_xyz");
+    compare(dashBoardStub.activeLayer, null);
+  }
+}

--- a/test/qml/tst_plugin_functionalities.qml
+++ b/test/qml/tst_plugin_functionalities.qml
@@ -69,10 +69,10 @@ TestCase {
     return null;
   }
 
-  // Bees-Focus
+  // Active layer switching via plugin toolbar buttons
 
   Component {
-    id: beesFocusPlugin
+    id: activeLayerSwitcherPlugin
 
     Item {
       id: plugin
@@ -101,7 +101,7 @@ TestCase {
         iconColor: Theme.toolButtonColor
         bgcolor: Theme.toolButtonBackgroundColor
         round: true
-        onClicked: plugin.activateLayerByName("BeesFocusApiary")
+        onClicked: plugin.activateLayerByName("ApiaryLayer")
       }
 
       QfToolButton {
@@ -110,65 +110,65 @@ TestCase {
         iconColor: Theme.toolButtonColor
         bgcolor: Theme.toolButtonBackgroundColor
         round: true
-        onClicked: plugin.activateLayerByName("BeesFocusTracks")
+        onClicked: plugin.activateLayerByName("TracksLayer")
       }
     }
   }
 
-  function test_beesFocus_01_pluginInstantiatesWithRealIface() {
-    const plugin = createTemporaryObject(beesFocusPlugin, testCase);
+  function test_pluginInstantiatesWithRealIface() {
+    const plugin = createTemporaryObject(activeLayerSwitcherPlugin, testCase);
     verify(plugin !== null);
   }
 
-  function test_beesFocus_02_pluginResolvesMainWindowFromIface() {
-    const plugin = createTemporaryObject(beesFocusPlugin, testCase);
+  function test_ifaceMainWindowResolvesFromContext() {
+    const plugin = createTemporaryObject(activeLayerSwitcherPlugin, testCase);
     verify(plugin.mainWindow !== null);
   }
 
-  function test_beesFocus_03_pluginResolvesDashBoardFromIface() {
-    const plugin = createTemporaryObject(beesFocusPlugin, testCase);
+  function test_ifaceFindItemByObjectNameResolvesDashBoard() {
+    const plugin = createTemporaryObject(activeLayerSwitcherPlugin, testCase);
     verify(plugin.dashBoard !== null);
     compare(plugin.dashBoard.objectName, "dashBoard");
   }
 
-  function test_beesFocus_04_pluginRegistersBothButtonsToToolbar() {
-    createTemporaryObject(beesFocusPlugin, testCase);
+  function test_ifaceAddItemToPluginsToolbarReparentsButtons() {
+    createTemporaryObject(activeLayerSwitcherPlugin, testCase);
     compare(pluginsToolbar.children.length, 2);
     compare(pluginsToolbar.children[0].text, "A");
     compare(pluginsToolbar.children[1].text, "T");
   }
 
-  function test_beesFocus_05_buttonsHaveExpectedAppearance() {
-    createTemporaryObject(beesFocusPlugin, testCase);
+  function test_qfToolButtonHonoursPluginConfiguredAppearance() {
+    createTemporaryObject(activeLayerSwitcherPlugin, testCase);
     const apiary = findToolbarButtonByText("A");
     compare(apiary.round, true);
     compare(apiary.iconColor, Theme.toolButtonColor);
     compare(apiary.bgcolor, Theme.toolButtonBackgroundColor);
   }
 
-  function test_beesFocus_06_switchingBetweenLayersUpdatesActiveLayer() {
-    makeMemoryLayer("BeesFocusApiary");
-    makeMemoryLayer("BeesFocusTracks");
-    const plugin = createTemporaryObject(beesFocusPlugin, testCase);
+  function test_dashBoardActiveLayerSwitchesAcrossLayers() {
+    makeMemoryLayer("ApiaryLayer");
+    makeMemoryLayer("TracksLayer");
+    const plugin = createTemporaryObject(activeLayerSwitcherPlugin, testCase);
 
-    plugin.activateLayerByName("BeesFocusApiary");
-    compare(dashBoardItem.activeLayer.name, "BeesFocusApiary");
-    plugin.activateLayerByName("BeesFocusTracks");
-    compare(dashBoardItem.activeLayer.name, "BeesFocusTracks");
+    plugin.activateLayerByName("ApiaryLayer");
+    compare(dashBoardItem.activeLayer.name, "ApiaryLayer");
+    plugin.activateLayerByName("TracksLayer");
+    compare(dashBoardItem.activeLayer.name, "TracksLayer");
   }
 
-  function test_beesFocus_07_missingLayerNameLeavesActiveLayerUntouched() {
-    const plugin = createTemporaryObject(beesFocusPlugin, testCase);
-    plugin.activateLayerByName("BeesFocusDoesNotExist_xyz");
+  function test_activateLayerByNameNoOpsForUnknownLayer() {
+    const plugin = createTemporaryObject(activeLayerSwitcherPlugin, testCase);
+    plugin.activateLayerByName("UnknownLayer_xyz");
     compare(dashBoardItem.activeLayer, null);
   }
 
-  function test_beesFocus_08_buttonClickActivatesMatchingLayer() {
-    makeMemoryLayer("BeesFocusApiary");
-    createTemporaryObject(beesFocusPlugin, testCase);
+  function test_qfToolButtonClickActivatesTargetLayer() {
+    makeMemoryLayer("ApiaryLayer");
+    createTemporaryObject(activeLayerSwitcherPlugin, testCase);
     const apiary = findToolbarButtonByText("A");
     apiary.clicked();
     verify(dashBoardItem.activeLayer !== null);
-    compare(dashBoardItem.activeLayer.name, "BeesFocusApiary");
+    compare(dashBoardItem.activeLayer.name, "ApiaryLayer");
   }
 }

--- a/test/qml/tst_plugin_functionalities.qml
+++ b/test/qml/tst_plugin_functionalities.qml
@@ -3,39 +3,49 @@ import QtTest
 import org.qfield
 import org.qgis
 import Theme
+import "../../src/qml/" as QFieldControls
 
 TestCase {
   id: testCase
   name: "PluginFunctionalities"
 
+  // DashBoard reads mainWindow, stateMachine and displayToast from its
+  // surrounding scope, mirroring how qgismobileapp.qml exposes them in production
   Item {
-    id: dashBoardStub
+    id: mainWindow
+
+    width: 800
+    height: 600
+    property double sceneLeftMargin: 0
+    property double sceneTopMargin: 0
+    property double sceneBottomMargin: 0
+    property var contentItem: testCase
+
+    function displayToast(message) {
+    }
+  }
+
+  QtObject {
+    id: stateMachine
+
+    property string state: "browse"
+  }
+
+  Item {
+    id: pluginsToolbar
+    objectName: "pluginsToolbar"
+  }
+
+  QFieldControls.DashBoard {
+    id: dashBoardItem
     objectName: "dashBoard"
-
-    property var activeLayer: null
   }
-
-  Item {
-    id: pluginsToolbarStub
-
-    property var addedItems: []
-  }
-
-  property var ifaceStub: ({
-      "mainWindow": function () {
-        return testCase;
-      },
-      "findItemByObjectName": function (name) {
-        return name === "dashBoard" ? dashBoardStub : null;
-      },
-      "addItemToPluginsToolbar": function (item) {
-        pluginsToolbarStub.addedItems.push(item);
-      }
-    })
 
   function init() {
-    dashBoardStub.activeLayer = null;
-    pluginsToolbarStub.addedItems = [];
+    for (let i = pluginsToolbar.children.length - 1; i >= 0; --i) {
+      pluginsToolbar.children[i].parent = null;
+    }
+    dashBoardItem.activeLayer = null;
   }
 
   function makeMemoryLayer(name) {
@@ -49,18 +59,17 @@ TestCase {
     return layer;
   }
 
-  // Bees-Focus
-
-  Component {
-    id: beesFocusToolButton
-
-    QfToolButton {
-      text: "A"
-      iconColor: Theme.toolButtonColor
-      bgcolor: Theme.toolButtonBackgroundColor
-      round: true
+  function findToolbarButtonByText(text) {
+    for (let i = 0; i < pluginsToolbar.children.length; ++i) {
+      const child = pluginsToolbar.children[i];
+      if (child.text === text) {
+        return child;
+      }
     }
+    return null;
   }
+
+  // Bees-Focus
 
   Component {
     id: beesFocusPlugin
@@ -68,12 +77,8 @@ TestCase {
     Item {
       id: plugin
 
-      property var iface
-      property var qgisProject
-      property var mainWindow: iface ? iface.mainWindow() : null
-      property var dashBoard: iface ? iface.findItemByObjectName("dashBoard") : null
-      property string apiaryLayerName: "BeesFocusApiary"
-      property string tracksLayerName: "BeesFocusTracks"
+      property var mainWindow: iface.mainWindow()
+      property var dashBoard: iface.findItemByObjectName("dashBoard")
 
       function activateLayerByName(name) {
         const layers = ProjectUtils.mapLayers(qgisProject);
@@ -92,104 +97,78 @@ TestCase {
 
       QfToolButton {
         id: apiaryButton
-
         text: "A"
         iconColor: Theme.toolButtonColor
         bgcolor: Theme.toolButtonBackgroundColor
         round: true
-
-        onClicked: plugin.activateLayerByName(plugin.apiaryLayerName)
+        onClicked: plugin.activateLayerByName("BeesFocusApiary")
       }
 
       QfToolButton {
         id: tracksButton
-
         text: "T"
         iconColor: Theme.toolButtonColor
         bgcolor: Theme.toolButtonBackgroundColor
         round: true
-
-        onClicked: plugin.activateLayerByName(plugin.tracksLayerName)
+        onClicked: plugin.activateLayerByName("BeesFocusTracks")
       }
     }
   }
 
-  function test_beesFocus_01_projectUtilsMapLayersReturnsLayer() {
-    const layer = makeMemoryLayer("BeesFocusMapLayersTest");
-    const layers = ProjectUtils.mapLayers(qgisProject);
-    verify(typeof layers === "object" && layers !== null);
-    verify(layer.id in layers);
-    compare(layers[layer.id].id, layer.id);
-  }
-
-  function test_beesFocus_02_mapLayerExposesNameProperty() {
-    const layer = makeMemoryLayer("BeesFocusNameTest");
-    const layers = ProjectUtils.mapLayers(qgisProject);
-    compare(layers[layer.id].name, "BeesFocusNameTest");
-  }
-
-  function test_beesFocus_03_qfToolButtonAcceptsPluginProperties() {
-    const btn = createTemporaryObject(beesFocusToolButton, testCase);
-    verify(btn !== null);
-    compare(btn.text, "A");
-    compare(btn.round, true);
-    compare(btn.iconColor, Theme.toolButtonColor);
-    compare(btn.bgcolor, Theme.toolButtonBackgroundColor);
-  }
-
-  function test_beesFocus_04_qfToolButtonClickedTriggersHandler() {
-    const btn = createTemporaryObject(beesFocusToolButton, testCase);
-    let fired = 0;
-    btn.clicked.connect(function () {
-      fired += 1;
-    });
-    btn.clicked();
-    compare(fired, 1);
-  }
-
-  function test_beesFocus_05_pluginCompletionRegistersBothButtons() {
-    const plugin = createTemporaryObject(beesFocusPlugin, testCase, {
-      "iface": ifaceStub,
-      "qgisProject": qgisProject
-    });
+  function test_beesFocus_01_pluginInstantiatesWithRealIface() {
+    const plugin = createTemporaryObject(beesFocusPlugin, testCase);
     verify(plugin !== null);
-    compare(pluginsToolbarStub.addedItems.length, 2);
-    compare(pluginsToolbarStub.addedItems[0].text, "A");
-    compare(pluginsToolbarStub.addedItems[1].text, "T");
   }
 
-  function test_beesFocus_06_pluginResolvesIfaceProperties() {
-    const plugin = createTemporaryObject(beesFocusPlugin, testCase, {
-      "iface": ifaceStub,
-      "qgisProject": qgisProject
-    });
-    verify(plugin !== null);
-    compare(plugin.mainWindow, testCase);
-    compare(plugin.dashBoard, dashBoardStub);
+  function test_beesFocus_02_pluginResolvesMainWindowFromIface() {
+    const plugin = createTemporaryObject(beesFocusPlugin, testCase);
+    verify(plugin.mainWindow !== null);
   }
 
-  function test_beesFocus_07_buttonClickActivatesMatchingLayer() {
+  function test_beesFocus_03_pluginResolvesDashBoardFromIface() {
+    const plugin = createTemporaryObject(beesFocusPlugin, testCase);
+    verify(plugin.dashBoard !== null);
+    compare(plugin.dashBoard.objectName, "dashBoard");
+  }
+
+  function test_beesFocus_04_pluginRegistersBothButtonsToToolbar() {
+    createTemporaryObject(beesFocusPlugin, testCase);
+    compare(pluginsToolbar.children.length, 2);
+    compare(pluginsToolbar.children[0].text, "A");
+    compare(pluginsToolbar.children[1].text, "T");
+  }
+
+  function test_beesFocus_05_buttonsHaveExpectedAppearance() {
+    createTemporaryObject(beesFocusPlugin, testCase);
+    const apiary = findToolbarButtonByText("A");
+    compare(apiary.round, true);
+    compare(apiary.iconColor, Theme.toolButtonColor);
+    compare(apiary.bgcolor, Theme.toolButtonBackgroundColor);
+  }
+
+  function test_beesFocus_06_switchingBetweenLayersUpdatesActiveLayer() {
     makeMemoryLayer("BeesFocusApiary");
     makeMemoryLayer("BeesFocusTracks");
-    const plugin = createTemporaryObject(beesFocusPlugin, testCase, {
-      "iface": ifaceStub,
-      "qgisProject": qgisProject
-    });
-    verify(plugin !== null);
-    pluginsToolbarStub.addedItems[0].clicked();
-    verify(dashBoardStub.activeLayer !== null);
-    compare(dashBoardStub.activeLayer.name, "BeesFocusApiary");
-    pluginsToolbarStub.addedItems[1].clicked();
-    compare(dashBoardStub.activeLayer.name, "BeesFocusTracks");
+    const plugin = createTemporaryObject(beesFocusPlugin, testCase);
+
+    plugin.activateLayerByName("BeesFocusApiary");
+    compare(dashBoardItem.activeLayer.name, "BeesFocusApiary");
+    plugin.activateLayerByName("BeesFocusTracks");
+    compare(dashBoardItem.activeLayer.name, "BeesFocusTracks");
   }
 
-  function test_beesFocus_08_missingLayerNameLeavesActiveLayerUntouched() {
-    const plugin = createTemporaryObject(beesFocusPlugin, testCase, {
-      "iface": ifaceStub,
-      "qgisProject": qgisProject
-    });
-    verify(plugin !== null);
+  function test_beesFocus_07_missingLayerNameLeavesActiveLayerUntouched() {
+    const plugin = createTemporaryObject(beesFocusPlugin, testCase);
     plugin.activateLayerByName("BeesFocusDoesNotExist_xyz");
-    compare(dashBoardStub.activeLayer, null);
+    compare(dashBoardItem.activeLayer, null);
+  }
+
+  function test_beesFocus_08_buttonClickActivatesMatchingLayer() {
+    makeMemoryLayer("BeesFocusApiary");
+    createTemporaryObject(beesFocusPlugin, testCase);
+    const apiary = findToolbarButtonByText("A");
+    apiary.clicked();
+    verify(dashBoardItem.activeLayer !== null);
+    compare(dashBoardItem.activeLayer.name, "BeesFocusApiary");
   }
 }


### PR DESCRIPTION
Tests to have regression coverage for the QML invokables and properties used by the plugin micro-projects, starting with Bees-Focus

Actual iface, real DashBoard, real ProjectUtils / LayerUtils / QfToolButton is upadated to use after the pr review at refractor in appinterface source.  The plugin is instantiated as a Component and reads iface and qgisProject from context, similar to production. Each test creates its own memory layer, so nothing depends on test_bees.qgz contents.

The AppInterface constructible against a plain QQmlEngine and resolves rootObject() in test mode by walking QGuiApplication::topLevelWindows(), adjust in this pr, without that, iface was returning null for tree walk lookups in the QtQuickTest harness.