### PR TITLE
[Backport release-4_1] Safeguard from crashes when FeatureModel fails to create() a feature but QML still calls save()

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -700,9 +700,16 @@ bool FeatureModel::save( bool flushBuffer )
             }
           }
 
-          if ( hasChanged && changed )
+          if ( hasChanged )
           {
-            mSavedFeature = mFeature;
+            if ( changed )
+            {
+              mSavedFeature = mFeature;
+            }
+            else
+            {
+              QgsMessageLog::logMessage( tr( "Cannot update feature" ), QStringLiteral( "QField" ), Qgis::Warning );
+            }
           }
         }
         else
@@ -712,11 +719,11 @@ bool FeatureModel::save( bool flushBuffer )
           {
             mSavedFeature = mFeature;
           }
-        }
 
-        if ( !changed )
-        {
-          QgsMessageLog::logMessage( tr( "Cannot update feature" ), QStringLiteral( "QField" ), Qgis::Warning );
+          if ( !changed )
+          {
+            QgsMessageLog::logMessage( tr( "Cannot update feature" ), QStringLiteral( "QField" ), Qgis::Warning );
+          }
         }
 
         if ( flushBuffer )

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -69,7 +69,7 @@ void FeatureModel::setFeature( const QgsFeature &feature )
 
   beginResetModel();
   mFeature = feature;
-  mSavedFeature = QgsFeature();
+  mSavedFeature = QgsFeature( mFeature.fields() );
   mFeatures.clear();
   mAttributesAllowEdit.clear();
   endResetModel();
@@ -157,7 +157,7 @@ void FeatureModel::setCurrentLayer( QgsVectorLayer *layer )
       }
     }
 
-    mSavedFeature = QgsFeature();
+    mSavedFeature = QgsFeature( mLayer->fields() );
 
     if ( mLayer->customPropertyKeys().contains( QStringLiteral( "is_geometry_locked" ) ) )
     {
@@ -679,7 +679,7 @@ bool FeatureModel::save( bool flushBuffer )
         updateDefaultValues();
 
         bool changed = false;
-        if ( mSavedFeature.id() == mFeature.id() )
+        if ( mSavedFeature.id() == mFeature.id() && mSavedFeature.fields() == mFeature.fields() )
         {
           bool hasChanged = false;
           if ( ( mFeature.hasGeometry() || mSavedFeature.hasGeometry() ) && !mFeature.geometry().equals( mSavedFeature.geometry() ) )
@@ -841,7 +841,7 @@ void FeatureModel::resetFeature()
   }
 
   mFeature = QgsFeature( mLayer->fields() );
-  mSavedFeature = QgsFeature();
+  mSavedFeature = QgsFeature( mLayer->fields() );
 }
 
 void FeatureModel::resetFeatureId()
@@ -905,7 +905,7 @@ void FeatureModel::resetAttributes( bool partialReset )
   QgsExpressionContext expressionContext = createExpressionContext();
   expressionContext.setFeature( mFeature );
   mFeature = QgsVectorLayerUtils::createFeature( mLayer, mFeature.geometry(), mFeature.attributes().toMap(), &expressionContext );
-  mSavedFeature = QgsFeature();
+  mSavedFeature = QgsFeature( mLayer->fields() );
   endResetModel();
 
   updatePermissions();


### PR DESCRIPTION
Backport #7405
 **Authored by:** @nirvn