### PR TITLE
[Backport release-4_1] When tracking position onto a feature, skip topological editing to prevent UI freezes

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -974,7 +974,7 @@ bool FeatureModel::updateAttributesFromFeature( const QgsFeature &feature )
   return updated;
 }
 
-void FeatureModel::applyGeometry( bool fromVertexModel )
+void FeatureModel::applyGeometry( bool fromVertexModel, bool skipTopologicalEditing )
 {
   if ( ( !fromVertexModel && !mGeometry ) || ( fromVertexModel && !mVertexModel ) )
   {
@@ -982,7 +982,7 @@ void FeatureModel::applyGeometry( bool fromVertexModel )
   }
 
   const bool wasEditing = mLayer->editBuffer();
-  const bool requiresEditing = ( mProject && mProject->topologicalEditing() );
+  const bool requiresEditing = ( !skipTopologicalEditing && mProject && mProject->topologicalEditing() );
   if ( !wasEditing && requiresEditing )
   {
     mLayer->startEditing();
@@ -1128,7 +1128,7 @@ void FeatureModel::applyGeometry( bool fromVertexModel )
       geometry = deduplicatedGeometry;
   }
 
-  if ( mProject && mProject->topologicalEditing() )
+  if ( !skipTopologicalEditing && mProject && mProject->topologicalEditing() )
   {
     applyGeometryTopography( geometry );
   }

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -259,8 +259,9 @@ class FeatureModel : public QAbstractListModel
     /**
      * Apply the geometry object or vertex model object's geometry to the feature geometry.
      * \param fromVertexModel set to TRUE to use the vertex model
+     * \param skipTopologicalEditing set to TRUE to skip project-level topological editing rule
      */
-    Q_INVOKABLE void applyGeometry( bool fromVertexModel = false );
+    Q_INVOKABLE void applyGeometry( bool fromVertexModel = false, bool skipTopologicalEditing = false );
 
     //! Apply the feature geometry to a vertex model if present.
     Q_INVOKABLE void applyGeometryToVertexModel();

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -407,7 +407,7 @@ void Tracker::replayPositionInformationList( const QList<GnssPositionInformation
   const int vertexCount = mRubberbandModel->vertexCount();
   if ( ( geometryType == Qgis::GeometryType::Line && vertexCount > 2 ) || ( geometryType == Qgis::GeometryType::Polygon && vertexCount > 3 ) )
   {
-    mFeatureModel->applyGeometry();
+    mFeatureModel->applyGeometry( false, true );
     if ( mFeature.id() == FID_NULL )
     {
       mFeatureModel->create( false );
@@ -461,7 +461,7 @@ void Tracker::rubberbandModelVertexCountChanged()
   const int vertexCount = mRubberbandModel->vertexCount();
   if ( geometryType == Qgis::GeometryType::Point )
   {
-    mFeatureModel->applyGeometry();
+    mFeatureModel->applyGeometry( false, true );
     mFeatureModel->resetFeatureId();
     mFeatureModel->resetAttributes( true );
     mFeatureModel->create( flushBuffer );
@@ -475,7 +475,7 @@ void Tracker::rubberbandModelVertexCountChanged()
       {
         if ( ( geometryType == Qgis::GeometryType::Line && vertexCount == 3 ) || ( geometryType == Qgis::GeometryType::Polygon && vertexCount == 4 ) )
         {
-          mFeatureModel->applyGeometry();
+          mFeatureModel->applyGeometry( false, true );
           // We must flush the buffer on feature creation to get the proper feature ID
           mFeatureModel->create();
           mFeature = mFeatureModel->feature();
@@ -483,7 +483,7 @@ void Tracker::rubberbandModelVertexCountChanged()
         }
         else
         {
-          mFeatureModel->applyGeometry();
+          mFeatureModel->applyGeometry( false, true );
           mFeatureModel->save( flushBuffer );
         }
       }


### PR DESCRIPTION
Backport #7386
 **Authored by:** @nirvn