### PR TITLE
Leave file permissions untouched on non-Windows OSes

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -1479,7 +1479,9 @@ bool QFieldCloudProject::moveDownloadedFilesToPermanentStorage()
     if ( QFile::exists( finalFilePath ) )
     {
       // Insure correct permissions prior to removing the file
-      QFile::setPermissions( finalFilePath, QFileDevice::ReadUser | QFileDevice::WriteUser | QFileDevice::ReadOwner | QFileDevice::WriteOwner );
+#ifdef Q_OS_WIN
+      QFile::setPermissions( finalFilePath, QFileDevice::ReadUser | QFileDevice::WriteUser | QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ReadGroup | QFileDevice::WriteGroup );
+#endif
       if ( !QFile::remove( finalFilePath ) )
       {
         hasError = true;

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -148,6 +148,7 @@ Popup {
         QFieldCloudStatusBanner {
           cloudServiceStatus: popup.cloudServiceStatus
           Layout.margins: 10
+          visible: cloudServiceStatus && cloudServiceStatus.hasProblem && !connectionSettings.visible
         }
 
         Text {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -5262,6 +5262,8 @@ ApplicationWindow {
     visible: false
     focus: visible
 
+    cloudServiceStatus: qfieldCloudStatus
+
     onFinished: {
       visible = false;
     }
@@ -5285,6 +5287,8 @@ ApplicationWindow {
 
     width: parent.width
     height: parent.height
+
+    cloudServiceStatus: qfieldCloudStatus
 
     Component.onCompleted: focusstack.addFocusTaker(this)
   }


### PR DESCRIPTION
Possible fix to incoming reports of issues with cloud project synchronization.