### PR TITLE
Add test to insure URLs shipped in QField all remain valid

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -22,7 +22,7 @@ contact_links:
       Check if your issue was already reported and if not, then create a new issue at the QFieldCloud Python SDK repository.
 
   - name: Seek community and commercial support
-    url: https://docs.qfield.org/get-started/support/
+    url: https://qfield.org/assistance/
     about: >
       Check how to get commercial or community support for your QFieldCloud on-premise or other QField ecosystem questions.
 

--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -27,7 +27,7 @@ jobs:
 
   banned_keywords_check:
     name: banned keywords check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -46,3 +46,20 @@ jobs:
           sudo apt install -y cppcheck
       - name: Run cppcheck test
         run: ./scripts/cppcheck.sh
+
+  url_check:
+    name: URLs check
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check QField URLs
+        uses: nirvn/check-urls@main
+        with:
+          search_path: ./
+          search_regexp: https://[A-Za-z\.]+qfield.(cloud|org)[^ <>\\\"')]+
+          skip_urls: |
+            https://app.qfield.cloud/settings/%1/billing
+            https://docs.qfield.org/%1
+            https://qfield.cloud/some-new-ignored-url

--- a/.github/workflows/code_layout.yml
+++ b/.github/workflows/code_layout.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Check QField URLs
         uses: nirvn/check-urls@main
         with:
-          search_path: ./
+          search_path: ./src
           search_regexp: https://[A-Za-z\.]+qfield.(cloud|org)[^ <>\\\"')]+
           skip_urls: |
             https://app.qfield.cloud/settings/%1/billing

--- a/src/qml/BadLayerItem.qml
+++ b/src/qml/BadLayerItem.qml
@@ -108,7 +108,7 @@ Page {
       Layout.fillHeight: false
       Layout.topMargin: 5
 
-      text: qsTr('You may check the %1Portable Project%2 documentation page for more help.').arg("<a href=\"https://docs.qfield.org/how-to/advanced-how-tos/movable-project/\">").arg("</a>")
+      text: qsTr('You may check the %1Portable Project%2 documentation page for more help.').arg("<a href=\"https://docs.qfield.org/how-to/project-setup/hiding-legend-nodes/#data-source-configuration\">").arg("</a>")
       textFormat: Text.RichText
       font: Theme.tipFont
       color: Theme.secondaryTextColor


### PR DESCRIPTION
This should insure hyperlinks to websites we control (i.e. *.qfield.(cloud|org)) are not going 404 without us knowing.