### PR TITLE
Allow safe directory deletion in user‑managed local roots

### DIFF
--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -870,7 +870,7 @@ bool FileUtils::unzip( const QString &zipFilename, const QString &dir, QStringLi
 bool FileUtils::isDeletable( const QString &filePath )
 {
   const QFileInfo fileInfo( filePath );
-  if ( !fileInfo.exists() || !fileInfo.isFile() )
+  if ( !fileInfo.exists() )
   {
     return false;
   }
@@ -915,6 +915,46 @@ bool FileUtils::isDeletable( const QString &filePath )
     return false;
   }
 
+  if ( fileInfo.isDir() )
+  {
+    static const QStringList userManagedRoots = {
+      QStringLiteral( "Imported Projects" ),
+      QStringLiteral( "Imported Datasets" ),
+      QStringLiteral( "Created Projects" ) };
+
+    QStringList appRoots;
+    const QString appDir = PlatformUtilities::instance()->applicationDirectory();
+    if ( !appDir.isEmpty() )
+    {
+      appRoots << appDir;
+    }
+    appRoots << PlatformUtilities::instance()->additionalApplicationDirectories();
+
+    const QString parentCanonicalPath = QFileInfo( fileInfo.absolutePath() ).canonicalFilePath();
+    for ( const QString &appRoot : std::as_const( appRoots ) )
+    {
+      if ( appRoot.isEmpty() )
+      {
+        continue;
+      }
+      for ( const QString &subDir : userManagedRoots )
+      {
+        const QString canonicalRoot = QFileInfo( QStringLiteral( "%1/%2" ).arg( appRoot, subDir ) ).canonicalFilePath();
+        if ( !canonicalRoot.isEmpty() && parentCanonicalPath == canonicalRoot )
+        {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  if ( !fileInfo.isFile() )
+  {
+    return false;
+  }
+
   const QString suffix = fileInfo.suffix().toLower();
 
   static const QStringList allowedExtensions = { "pdf", "png", "jpg", "jpeg", "mp4", "mp4a", "mp3" };
@@ -937,23 +977,40 @@ QVariantMap FileUtils::deleteFiles( const QStringList &filePaths )
 
     const QFileInfo fileInfo( filePath );
     const QString canonicalPath = fileInfo.canonicalFilePath();
-    QFile file( canonicalPath );
 
-    if ( !file.exists() )
+    if ( !QFileInfo::exists( canonicalPath ) )
     {
       qWarning() << QStringLiteral( "File does not exist: %1" ).arg( filePath );
       results[filePath] = false;
       continue;
     }
 
-    const bool success = file.remove();
-    if ( success )
+    bool success = false;
+    if ( fileInfo.isDir() )
     {
-      qDebug() << QStringLiteral( "Successfully deleted file: %1" ).arg( filePath );
+      QDir dir( canonicalPath );
+      success = dir.removeRecursively();
+      if ( success )
+      {
+        qDebug() << QStringLiteral( "Successfully deleted directory: %1" ).arg( filePath );
+      }
+      else
+      {
+        qWarning() << QStringLiteral( "Failed to delete directory: %1" ).arg( filePath );
+      }
     }
     else
     {
-      qWarning() << QStringLiteral( "Failed to delete file: %1 - %2" ).arg( filePath, file.errorString() );
+      QFile file( canonicalPath );
+      success = file.remove();
+      if ( success )
+      {
+        qDebug() << QStringLiteral( "Successfully deleted file: %1" ).arg( filePath );
+      }
+      else
+      {
+        qWarning() << QStringLiteral( "Failed to delete file: %1 - %2" ).arg( filePath, file.errorString() );
+      }
     }
 
     results[filePath] = success;

--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -931,23 +931,14 @@ bool FileUtils::isDeletable( const QString &filePath )
     appRoots << PlatformUtilities::instance()->additionalApplicationDirectories();
 
     const QString parentCanonicalPath = QFileInfo( fileInfo.absolutePath() ).canonicalFilePath();
-    for ( const QString &appRoot : std::as_const( appRoots ) )
-    {
+    return std::any_of( appRoots.cbegin(), appRoots.cend(), [&parentCanonicalPath]( const QString &appRoot ) {
       if ( appRoot.isEmpty() )
-      {
-        continue;
-      }
-      for ( const QString &subDir : userManagedRoots )
-      {
+        return false;
+      return std::any_of( userManagedRoots.cbegin(), userManagedRoots.cend(), [&appRoot, &parentCanonicalPath]( const QString &subDir ) {
         const QString canonicalRoot = QFileInfo( QStringLiteral( "%1/%2" ).arg( appRoot, subDir ) ).canonicalFilePath();
-        if ( !canonicalRoot.isEmpty() && parentCanonicalPath == canonicalRoot )
-        {
-          return true;
-        }
-      }
-    }
-
-    return false;
+        return !canonicalRoot.isEmpty() && parentCanonicalPath == canonicalRoot;
+      } );
+    } );
   }
 
   if ( !fileInfo.isFile() )

--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -923,17 +923,18 @@ bool FileUtils::isDeletable( const QString &filePath )
       QStringLiteral( "Created Projects" ) };
 
     QStringList appRoots;
-    const QString appDir = PlatformUtilities::instance()->applicationDirectory();
-    if ( !appDir.isEmpty() )
-    {
-      appRoots << appDir;
-    }
+    appRoots << PlatformUtilities::instance()->applicationDirectory();
     appRoots << PlatformUtilities::instance()->additionalApplicationDirectories();
+    appRoots.erase( std::remove_if( appRoots.begin(), appRoots.end(), []( const QString &appRoot ) {
+                      return appRoot.isEmpty();
+                    } ),
+                    appRoots.end() );
+
+    if ( appRoots.isEmpty() )
+      return false;
 
     const QString parentCanonicalPath = QFileInfo( fileInfo.absolutePath() ).canonicalFilePath();
     return std::any_of( appRoots.cbegin(), appRoots.cend(), [&parentCanonicalPath]( const QString &appRoot ) {
-      if ( appRoot.isEmpty() )
-        return false;
       return std::any_of( userManagedRoots.cbegin(), userManagedRoots.cend(), [&appRoot, &parentCanonicalPath]( const QString &subDir ) {
         const QString canonicalRoot = QFileInfo( QStringLiteral( "%1/%2" ).arg( appRoot, subDir ) ).canonicalFilePath();
         return !canonicalRoot.isEmpty() && parentCanonicalPath == canonicalRoot;
@@ -961,7 +962,7 @@ QVariantMap FileUtils::deleteFiles( const QStringList &filePaths )
   {
     if ( !isDeletable( filePath ) )
     {
-      qWarning() << QStringLiteral( "Cannot delete file (not allowed): %1" ).arg( filePath );
+      QgsMessageLog::logMessage( QObject::tr( "Cannot delete file (not allowed): %1" ).arg( filePath ), QString(), Qgis::MessageLevel::Warning );
       results[filePath] = false;
       continue;
     }
@@ -971,7 +972,7 @@ QVariantMap FileUtils::deleteFiles( const QStringList &filePaths )
 
     if ( !QFileInfo::exists( canonicalPath ) )
     {
-      qWarning() << QStringLiteral( "File does not exist: %1" ).arg( filePath );
+      QgsMessageLog::logMessage( QObject::tr( "File does not exist: %1" ).arg( filePath ), QString(), Qgis::MessageLevel::Warning );
       results[filePath] = false;
       continue;
     }
@@ -981,26 +982,18 @@ QVariantMap FileUtils::deleteFiles( const QStringList &filePaths )
     {
       QDir dir( canonicalPath );
       success = dir.removeRecursively();
-      if ( success )
+      if ( !success )
       {
-        qDebug() << QStringLiteral( "Successfully deleted directory: %1" ).arg( filePath );
-      }
-      else
-      {
-        qWarning() << QStringLiteral( "Failed to delete directory: %1" ).arg( filePath );
+        QgsMessageLog::logMessage( QObject::tr( "Failed to delete directory: %1" ).arg( filePath ), QString(), Qgis::MessageLevel::Warning );
       }
     }
     else
     {
       QFile file( canonicalPath );
       success = file.remove();
-      if ( success )
+      if ( !success )
       {
-        qDebug() << QStringLiteral( "Successfully deleted file: %1" ).arg( filePath );
-      }
-      else
-      {
-        qWarning() << QStringLiteral( "Failed to delete file: %1 - %2" ).arg( filePath, file.errorString() );
+        QgsMessageLog::logMessage( QObject::tr( "Failed to delete file: %1 - %2" ).arg( filePath, file.errorString() ), QString(), Qgis::MessageLevel::Warning );
       }
     }
 

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -652,7 +652,7 @@ Page {
 
       MenuItem {
         id: deleteFile
-        enabled: FileUtils.isDeletable(itemMenu.itemPath)
+        enabled: itemMenu.itemMetaType !== LocalFilesModel.Folder && FileUtils.isDeletable(itemMenu.itemPath)
         visible: enabled
 
         font: Theme.defaultFont

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -652,7 +652,7 @@ Page {
 
       MenuItem {
         id: deleteFile
-        enabled: itemMenu.itemMetaType !== LocalFilesModel.Folder && FileUtils.isDeletable(itemMenu.itemPath)
+        enabled: FileUtils.isDeletable(itemMenu.itemPath)
         visible: enabled
 
         font: Theme.defaultFont
@@ -660,7 +660,7 @@ Page {
         height: enabled ? 48 : 0
         leftPadding: Theme.menuItemLeftPadding
 
-        text: qsTr("Delete file")
+        text: itemMenu.itemMetaType === LocalFilesModel.Folder ? qsTr("Delete folder") : qsTr("Delete file")
         onTriggered: {
           confirmRemoveDialog.itemsToRemove = [itemMenu.itemPath];
           confirmRemoveDialog.open();


### PR DESCRIPTION
## 🚀 Description

Following up on #6738 (safe file deletion), the `FileUtils::isDeletable()` guard rejected **every directory**, making **Delete** unreachable.

This PR enables directory removal, but only for folders that are direct children of one of the **user‑managed roots** (`Imported Projects`, `Imported Datasets`, `Created Projects`) under the application directory or any additional application directory.

## ✨ Key Changes

- **`FileUtils::isDeletable`** – allow a path when it is a directory whose parent equals `<appDir>/Imported Projects`, `<appDir>/Imported Datasets` or `<appDir>/Created Projects` 
- **`FileUtils::deleteFiles`** – branch on `QFileInfo::isDir()` and use `QDir::removeRecursively()` for directory entries.

---

🔗 Related https://github.com/opengisch/QField/issues/7384