### PR TITLE
Fix Clamped range widget value

### DIFF
--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -10,8 +10,8 @@ EditorWidgetBase {
   property bool isDouble: field === undefined || (LayerUtils.fieldType(field) !== 'int' && LayerUtils.fieldType(field) !== 'qlonglong')
   property string widgetStyle: config["Style"] ? config["Style"] : "TextField"
   property int precision: config["Precision"] ? config["Precision"] : isDouble ? 2 : 0
-  property real min: config["Min"] !== undefined ? config["Min"] : -Infinity
-  property real max: config["Max"] !== undefined ? config["Max"] : Infinity
+  property real min: 50 // config["Min"] !== undefined ? config["Min"] : -Infinity
+  property real max: 250 // config["Max"] !== undefined ? config["Max"] : Infinity
   property real step: config["Step"] !== undefined ? config["Step"] : 1
   property string suffix: config["Suffix"] ? config["Suffix"] : ""
 
@@ -64,6 +64,32 @@ EditorWidgetBase {
       background.visible: isEnabled || (!isEditable && isEditing)
 
       onTextEdited: {
+        if (text === "") {
+          if (!isNull)
+            valueChangeRequested(text, true);
+        } else {
+          const parsedValue = parseFloat(text);
+          if (!isNaN(parsedValue)) {
+            if (Number.isFinite(rangeItem.max) && parsedValue > rangeItem.max) {
+              valueChangeRequested(rangeItem.max, false);
+              text = Qt.binding(function () {
+                return isNull ? '' : value;
+              });
+            } else {
+              valueChangeRequested(parsedValue, false);
+            }
+          }
+        }
+      }
+
+      onActiveFocusChanged: {
+        if (!activeFocus)
+          commitTypedValue();
+      }
+
+      onEditingFinished: commitTypedValue()
+
+      function commitTypedValue() {
         if (text !== "") {
           const parsedValue = parseFloat(text);
           if (!isNaN(parsedValue)) {
@@ -73,18 +99,11 @@ EditorWidgetBase {
             } else if (Number.isFinite(rangeItem.max) && parsedValue > rangeItem.max) {
               clampedValue = rangeItem.max;
             }
-
-            if (clampedValue !== value) {
-              valueChangeRequested(clampedValue, false);
-            }
-            if (parsedValue !== value) {
-              text = Qt.binding(function () {
-                return isNull ? '' : value;
-              });
-            }
+            valueChangeRequested(clampedValue, false);
+            text = Qt.binding(function () {
+              return isNull ? '' : value;
+            });
           }
-        } else if (!isNull) {
-          valueChangeRequested(text, true);
         }
       }
     }

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -10,8 +10,8 @@ EditorWidgetBase {
   property bool isDouble: field === undefined || (LayerUtils.fieldType(field) !== 'int' && LayerUtils.fieldType(field) !== 'qlonglong')
   property string widgetStyle: config["Style"] ? config["Style"] : "TextField"
   property int precision: config["Precision"] ? config["Precision"] : isDouble ? 2 : 0
-  property real min: 50 // config["Min"] !== undefined ? config["Min"] : -Infinity
-  property real max: 250 // config["Max"] !== undefined ? config["Max"] : Infinity
+  property real min: config["Min"] !== undefined ? config["Min"] : -Infinity
+  property real max: config["Max"] !== undefined ? config["Max"] : Infinity
   property real step: config["Step"] !== undefined ? config["Step"] : 1
   property string suffix: config["Suffix"] ? config["Suffix"] : ""
 

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -65,8 +65,9 @@ EditorWidgetBase {
 
       onTextEdited: {
         if (text === "") {
-          if (!isNull)
+          if (!isNull) {
             valueChangeRequested(text, true);
+          }
         } else {
           const parsedValue = parseFloat(text);
           if (!isNaN(parsedValue)) {
@@ -83,13 +84,14 @@ EditorWidgetBase {
       }
 
       onActiveFocusChanged: {
-        if (!activeFocus)
-          commitTypedValue();
+        if (!activeFocus) {
+          commitValue();
+        }
       }
 
-      onEditingFinished: commitTypedValue()
+      onEditingFinished: commitValue()
 
-      function commitTypedValue() {
+      function commitValue() {
         if (text !== "") {
           const parsedValue = parseFloat(text);
           if (!isNaN(parsedValue)) {
@@ -99,7 +101,9 @@ EditorWidgetBase {
             } else if (Number.isFinite(rangeItem.max) && parsedValue > rangeItem.max) {
               clampedValue = rangeItem.max;
             }
-            valueChangeRequested(clampedValue, false);
+            if (clampedValue !== value) {
+              valueChangeRequested(clampedValue, false);
+            }
             text = Qt.binding(function () {
               return isNull ? '' : value;
             });

--- a/test/qml/tst_editorwidgets.qml
+++ b/test/qml/tst_editorwidgets.qml
@@ -286,15 +286,15 @@ TestCase {
     const textField = range.children[0].children[1];
 
     textField.text = "20";
-    textField.commitTypedValue();
+    textField.commitValue();
     compare(range.value, 50);
 
     textField.text = "999";
-    textField.commitTypedValue();
+    textField.commitValue();
     compare(range.value, 250);
 
     textField.text = "150";
-    textField.commitTypedValue();
+    textField.commitValue();
     compare(range.value, 150);
 
     isEditing = false;

--- a/test/qml/tst_editorwidgets.qml
+++ b/test/qml/tst_editorwidgets.qml
@@ -46,6 +46,13 @@ TestCase {
     readonly property real default_value: 999
   }
 
+  Connections {
+    target: range
+    function onValueChangeRequested(value, isNull) {
+      range.value = value;
+    }
+  }
+
   EditorWidgets.DateTime {
     id: dateTime
     property var mainWindow: mainWindowItem
@@ -264,6 +271,33 @@ TestCase {
     compare(sliderRow.visible, false);
     compare(valueLabel.text, range.min + ".0000DEFAULT_SUFFIX"); // NOTE: using `range.min` because of `rangeItem.parent.value`
     compare(slider.value, range.min); // NOTE: using `range.min` because of `rangeItem.parent.value`
+  }
+
+  function test_02_range() {
+    range.config = {
+      "Min": 50,
+      "Max": 250,
+      "Step": 1
+    };
+    range.value = 100;
+    isEditing = true;
+    waitForRendering(range);
+
+    const textField = range.children[0].children[1];
+
+    textField.text = "20";
+    textField.commitTypedValue();
+    compare(range.value, 50);
+
+    textField.text = "999";
+    textField.commitTypedValue();
+    compare(range.value, 250);
+
+    textField.text = "150";
+    textField.commitTypedValue();
+    compare(range.value, 150);
+
+    isEditing = false;
   }
 
   /**


### PR DESCRIPTION
### 🚀 Description
Follow-up to #7127 — which introduced clamping of range widget values to configured min/max limits. This PR addresses one more edge cases in the TextField variant of the Range editor widget around when and how values are committed and clamped.

### 🐛 Problem
When using a defined range (e.g., 50–250), it is not possible to enter certain valid values due to premature validation. For example as soon as the user types the first digit (2), the input is immediately corrected to the minimum value (50).