### PR TITLE
tests extended with new-extra plugin functionality coverage with Bees-Model

### DIFF
--- a/test/qml/tst_plugin_functionalities.qml
+++ b/test/qml/tst_plugin_functionalities.qml
@@ -1,4 +1,6 @@
 import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import QtTest
 import org.qfield
 import org.qgis
@@ -170,5 +172,156 @@ TestCase {
     apiary.clicked();
     verify(dashBoardItem.activeLayer !== null);
     compare(dashBoardItem.activeLayer.name, "ApiaryLayer");
+  }
+
+  // Bees-Model
+
+  Component {
+    id: beesModelLayerNamesProbe
+
+    Instantiator {
+      property var collected: []
+
+      delegate: QtObject {
+        property string layerName: model.Name
+        property var layerPointer: model.LayerPointer
+      }
+
+      onObjectAdded: function (index, object) {
+        collected.push({
+          "name": object.layerName,
+          "pointer": object.layerPointer
+        });
+      }
+    }
+  }
+
+  Component {
+    id: beesModelPlugin
+
+    Item {
+      id: plugin
+
+      property var iface
+      property var qgisProject
+      property var mainWindow: iface ? iface.mainWindow() : null
+      property alias layersButton: layersButton
+      property alias layersDialog: layersDialog
+      property alias layersComboBox: layersComboBox
+      property alias layersModel: layersModel
+
+      Component.onCompleted: {
+        iface.addItemToPluginsToolbar(layersButton);
+      }
+
+      QfToolButton {
+        id: layersButton
+
+        text: "?"
+        iconColor: Theme.toolButtonColor
+        bgcolor: Theme.toolButtonBackgroundColor
+        round: true
+
+        onClicked: layersDialog.open()
+      }
+
+      QfDialog {
+        id: layersDialog
+
+        x: mainWindow ? (mainWindow.width - width) / 2 : 0
+        y: mainWindow ? (mainWindow.height - height) / 2 : 0
+        width: 300
+        height: layersLayout.height + 100
+        parent: mainWindow ? mainWindow.contentItem : plugin
+
+        ColumnLayout {
+          id: layersLayout
+          width: parent.width
+
+          Label {
+            Layout.fillWidth: true
+            text: "A combobox full of layers"
+          }
+
+          QfComboBox {
+            id: layersComboBox
+
+            Layout.fillWidth: true
+            model: MapLayerModel {
+              id: layersModel
+              project: plugin.qgisProject
+            }
+            textRole: 'Name'
+            valueRole: 'LayerPointer'
+          }
+        }
+      }
+    }
+  }
+
+  function test_beesModel_01_mapLayerModelTracksProjectLayers() {
+    makeMemoryLayer("BeesModelLayerA");
+    makeMemoryLayer("BeesModelLayerB");
+    const plugin = createTemporaryObject(beesModelPlugin, testCase, {
+      "iface": ifaceStub,
+      "qgisProject": qgisProject
+    });
+    verify(plugin !== null);
+    verify(plugin.layersModel.rowCount() >= 2, "model must include the freshly added layers");
+  }
+
+  function test_beesModel_02_mapLayerModelExposesNameAndLayerPointerRoles() {
+    const layer = makeMemoryLayer("BeesModelRolesProbe");
+    const plugin = createTemporaryObject(beesModelPlugin, testCase, {
+      "iface": ifaceStub,
+      "qgisProject": qgisProject
+    });
+    verify(plugin !== null);
+    const probe = createTemporaryObject(beesModelLayerNamesProbe, testCase, {
+      "model": plugin.layersModel
+    });
+    verify(probe !== null);
+    let probeNames = probe.collected.map(function (e) {
+      return e.name;
+    });
+    verify(probeNames.indexOf("BeesModelRolesProbe") !== -1, "Name role must populate from layer.name");
+    const entry = probe.collected.find(function (e) {
+      return e.name === "BeesModelRolesProbe";
+    });
+    verify(entry !== undefined);
+    verify(entry.pointer !== null && entry.pointer !== undefined, "LayerPointer role must populate");
+    compare(entry.pointer.id, layer.id);
+  }
+
+  function test_beesModel_03_qfComboBoxAcceptsModelAndRoles() {
+    const plugin = createTemporaryObject(beesModelPlugin, testCase, {
+      "iface": ifaceStub,
+      "qgisProject": qgisProject
+    });
+    verify(plugin !== null);
+    compare(plugin.layersComboBox.textRole, "Name");
+    compare(plugin.layersComboBox.valueRole, "LayerPointer");
+    compare(plugin.layersComboBox.model, plugin.layersModel);
+  }
+
+  function test_beesModel_04_qfDialogOpensOnButtonClick() {
+    const plugin = createTemporaryObject(beesModelPlugin, testCase, {
+      "iface": ifaceStub,
+      "qgisProject": qgisProject
+    });
+    verify(plugin !== null);
+    compare(plugin.layersDialog.visible, false);
+    plugin.layersButton.clicked();
+    tryCompare(plugin.layersDialog, "visible", true);
+  }
+
+  function test_beesModel_05_pluginCompletionRegistersLayersButton() {
+    const plugin = createTemporaryObject(beesModelPlugin, testCase, {
+      "iface": ifaceStub,
+      "qgisProject": qgisProject
+    });
+    verify(plugin !== null);
+    compare(pluginsToolbarStub.addedItems.length, 1);
+    compare(pluginsToolbarStub.addedItems[0].text, "?");
   }
 }

