### PR TITLE
Fix image stamping orientation

### DIFF
--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -410,6 +410,10 @@ void FileUtils::addImageMetadata( const QString &imagePath, const GnssPositionIn
 
 void FileUtils::addImageStamp( const QString &imagePath, const QString &text, const QString &textFormat, Qgis::TextHorizontalAlignment horizontalAlignment, const QString &imageDecoration )
 {
+  qDebug() << "addImageStamp: text=" << text
+           << "alignment=" << static_cast<int>(horizontalAlignment)
+           << "textFormat empty=" << textFormat.isEmpty()
+           << "decoration=" << imageDecoration;
   if ( !QFileInfo::exists( imagePath ) || text.isEmpty() )
   {
     return;
@@ -418,7 +422,9 @@ void FileUtils::addImageStamp( const QString &imagePath, const QString &text, co
   QgsReadWriteContext readWriteContent;
   readWriteContent.setPathResolver( QgsProject::instance()->pathResolver() );
   QVariantMap metadata = QgsExifTools::readTags( imagePath );
-  QImage img( imagePath );
+  QImageReader imageReader( imagePath );
+  imageReader.setAutoTransform( true );
+  QImage img = imageReader.read();
   if ( !img.isNull() )
   {
     QPainter painter( &img );
@@ -511,6 +517,11 @@ void FileUtils::addImageStamp( const QString &imagePath, const QString &text, co
 
     for ( const QString &key : metadata.keys() )
     {
+      if ( key == QLatin1String( "Exif.Image.Orientation" ) )
+      {
+        // The rotation transform already happened when we loaded the image, skip the tag
+        continue;
+      }
       QgsExifTools::tagImage( imagePath, key, metadata[key] );
     }
   }

--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -410,10 +410,6 @@ void FileUtils::addImageMetadata( const QString &imagePath, const GnssPositionIn
 
 void FileUtils::addImageStamp( const QString &imagePath, const QString &text, const QString &textFormat, Qgis::TextHorizontalAlignment horizontalAlignment, const QString &imageDecoration )
 {
-  qDebug() << "addImageStamp: text=" << text
-           << "alignment=" << static_cast<int>(horizontalAlignment)
-           << "textFormat empty=" << textFormat.isEmpty()
-           << "decoration=" << imageDecoration;
   if ( !QFileInfo::exists( imagePath ) || text.isEmpty() )
   {
     return;


### PR DESCRIPTION
addImageStamp loaded the JPEG with QImage(path) which ignores the EXIF Orientation tag, then re-applied that tag after save, so on ios and Android-landscape captures, the stamp was painted onto the sensor-native pixel buffer and the viewer's display rotation pushed it onto the wrong edge.

Switched the load to QImageReader with setAutoTransform(true) so the painter operates on display-oriented pixels, and skip Exif.Image.Orientation when restoring metadata to avoid double rotation. Mirrors the existing pattern in DrawingCanvas::createCanvasFromImage/save.

Related to: #7389