--- a/test/qml/tst_plugin_functionalities.qml
+++ b/test/qml/tst_plugin_functionalities.qml
@@ -174,10 +174,10 @@ TestCase {
     compare(dashBoardItem.activeLayer.name, "ApiaryLayer");
   }
 
-  // Bees-Model
+  // Layer combobox dialog backed by MapLayerModel
 
   Component {
-    id: beesModelPlugin
+    id: layerComboBoxDialogPlugin
 
     Item {
       id: plugin
@@ -234,51 +234,51 @@ TestCase {
     }
   }
 
-  function test_beesModel_01_pluginInstantiatesWithRealIface() {
-    const plugin = createTemporaryObject(beesModelPlugin, testCase);
+  function test_dialogPluginInstantiatesWithRealIface() {
+    const plugin = createTemporaryObject(layerComboBoxDialogPlugin, testCase);
     verify(plugin !== null);
   }
 
-  function test_beesModel_02_pluginRegistersLayersButtonToToolbar() {
-    createTemporaryObject(beesModelPlugin, testCase);
+  function test_dialogPluginRegistersToolbarButton() {
+    createTemporaryObject(layerComboBoxDialogPlugin, testCase);
     compare(pluginsToolbar.children.length, 1);
     compare(pluginsToolbar.children[0].text, "?");
   }
 
-  function test_beesModel_03_mapLayerModelTracksProjectLayers() {
-    makeMemoryLayer("BeesModelLayerA");
-    makeMemoryLayer("BeesModelLayerB");
-    const plugin = createTemporaryObject(beesModelPlugin, testCase);
+  function test_mapLayerModelTracksProjectLayers() {
+    makeMemoryLayer("ComboLayerA");
+    makeMemoryLayer("ComboLayerB");
+    const plugin = createTemporaryObject(layerComboBoxDialogPlugin, testCase);
     verify(plugin.layersModel.rowCount() >= 2);
   }
 
-  function test_beesModel_04_mapLayerModelExposesNameAndLayerPointerRoles() {
-    const layer = makeMemoryLayer("BeesModelRolesProbe");
-    const plugin = createTemporaryObject(beesModelPlugin, testCase);
+  function test_mapLayerModelGetExposesNameAndLayerPointer() {
+    const layer = makeMemoryLayer("ComboRolesProbe");
+    const plugin = createTemporaryObject(layerComboBoxDialogPlugin, testCase);
 
     let foundEntry = null;
     for (let row = 0; row < plugin.layersModel.rowCount(); ++row) {
       const entry = plugin.layersModel.get(row);
-      if (entry.Name === "BeesModelRolesProbe") {
+      if (entry.Name === "ComboRolesProbe") {
         foundEntry = entry;
         break;
       }
     }
     verify(foundEntry !== null);
-    compare(foundEntry.Name, "BeesModelRolesProbe");
+    compare(foundEntry.Name, "ComboRolesProbe");
     verify(foundEntry.LayerPointer !== null);
     compare(foundEntry.LayerPointer.id, layer.id);
   }
 
-  function test_beesModel_05_qfComboBoxAcceptsModelAndRoles() {
-    const plugin = createTemporaryObject(beesModelPlugin, testCase);
+  function test_qfComboBoxBindsToMapLayerModelWithExpectedRoles() {
+    const plugin = createTemporaryObject(layerComboBoxDialogPlugin, testCase);
     compare(plugin.layersComboBox.textRole, "Name");
     compare(plugin.layersComboBox.valueRole, "LayerPointer");
     compare(plugin.layersComboBox.model, plugin.layersModel);
   }
 
-  function test_beesModel_06_dialogOpensOnButtonClick() {
-    const plugin = createTemporaryObject(beesModelPlugin, testCase);
+  function test_qfDialogOpensOnToolbarButtonClick() {
+    const plugin = createTemporaryObject(layerComboBoxDialogPlugin, testCase);
     compare(plugin.layersDialog.visible, false);
     plugin.layersButton.clicked();
     tryCompare(plugin.layersDialog, "visible", true);

--- a/test/qml/tst_plugin_functionalities.qml
+++ b/test/qml/tst_plugin_functionalities.qml
@@ -177,34 +177,12 @@ TestCase {
   // Bees-Model
 
   Component {
-    id: beesModelLayerNamesProbe
-
-    Instantiator {
-      property var collected: []
-
-      delegate: QtObject {
-        property string layerName: model.Name
-        property var layerPointer: model.LayerPointer
-      }
-
-      onObjectAdded: function (index, object) {
-        collected.push({
-          "name": object.layerName,
-          "pointer": object.layerPointer
-        });
-      }
-    }
-  }
-
-  Component {
     id: beesModelPlugin
 
     Item {
       id: plugin
 
-      property var iface
-      property var qgisProject
-      property var mainWindow: iface ? iface.mainWindow() : null
+      property var mainWindow: iface.mainWindow()
       property alias layersButton: layersButton
       property alias layersDialog: layersDialog
       property alias layersComboBox: layersComboBox
@@ -216,12 +194,10 @@ TestCase {
 
       QfToolButton {
         id: layersButton
-
         text: "?"
         iconColor: Theme.toolButtonColor
         bgcolor: Theme.toolButtonBackgroundColor
         round: true
-
         onClicked: layersDialog.open()
       }
 
@@ -245,11 +221,10 @@ TestCase {
 
           QfComboBox {
             id: layersComboBox
-
             Layout.fillWidth: true
             model: MapLayerModel {
               id: layersModel
-              project: plugin.qgisProject
+              project: qgisProject
             }
             textRole: 'Name'
             valueRole: 'LayerPointer'
@@ -259,69 +234,53 @@ TestCase {
     }
   }
 
-  function test_beesModel_01_mapLayerModelTracksProjectLayers() {
+  function test_beesModel_01_pluginInstantiatesWithRealIface() {
+    const plugin = createTemporaryObject(beesModelPlugin, testCase);
+    verify(plugin !== null);
+  }
+
+  function test_beesModel_02_pluginRegistersLayersButtonToToolbar() {
+    createTemporaryObject(beesModelPlugin, testCase);
+    compare(pluginsToolbar.children.length, 1);
+    compare(pluginsToolbar.children[0].text, "?");
+  }
+
+  function test_beesModel_03_mapLayerModelTracksProjectLayers() {
     makeMemoryLayer("BeesModelLayerA");
     makeMemoryLayer("BeesModelLayerB");
-    const plugin = createTemporaryObject(beesModelPlugin, testCase, {
-      "iface": ifaceStub,
-      "qgisProject": qgisProject
-    });
-    verify(plugin !== null);
-    verify(plugin.layersModel.rowCount() >= 2, "model must include the freshly added layers");
+    const plugin = createTemporaryObject(beesModelPlugin, testCase);
+    verify(plugin.layersModel.rowCount() >= 2);
   }
 
-  function test_beesModel_02_mapLayerModelExposesNameAndLayerPointerRoles() {
+  function test_beesModel_04_mapLayerModelExposesNameAndLayerPointerRoles() {
     const layer = makeMemoryLayer("BeesModelRolesProbe");
-    const plugin = createTemporaryObject(beesModelPlugin, testCase, {
-      "iface": ifaceStub,
-      "qgisProject": qgisProject
-    });
-    verify(plugin !== null);
-    const probe = createTemporaryObject(beesModelLayerNamesProbe, testCase, {
-      "model": plugin.layersModel
-    });
-    verify(probe !== null);
-    let probeNames = probe.collected.map(function (e) {
-      return e.name;
-    });
-    verify(probeNames.indexOf("BeesModelRolesProbe") !== -1, "Name role must populate from layer.name");
-    const entry = probe.collected.find(function (e) {
-      return e.name === "BeesModelRolesProbe";
-    });
-    verify(entry !== undefined);
-    verify(entry.pointer !== null && entry.pointer !== undefined, "LayerPointer role must populate");
-    compare(entry.pointer.id, layer.id);
+    const plugin = createTemporaryObject(beesModelPlugin, testCase);
+
+    let foundEntry = null;
+    for (let row = 0; row < plugin.layersModel.rowCount(); ++row) {
+      const entry = plugin.layersModel.get(row);
+      if (entry.Name === "BeesModelRolesProbe") {
+        foundEntry = entry;
+        break;
+      }
+    }
+    verify(foundEntry !== null);
+    compare(foundEntry.Name, "BeesModelRolesProbe");
+    verify(foundEntry.LayerPointer !== null);
+    compare(foundEntry.LayerPointer.id, layer.id);
   }
 
-  function test_beesModel_03_qfComboBoxAcceptsModelAndRoles() {
-    const plugin = createTemporaryObject(beesModelPlugin, testCase, {
-      "iface": ifaceStub,
-      "qgisProject": qgisProject
-    });
-    verify(plugin !== null);
+  function test_beesModel_05_qfComboBoxAcceptsModelAndRoles() {
+    const plugin = createTemporaryObject(beesModelPlugin, testCase);
     compare(plugin.layersComboBox.textRole, "Name");
     compare(plugin.layersComboBox.valueRole, "LayerPointer");
     compare(plugin.layersComboBox.model, plugin.layersModel);
   }
 
-  function test_beesModel_04_qfDialogOpensOnButtonClick() {
-    const plugin = createTemporaryObject(beesModelPlugin, testCase, {
-      "iface": ifaceStub,
-      "qgisProject": qgisProject
-    });
-    verify(plugin !== null);
+  function test_beesModel_06_dialogOpensOnButtonClick() {
+    const plugin = createTemporaryObject(beesModelPlugin, testCase);
     compare(plugin.layersDialog.visible, false);
     plugin.layersButton.clicked();
     tryCompare(plugin.layersDialog, "visible", true);
-  }
-
-  function test_beesModel_05_pluginCompletionRegistersLayersButton() {
-    const plugin = createTemporaryObject(beesModelPlugin, testCase, {
-      "iface": ifaceStub,
-      "qgisProject": qgisProject
-    });
-    verify(plugin !== null);
-    compare(pluginsToolbarStub.addedItems.length, 1);
-    compare(pluginsToolbarStub.addedItems[0].text, "?");
   }
 }


### PR DESCRIPTION
Follow-up to #7382 . Adds the Bees-Model micro-projects invokable propertues surface coverage

New tests pin MapLayerModel, Name/LayerPointer roles, the project tracking behaviour, QfComboBox model/role properties, and QfDialog.open() triggered through the registered toolbar button.

Also expands the shared scaffolding ifaceStub.mainWindow() now returns a mainWindowStub Item exposing width/height/contentItem (needed by QfDialog positioning bindings). The Bees-Focus assertion that previously compared against testCase is retargeted to mainWindowStub accordingly