### PR TITLE
Add a search filter for QFieldCloud projects

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1290,9 +1290,12 @@ bool QFieldCloudProjectsFilterModel::filterAcceptsRow( int source_row, const QMo
     return false;
   }
 
-  if ( !mIncludePublic && mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::UserRoleOriginRole ).toString() == QStringLiteral( "public" ) )
+  if ( !mIncludePublic )
   {
-    return false;
+    if ( mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::UserRoleOriginRole ).toString() == QStringLiteral( "public" ) && mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::LocalPathRole ).toString().isEmpty() )
+    {
+      return false;
+    }
   }
 
   if ( !mShowInValidProjects && mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::StatusRole ).toInt() == static_cast<int>( QFieldCloudProject::ProjectStatus::Failing ) )
@@ -1357,7 +1360,7 @@ void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
 
   QString searchTerm;
   QString owner;
-  bool includePublic = mIncludePublic;
+  bool includePublic = false;
 
   const QStringList tokens = text.split( QLatin1Char( ' ' ), Qt::SkipEmptyParts );
   for ( const QString &token : tokens )
@@ -1382,12 +1385,7 @@ void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
 
   mKeywordFilter = searchTerm.split( QLatin1Char( ' ' ), Qt::SkipEmptyParts );
   mOwnerFilter = owner;
-
-  if ( mIncludePublic != includePublic )
-  {
-    mIncludePublic = includePublic;
-    emit includePublicChanged();
-  }
+  mIncludePublic = includePublic;
 
   if ( mSourceModel && ( !mOwnerFilter.isEmpty() || !mKeywordFilter.isEmpty() ) )
   {
@@ -1398,6 +1396,12 @@ void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
   }
   else
   {
+    if ( mIsSearching )
+    {
+      mIsSearching = false;
+      emit isSearchingChanged();
+    }
+
     mProjectsAppendingTimer.stop();
   }
 
@@ -1447,25 +1451,6 @@ void QFieldCloudProjectsFilterModel::setShowFeaturedOnTop( bool showFeaturedOnTo
 bool QFieldCloudProjectsFilterModel::showFeaturedOnTop() const
 {
   return mShowFeaturedOnTop;
-}
-
-bool QFieldCloudProjectsFilterModel::includePublic() const
-{
-  return mIncludePublic;
-}
-
-void QFieldCloudProjectsFilterModel::setIncludePublic( bool includePublic )
-{
-  if ( mIncludePublic == includePublic )
-  {
-    return;
-  }
-
-  beginFilterChange();
-  mIncludePublic = includePublic;
-  endFilterChange( QSortFilterProxyModel::Direction::Rows );
-
-  emit includePublicChanged();
 }
 
 bool QFieldCloudProjectsFilterModel::isSearching() const

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -26,6 +26,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QNetworkReply>
+#include <QRegularExpression>
 #include <QSettings>
 #include <QTemporaryFile>
 #include <qgis.h>
@@ -1264,16 +1265,27 @@ bool QFieldCloudProjectsFilterModel::filterAcceptsRow( int source_row, const QMo
     return false;
   }
 
-  if ( mTextFilter.isEmpty() )
-  {
-    return true;
-  }
-
   const QString name = mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::NameRole ).toString();
   const QString description = mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::DescriptionRole ).toString();
   const QString owner = mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::OwnerRole ).toString();
 
-  return name.contains( mTextFilter, Qt::CaseInsensitive ) || description.contains( mTextFilter, Qt::CaseInsensitive ) || owner.contains( mTextFilter, Qt::CaseInsensitive );
+  bool matchesSearchTerm = true;
+  if ( !mSearchTermFilter.isEmpty() )
+  {
+    const QStringList words = mSearchTermFilter.split( QRegularExpression( QStringLiteral( "\\s+" ) ), Qt::SkipEmptyParts );
+    for ( const QString &word : words )
+    {
+      if ( !name.contains( word, Qt::CaseInsensitive ) && !description.contains( word, Qt::CaseInsensitive ) )
+      {
+        matchesSearchTerm = false;
+        break;
+      }
+    }
+  }
+
+  const bool matchesOwner = mOwnerFilter.isEmpty() || owner.compare( mOwnerFilter, Qt::CaseInsensitive ) == 0;
+
+  return matchesSearchTerm && matchesOwner;
 }
 
 void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
@@ -1285,6 +1297,58 @@ void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
 
   beginFilterChange();
   mTextFilter = text;
+
+  QString searchTerm;
+  QString owner;
+  bool includePublic = mIncludePublic;
+
+  const QStringList tokens = text.split( QRegularExpression( QStringLiteral( "\\s+" ) ), Qt::SkipEmptyParts );
+  for ( const QString &token : tokens )
+  {
+    if ( token.startsWith( QStringLiteral( "owner:" ), Qt::CaseInsensitive ) )
+    {
+      owner = token.mid( 6 ).trimmed();
+    }
+    else if ( token.compare( QStringLiteral( "public" ), Qt::CaseInsensitive ) == 0 )
+    {
+      includePublic = true;
+    }
+    else
+    {
+      if ( !searchTerm.isEmpty() )
+      {
+        searchTerm += QLatin1Char( ' ' );
+      }
+      searchTerm += token;
+    }
+  }
+
+  mSearchTermFilter = searchTerm;
+  mOwnerFilter = owner;
+
+  if ( mIncludePublic != includePublic )
+  {
+    mIncludePublic = includePublic;
+    emit includePublicChanged();
+  }
+
+  const bool hasSearchInput = !mOwnerFilter.isEmpty() || !mSearchTermFilter.isEmpty();
+  if ( hasSearchInput && mSourceModel )
+  {
+    mIsSearching = true;
+    emit isSearchingChanged();
+
+    QMetaObject::Connection *conn = new QMetaObject::Connection;
+    *conn = connect( mSourceModel, &QFieldCloudProjectsModel::projectsAppended, this, [this, conn]( const QString &, const QString &, bool, const QString & ) {
+      mIsSearching = false;
+      emit isSearchingChanged();
+      QObject::disconnect( *conn );
+      delete conn;
+    } );
+
+    mSourceModel->appendProjects( mOwnerFilter, mSearchTermFilter );
+  }
+
   endFilterChange( QSortFilterProxyModel::Direction::Rows );
 
   emit textFilterChanged();
@@ -1331,4 +1395,28 @@ void QFieldCloudProjectsFilterModel::setShowFeaturedOnTop( bool showFeaturedOnTo
 bool QFieldCloudProjectsFilterModel::showFeaturedOnTop() const
 {
   return mShowFeaturedOnTop;
+}
+
+bool QFieldCloudProjectsFilterModel::includePublic() const
+{
+  return mIncludePublic;
+}
+
+void QFieldCloudProjectsFilterModel::setIncludePublic( bool includePublic )
+{
+  if ( mIncludePublic == includePublic )
+  {
+    return;
+  }
+
+  beginFilterChange();
+  mIncludePublic = includePublic;
+  endFilterChange( QSortFilterProxyModel::Direction::Rows );
+
+  emit includePublicChanged();
+}
+
+bool QFieldCloudProjectsFilterModel::isSearching() const
+{
+  return mIsSearching;
 }

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1309,7 +1309,7 @@ void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
     {
       owner = token.mid( 6 ).trimmed();
     }
-    else if ( token.compare( QStringLiteral( "public" ), Qt::CaseInsensitive ) == 0 )
+    else if ( token.compare( QStringLiteral( "include:public" ), Qt::CaseInsensitive ) == 0 )
     {
       includePublic = true;
     }

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1286,22 +1286,27 @@ bool QFieldCloudProjectsFilterModel::filterAcceptsRow( int source_row, const QMo
     return false;
   }
 
-  const QString name = mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::NameRole ).toString();
-  const QString description = mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::DescriptionRole ).toString();
-  const QString owner = mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::OwnerRole ).toString();
-
-  bool matchesSearchTerm = true;
-  if ( !mSearchTermFilter.isEmpty() )
+  if ( !mOwnerFilter.isEmpty() )
   {
-    const QStringList words = mSearchTermFilter.split( QRegularExpression( QStringLiteral( "\\s+" ) ), Qt::SkipEmptyParts );
-    matchesSearchTerm = std::all_of( words.cbegin(), words.cend(), [&name, &description]( const QString &word ) {
-      return name.contains( word, Qt::CaseInsensitive ) || description.contains( word, Qt::CaseInsensitive );
-    } );
+    const QString owner = mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::OwnerRole ).toString();
+    if ( owner.compare( mOwnerFilter, Qt::CaseInsensitive ) != 0 )
+    {
+      return false;
+    }
   }
 
-  const bool matchesOwner = mOwnerFilter.isEmpty() || owner.compare( mOwnerFilter, Qt::CaseInsensitive ) == 0;
+  const QString name = mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::NameRole ).toString();
+  const QString description = mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::DescriptionRole ).toString();
 
-  return matchesSearchTerm && matchesOwner;
+  if ( !mKeywordFilter.isEmpty() )
+  {
+    if ( std::any_of( mKeywordFilter.begin(), mKeywordFilter.end(), [&name, &description]( const QString &keyword ) { return !name.contains( keyword, Qt::CaseInsensitive ) && !description.contains( keyword, Qt::CaseInsensitive ); } ) )
+    {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
@@ -1318,7 +1323,7 @@ void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
   QString owner;
   bool includePublic = mIncludePublic;
 
-  const QStringList tokens = text.split( QRegularExpression( QStringLiteral( "\\s+" ) ), Qt::SkipEmptyParts );
+  const QStringList tokens = text.split( QLatin1Char( ' ' ), Qt::SkipEmptyParts );
   for ( const QString &token : tokens )
   {
     if ( token.startsWith( QStringLiteral( "owner:" ), Qt::CaseInsensitive ) )
@@ -1339,7 +1344,7 @@ void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
     }
   }
 
-  mSearchTermFilter = searchTerm;
+  mKeywordFilter = searchTerm.split( QLatin1Char( ' ' ), Qt::SkipEmptyParts );
   mOwnerFilter = owner;
 
   if ( mIncludePublic != includePublic )
@@ -1348,8 +1353,7 @@ void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
     emit includePublicChanged();
   }
 
-  const bool hasSearchInput = !mOwnerFilter.isEmpty() || !mSearchTermFilter.isEmpty();
-  if ( hasSearchInput && mSourceModel )
+  if ( ( !mOwnerFilter.isEmpty() || !mKeywordFilter.isEmpty() ) )
   {
     mIsSearching = true;
     emit isSearchingChanged();
@@ -1362,9 +1366,8 @@ void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
       delete conn;
     } );
 
-    mSourceModel->appendProjects( mOwnerFilter, mSearchTermFilter );
+    mSourceModel->appendProjects( mOwnerFilter, mKeywordFilter.join( QLatin1Char( ' ' ) ) );
   }
-
   endFilterChange( QSortFilterProxyModel::Direction::Rows );
 
   emit textFilterChanged();

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1206,8 +1206,18 @@ void QFieldCloudProjectsFilterModel::setProjectsModel( QFieldCloudProjectsModel 
     return;
   }
 
+  if ( mSourceModel )
+  {
+    disconnect( mSourceModel, &QFieldCloudProjectsModel::projectsAppended, this, &QFieldCloudProjectsFilterModel::projectsAppended );
+  }
+
   mSourceModel = projectsModel;
   setSourceModel( mSourceModel );
+
+  if ( mSourceModel )
+  {
+    connect( mSourceModel, &QFieldCloudProjectsModel::projectsAppended, this, &QFieldCloudProjectsFilterModel::projectsAppended );
+  }
 
   emit projectsModelChanged();
 }
@@ -1309,6 +1319,20 @@ bool QFieldCloudProjectsFilterModel::filterAcceptsRow( int source_row, const QMo
   return true;
 }
 
+void QFieldCloudProjectsFilterModel::projectsAppended( const QString &owner, const QString &search, const bool hasError, const QString &errorString )
+{
+  if ( mOwnerFilter.isEmpty() && mKeywordFilter.isEmpty() )
+  {
+    return;
+  }
+
+  if ( mOwnerFilter == owner && mKeywordFilter == search.split( QLatin1Char( ' ' ) ) )
+  {
+    mIsSearching = false;
+    emit isSearchingChanged();
+  }
+}
+
 void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
 {
   if ( mTextFilter == text )
@@ -1357,14 +1381,6 @@ void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
   {
     mIsSearching = true;
     emit isSearchingChanged();
-
-    QMetaObject::Connection *conn = new QMetaObject::Connection;
-    *conn = connect( mSourceModel, &QFieldCloudProjectsModel::projectsAppended, this, [this, conn]( const QString &, const QString &, bool, const QString & ) {
-      mIsSearching = false;
-      emit isSearchingChanged();
-      QObject::disconnect( *conn );
-      delete conn;
-    } );
 
     mSourceModel->appendProjects( mOwnerFilter, mKeywordFilter.join( QLatin1Char( ' ' ) ) );
   }

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -37,6 +37,8 @@
 #include <qgsproject.h>
 #include <qgsproviderregistry.h>
 
+#include <algorithm>
+
 
 QFieldCloudProjectsModel::QFieldCloudProjectsModel()
 {
@@ -288,6 +290,25 @@ void QFieldCloudProjectsModel::appendProjects( const QString &owner, const QStri
 
   const NetworkReply *reply = mCloudConnection->get( request, url, params );
   connect( reply, &NetworkReply::finished, this, &QFieldCloudProjectsModel::projectListReceived );
+}
+
+QStringList QFieldCloudProjectsModel::uniqueOwners() const
+{
+  QStringList owners;
+  for ( const QFieldCloudProject *project : std::as_const( mProjects ) )
+  {
+    if ( project->userRoleOrigin() == QStringLiteral( "public" ) )
+    {
+      continue;
+    }
+    const QString owner = project->owner();
+    if ( !owners.contains( owner ) )
+    {
+      owners.append( owner );
+    }
+  }
+  std::sort( owners.begin(), owners.end() );
+  return owners;
 }
 
 void QFieldCloudProjectsModel::removeLocalProject( const QString &projectId )
@@ -1273,14 +1294,9 @@ bool QFieldCloudProjectsFilterModel::filterAcceptsRow( int source_row, const QMo
   if ( !mSearchTermFilter.isEmpty() )
   {
     const QStringList words = mSearchTermFilter.split( QRegularExpression( QStringLiteral( "\\s+" ) ), Qt::SkipEmptyParts );
-    for ( const QString &word : words )
-    {
-      if ( !name.contains( word, Qt::CaseInsensitive ) && !description.contains( word, Qt::CaseInsensitive ) )
-      {
-        matchesSearchTerm = false;
-        break;
-      }
-    }
+    matchesSearchTerm = std::all_of( words.cbegin(), words.cend(), [&name, &description]( const QString &word ) {
+      return name.contains( word, Qt::CaseInsensitive ) || description.contains( word, Qt::CaseInsensitive );
+    } );
   }
 
   const bool matchesOwner = mOwnerFilter.isEmpty() || owner.compare( mOwnerFilter, Qt::CaseInsensitive ) == 0;

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1197,6 +1197,10 @@ QFieldCloudProjectsFilterModel::QFieldCloudProjectsFilterModel( QObject *parent 
   setDynamicSortFilter( true );
   setSortLocaleAware( true );
   sort( 0 );
+
+  mProjectsAppendingTimer.setInterval( 500 );
+  mProjectsAppendingTimer.setSingleShot( true );
+  connect( &mProjectsAppendingTimer, &QTimer::timeout, this, &QFieldCloudProjectsFilterModel::triggerProjectsAppending );
 }
 
 void QFieldCloudProjectsFilterModel::setProjectsModel( QFieldCloudProjectsModel *projectsModel )
@@ -1333,6 +1337,14 @@ void QFieldCloudProjectsFilterModel::projectsAppended( const QString &owner, con
   }
 }
 
+void QFieldCloudProjectsFilterModel::triggerProjectsAppending()
+{
+  if ( mSourceModel && ( !mOwnerFilter.isEmpty() || !mKeywordFilter.isEmpty() ) )
+  {
+    mSourceModel->appendProjects( mOwnerFilter, mKeywordFilter.join( QLatin1Char( ' ' ) ) );
+  }
+}
+
 void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
 {
   if ( mTextFilter == text )
@@ -1377,13 +1389,18 @@ void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
     emit includePublicChanged();
   }
 
-  if ( ( !mOwnerFilter.isEmpty() || !mKeywordFilter.isEmpty() ) )
+  if ( mSourceModel && ( !mOwnerFilter.isEmpty() || !mKeywordFilter.isEmpty() ) )
   {
     mIsSearching = true;
     emit isSearchingChanged();
 
-    mSourceModel->appendProjects( mOwnerFilter, mKeywordFilter.join( QLatin1Char( ' ' ) ) );
+    mProjectsAppendingTimer.start();
   }
+  else
+  {
+    mProjectsAppendingTimer.stop();
+  }
+
   endFilterChange( QSortFilterProxyModel::Direction::Rows );
 
   emit textFilterChanged();

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -364,6 +364,7 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
     void isSearchingChanged();
 
   private slots:
+    void triggerProjectsAppending();
     void projectsAppended( const QString &owner, const QString &search, const bool hasError = false, const QString &errorString = QString() );
 
   protected:
@@ -380,6 +381,8 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
     QString mOwnerFilter;
     bool mIncludePublic = false;
     bool mIsSearching = false;
+
+    QTimer mProjectsAppendingTimer;
 };
 
 #endif // QFIELDCLOUDPROJECTSMODEL_H

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -373,7 +373,7 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
     bool mShowInValidProjects = false;
     bool mShowFeaturedOnTop = false;
     QString mTextFilter;
-    QString mSearchTermFilter;
+    QStringList mKeywordFilter;
     QString mOwnerFilter;
     bool mIncludePublic = false;
     bool mIsSearching = false;

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -192,6 +192,9 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Fetches all cloud projects tied to a given \a search term and/or \a owner name.
     Q_INVOKABLE void appendProjects( const QString &owner, const QString &search, int projectFetchOffset = 0 );
 
+    //! Returns a list of unique project owners, excluding projects where the user has access only through public visibility.
+    Q_INVOKABLE QStringList uniqueOwners() const;
+
     /**
      * Transform a locally-stored project into a cloud project by uploading its content to the
      * QFieldCloud server.

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -363,6 +363,9 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
     void includePublicChanged();
     void isSearchingChanged();
 
+  private slots:
+    void projectsAppended( const QString &owner, const QString &search, const bool hasError = false, const QString &errorString = QString() );
+
   protected:
     bool lessThan( const QModelIndex &sourceLeft, const QModelIndex &sourceRight ) const override;
     virtual bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override;

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -271,6 +271,8 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
     Q_PROPERTY( bool showLocalOnly READ showLocalOnly WRITE setShowLocalOnly NOTIFY showLocalOnlyChanged )
     Q_PROPERTY( bool showInValidProjects READ showInValidProjects WRITE setShowInValidProjects NOTIFY showInValidProjectsChanged )
     Q_PROPERTY( bool showFeaturedOnTop READ showFeaturedOnTop WRITE setShowFeaturedOnTop NOTIFY showFeaturedOnTopChanged )
+    Q_PROPERTY( bool includePublic READ includePublic WRITE setIncludePublic NOTIFY includePublicChanged )
+    Q_PROPERTY( bool isSearching READ isSearching NOTIFY isSearchingChanged )
 
   public:
     explicit QFieldCloudProjectsFilterModel( QObject *parent = nullptr );
@@ -332,6 +334,21 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
      */
     bool showFeaturedOnTop() const;
 
+    /**
+     * Returns TRUE if public projects are currently included in the filtered list of cloud projects.
+     */
+    bool includePublic() const;
+
+    /**
+     * Sets whether to include public projects in the filtered list of cloud projects.
+     */
+    void setIncludePublic( bool includePublic );
+
+    /**
+     * Returns TRUE while an asynchronous fetch triggered by an owner filter is in flight.
+     */
+    bool isSearching() const;
+
   signals:
 
     void projectsModelChanged();
@@ -340,6 +357,8 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
     void textFilterChanged();
     void showInValidProjectsChanged();
     void showFeaturedOnTopChanged();
+    void includePublicChanged();
+    void isSearchingChanged();
 
   protected:
     bool lessThan( const QModelIndex &sourceLeft, const QModelIndex &sourceRight ) const override;
@@ -351,7 +370,10 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
     bool mShowInValidProjects = false;
     bool mShowFeaturedOnTop = false;
     QString mTextFilter;
+    QString mSearchTermFilter;
+    QString mOwnerFilter;
     bool mIncludePublic = false;
+    bool mIsSearching = false;
 };
 
 #endif // QFIELDCLOUDPROJECTSMODEL_H

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -348,7 +348,7 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
     void setIncludePublic( bool includePublic );
 
     /**
-     * Returns TRUE while an asynchronous fetch triggered by an owner filter is in flight.
+     * Returns TRUE while an asynchronous projects appending was triggered by a text filter.
      */
     bool isSearching() const;
 

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -274,7 +274,6 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
     Q_PROPERTY( bool showLocalOnly READ showLocalOnly WRITE setShowLocalOnly NOTIFY showLocalOnlyChanged )
     Q_PROPERTY( bool showInValidProjects READ showInValidProjects WRITE setShowInValidProjects NOTIFY showInValidProjectsChanged )
     Q_PROPERTY( bool showFeaturedOnTop READ showFeaturedOnTop WRITE setShowFeaturedOnTop NOTIFY showFeaturedOnTopChanged )
-    Q_PROPERTY( bool includePublic READ includePublic WRITE setIncludePublic NOTIFY includePublicChanged )
     Q_PROPERTY( bool isSearching READ isSearching NOTIFY isSearchingChanged )
 
   public:
@@ -338,16 +337,6 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
     bool showFeaturedOnTop() const;
 
     /**
-     * Returns TRUE if public projects are currently included in the filtered list of cloud projects.
-     */
-    bool includePublic() const;
-
-    /**
-     * Sets whether to include public projects in the filtered list of cloud projects.
-     */
-    void setIncludePublic( bool includePublic );
-
-    /**
      * Returns TRUE while an asynchronous projects appending was triggered by a text filter.
      */
     bool isSearching() const;
@@ -360,7 +349,6 @@ class QFieldCloudProjectsFilterModel : public QSortFilterProxyModel
     void textFilterChanged();
     void showInValidProjectsChanged();
     void showFeaturedOnTopChanged();
-    void includePublicChanged();
     void isSearchingChanged();
 
   private slots:

--- a/src/core/utils/stringutils.cpp
+++ b/src/core/utils/stringutils.cpp
@@ -219,3 +219,55 @@ QString StringUtils::highlightText( const QString &string, const QString &highli
 
   return formattedString;
 }
+
+QString StringUtils::snippet( const QString &string, int desiredCharactersLength )
+{
+  if ( string.isEmpty() )
+  {
+    return QString();
+  }
+
+  QString snippet = string.trimmed().replace( QRegularExpression( QString( "[\r\n]+" ) ), " " );
+  if ( snippet.size() <= desiredCharactersLength )
+  {
+    return snippet;
+  }
+  snippet.clear();
+
+  const QString paragraph = string.split( QRegularExpression( QString( "[\r\n]+" ) ), Qt::SkipEmptyParts ).at( 0 );
+  const QStringList sentences = paragraph.split( QRegularExpression( QString( "\\." ) ), Qt::SkipEmptyParts );
+  for ( const QString &sentence : sentences )
+  {
+    if ( snippet.size() + sentence.size() < desiredCharactersLength )
+    {
+      snippet += QStringLiteral( "%1." ).arg( sentence );
+    }
+    else
+    {
+      if ( snippet.isEmpty() )
+      {
+        const QStringList parts = string.split( QRegularExpression( QString( "\\s" ) ), Qt::SkipEmptyParts );
+        if ( !parts.isEmpty() )
+        {
+          for ( const QString &part : parts )
+          {
+            if ( snippet.size() + part.size() < desiredCharactersLength )
+            {
+              snippet += QStringLiteral( "%1 " ).arg( part );
+            }
+          }
+        }
+
+        if ( snippet.isEmpty() )
+        {
+          snippet = QStringLiteral( "%1" ).arg( sentence.mid( 0, desiredCharactersLength ) );
+        }
+
+        snippet += QStringLiteral( "…" );
+      }
+      break;
+    }
+  }
+
+  return snippet;
+}

--- a/src/core/utils/stringutils.h
+++ b/src/core/utils/stringutils.h
@@ -64,6 +64,9 @@ class QFIELD_CORE_EXPORT StringUtils : public QObject
      * values.
      */
     static Q_INVOKABLE QString replaceFilenameTags( const QString &string, const QString &filename );
+
+    //! Returns a short snippet representing the beginning of a longer text.
+    static Q_INVOKABLE QString snippet( const QString &string, int desiredCharactersLength = 160 );
 };
 
 #endif // STRINGUTILS_H

--- a/src/qml/QFieldCloudProjectDetails.qml
+++ b/src/qml/QFieldCloudProjectDetails.qml
@@ -276,7 +276,7 @@ ColumnLayout {
         return qsTr('Synchronize');
       }
       visible: true
-      enabled: cloudProject != undefined && cloudProject.deltaFileWrapper !== undefined && cloudProject.status === QFieldCloudProject.Idle && !cloudProject.deltaFileWrapper.hasError
+      enabled: cloudProject != undefined && cloudProject.status === QFieldCloudProject.Idle && cloudProject.deltaFileWrapper !== null && !cloudProject.deltaFileWrapper.hasError
 
       onClicked: {
         synchronize();

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -8,12 +8,14 @@ import Theme
 Pane {
   id: filterPanel
 
+  property string currentUsername: ""
+
   property string activePreset: ""
   readonly property var presets: [
     {
       id: "mine",
       label: qsTr("My Own Projects"),
-      owner: "@me",
+      owner: filterPanel.currentUsername,
       includePublic: false
     },
     {
@@ -21,33 +23,25 @@ Pane {
       label: qsTr("Projects shared with me"),
       owner: "",
       includePublic: false
-    },
-    {
-      id: "opengisch",
-      label: qsTr("OPENGIS.ch projects"),
-      owner: "opengisch",
-      includePublic: false
-    },
-    {
-      id: "showcased",
-      label: qsTr("Showcased projects"),
-      owner: "",
-      includePublic: true
     }
   ]
 
+  readonly property string ownerTerm: ownerCombo.editText.trim()
+  readonly property string searchTerm: searchTermField.text.trim()
+  readonly property bool includePublic: publicSwitch.checked
+
   readonly property string queryString: {
     const parts = [];
-    if (titleField.text.trim()) {
-      parts.push(titleField.text.trim());
+    if (searchTerm) {
+      parts.push(searchTerm);
     }
-    if (ownerCombo.editText.trim()) {
-      parts.push("owner:" + ownerCombo.editText.trim());
+    if (ownerTerm) {
+      parts.push("owner:" + ownerTerm);
     }
     if (typeCombo.currentValue) {
       parts.push("type:" + typeCombo.currentValue);
     }
-    if (publicSwitch.checked) {
+    if (includePublic) {
       parts.push("public");
     }
     return parts.join(" ");
@@ -56,7 +50,7 @@ Pane {
   signal filterApplied
 
   function clear() {
-    titleField.clear();
+    searchTermField.clear();
     ownerCombo.editText = "";
     typeCombo.currentIndex = 0;
     publicSwitch.checked = false;
@@ -123,13 +117,14 @@ Pane {
 
     Label {
       Layout.fillWidth: true
-      text: qsTr("Title")
+      text: qsTr("Search term")
       font.pointSize: Theme.tipFont.pointSize
       color: Theme.mainTextColor
     }
     QfTextField {
-      id: titleField
+      id: searchTermField
       Layout.fillWidth: true
+      placeholderText: qsTr("Title, description or related keywords...")
     }
 
     Label {
@@ -212,7 +207,7 @@ Pane {
         text: qsTr("Search")
         bgcolor: Theme.mainColor
         color: Theme.mainBackgroundColor
-        onClicked: filterPanel.applied()
+        onClicked: filterPanel.filterApplied()
       }
     }
   }

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -8,16 +8,65 @@ import Theme
 Pane {
   id: filterPanel
 
+  property string activePreset: ""
   readonly property var presets: [
-    {label: qsTr("My Own Projects")},
-    {label: qsTr("Projects shared with me")},
-    {label: qsTr("OPENGIS.ch projects")},
-    {label: qsTr("Showcased projects")}
+    {
+      id: "mine",
+      label: qsTr("My Own Projects"),
+      owner: "@me",
+      includePublic: false
+    },
+    {
+      id: "shared",
+      label: qsTr("Projects shared with me"),
+      owner: "",
+      includePublic: false
+    },
+    {
+      id: "opengisch",
+      label: qsTr("OPENGIS.ch projects"),
+      owner: "opengisch",
+      includePublic: false
+    },
+    {
+      id: "showcased",
+      label: qsTr("Showcased projects"),
+      owner: "",
+      includePublic: true
+    }
   ]
+
+  signal filterApplied
+
+  function clear() {
+    titleField.clear();
+    ownerCombo.editText = "";
+    typeCombo.currentIndex = 0;
+    publicSwitch.checked = false;
+    activePreset = "";
+  }
+
+  onActivePresetChanged: {
+    if (!activePreset) {
+      return;
+    }
+    const p = presets.find(x => x.id === activePreset);
+    if (!p) {
+      return;
+    }
+    ownerCombo.editText = p.owner;
+    publicSwitch.checked = p.includePublic;
+  }
+
+  padding: 0
+  background: Rectangle {
+    color: Theme.mainBackgroundColor
+    opacity: 0.9
+  }
 
   ColumnLayout {
     anchors.fill: parent
-    anchors.margins: 10
+    anchors.margins: 16
     spacing: 14
 
     Label {
@@ -37,12 +86,14 @@ Pane {
       model: filterPanel.presets
 
       delegate: QfButton {
-        id: presetButtons
-        width: implicitWidth + 32
-        radius: 4
-        //color: Theme.mainColor
-        font.pointSize: Theme.tipFont.pointSize
+        readonly property bool isActive: filterPanel.activePreset === modelData.id
+        height: ListView.view.height
         text: modelData.label
+        font.pointSize: Theme.tipFont.pointSize
+        radius: 4
+        bgcolor: isActive ? Theme.mainColor : "transparent"
+        color: isActive ? Theme.mainBackgroundColor : Theme.mainColor
+        onClicked: filterPanel.activePreset = isActive ? "" : modelData.id
       }
     }
 
@@ -59,7 +110,6 @@ Pane {
       font.pointSize: Theme.tipFont.pointSize
       color: Theme.mainTextColor
     }
-
     QfTextField {
       id: titleField
       Layout.fillWidth: true
@@ -71,7 +121,6 @@ Pane {
       font.pointSize: Theme.tipFont.pointSize
       color: Theme.mainTextColor
     }
-
     QfComboBox {
       id: ownerCombo
       Layout.fillWidth: true
@@ -84,14 +133,33 @@ Pane {
       font.pointSize: Theme.tipFont.pointSize
       color: Theme.mainTextColor
     }
-
     QfComboBox {
       id: typeCombo
       Layout.fillWidth: true
+      textRole: "label"
+      valueRole: "value"
+      model: [
+        {
+          value: "",
+          label: qsTr("any")
+        },
+        {
+          value: "project",
+          label: qsTr("project")
+        },
+        {
+          value: "shared_dataset",
+          label: qsTr("shared dataset")
+        },
+        {
+          value: "template",
+          label: qsTr("template")
+        }
+      ]
     }
 
     RowLayout {
-      Layout.alignment: Qt.AlignRight
+      Layout.fillWidth: true
       Layout.topMargin: 8
 
       Label {
@@ -101,7 +169,13 @@ Pane {
         color: Theme.mainTextColor
       }
 
-      Switch { id: publicSwitch }
+      Switch {
+        id: publicSwitch
+      }
+    }
+
+    Item {
+      Layout.fillHeight: true
     }
 
     RowLayout {
@@ -111,11 +185,15 @@ Pane {
 
       QfButton {
         text: qsTr("Reset")
+        bgcolor: Theme.controlBackgroundDisabledColor
+        color: Theme.mainTextColor
         onClicked: filterPanel.clear()
       }
 
       QfButton {
         text: qsTr("Search")
+        bgcolor: Theme.mainColor
+        color: Theme.mainBackgroundColor
         onClicked: filterPanel.applied()
       }
     }

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -37,7 +37,7 @@ Pane {
     if (includePublicSwitch.checked) {
       parts.push("include:public");
     }
-    if (searchTermTextField !== "") {
+    if (searchTermTextField.text !== "") {
       parts.push(searchTermTextField.text);
     }
 

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -32,17 +32,14 @@ Pane {
 
   readonly property string queryString: {
     const parts = [];
-    if (searchTerm) {
-      parts.push(searchTerm);
-    }
     if (ownerTerm) {
       parts.push("owner:" + ownerTerm);
     }
-    if (typeCombo.currentValue) {
-      parts.push("type:" + typeCombo.currentValue);
-    }
     if (includePublic) {
-      parts.push("public");
+      parts.push("include:public");
+    }
+    if (searchTerm) {
+      parts.push(searchTerm);
     }
     return parts.join(" ");
   }
@@ -52,7 +49,6 @@ Pane {
   function clear() {
     searchTermField.clear();
     ownerCombo.editText = "";
-    typeCombo.currentIndex = 0;
     publicSwitch.checked = false;
     activePreset = "";
   }
@@ -137,37 +133,6 @@ Pane {
       id: ownerCombo
       Layout.fillWidth: true
       editable: true
-    }
-
-    Label {
-      Layout.fillWidth: true
-      text: qsTr("Type")
-      font.pointSize: Theme.tipFont.pointSize
-      color: Theme.mainTextColor
-    }
-    QfComboBox {
-      id: typeCombo
-      Layout.fillWidth: true
-      textRole: "label"
-      valueRole: "value"
-      model: [
-        {
-          value: "",
-          label: qsTr("any")
-        },
-        {
-          value: "project",
-          label: qsTr("project")
-        },
-        {
-          value: "shared_dataset",
-          label: qsTr("shared dataset")
-        },
-        {
-          value: "template",
-          label: qsTr("template")
-        }
-      ]
     }
 
     RowLayout {

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -140,6 +140,7 @@ Pane {
         id: ownerCombo
         Layout.fillWidth: true
         editable: true
+        Material.accent: Theme.mainColor
       }
 
       RowLayout {

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -17,12 +17,6 @@ Pane {
       label: qsTr("My Own Projects"),
       owner: filterPanel.currentUsername,
       includePublic: false
-    },
-    {
-      id: "shared",
-      label: qsTr("Projects shared with me"),
-      owner: "",
-      includePublic: false
     }
   ]
 
@@ -53,6 +47,12 @@ Pane {
     activePreset = "";
   }
 
+  onVisibleChanged: {
+    if (visible) {
+      ownerCombo.model = cloudProjectsModel.uniqueOwners();
+    }
+  }
+
   onActivePresetChanged: {
     if (!activePreset) {
       return;
@@ -71,109 +71,116 @@ Pane {
     opacity: 0.95
   }
 
-  ColumnLayout {
+  ScrollView {
     anchors.fill: parent
-    anchors.margins: 16
-    spacing: 14
+    anchors.bottomMargin: searchButtonRow.height
+    ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+    ScrollBar.vertical: QfScrollBar {}
+    clip: true
 
-    Label {
-      Layout.fillWidth: true
-      text: qsTr("Predefined Filters")
-      font.pointSize: Theme.secondaryTitleFont.pointSize
-      color: Theme.mainTextColor
-    }
-
-    ListView {
-      Layout.fillWidth: true
-      Layout.preferredHeight: 40
-      orientation: ListView.Horizontal
-      spacing: 10
-      clip: true
-      boundsBehavior: Flickable.StopAtBounds
-      model: filterPanel.presets
-
-      delegate: QfButton {
-        readonly property bool isActive: filterPanel.activePreset === modelData.id
-        height: ListView.view.height
-        text: modelData.label
-        font.pointSize: Theme.tipFont.pointSize
-        radius: 4
-        bgcolor: isActive ? Theme.mainColor : "transparent"
-        color: isActive ? Theme.mainBackgroundColor : Theme.mainColor
-        onClicked: filterPanel.activePreset = isActive ? "" : modelData.id
-      }
-    }
-
-    Label {
-      Layout.fillWidth: true
-      text: qsTr("Criteria")
-      font.pointSize: Theme.secondaryTitleFont.pointSize
-      color: Theme.mainTextColor
-    }
-
-    Label {
-      Layout.fillWidth: true
-      text: qsTr("Search term")
-      font.pointSize: Theme.tipFont.pointSize
-      color: Theme.mainTextColor
-    }
-    QfTextField {
-      id: searchTermField
-      Layout.fillWidth: true
-      placeholderText: qsTr("Title, description or related keywords...")
-    }
-
-    Label {
-      Layout.fillWidth: true
-      text: qsTr("Owner")
-      font.pointSize: Theme.tipFont.pointSize
-      color: Theme.mainTextColor
-    }
-    QfComboBox {
-      id: ownerCombo
-      Layout.fillWidth: true
-      editable: true
-    }
-
-    RowLayout {
-      Layout.fillWidth: true
-      Layout.topMargin: 8
+    ColumnLayout {
+      width: filterPanel.width - 32
+      x: 16
+      y: 16
+      spacing: 14
 
       Label {
         Layout.fillWidth: true
-        text: qsTr("Include public projects")
+        text: qsTr("Predefined Filters")
+        font.pointSize: Theme.secondaryTitleFont.pointSize
+        color: Theme.mainTextColor
+      }
+
+      ListView {
+        Layout.fillWidth: true
+        Layout.preferredHeight: 40
+        orientation: ListView.Horizontal
+        spacing: 10
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+        model: filterPanel.presets
+
+        delegate: QfButton {
+          readonly property bool isActive: filterPanel.activePreset === modelData.id
+          height: ListView.view.height
+          text: modelData.label
+          font.pointSize: Theme.tipFont.pointSize
+          radius: 4
+          bgcolor: isActive ? Theme.mainColor : "transparent"
+          color: isActive ? Theme.mainBackgroundColor : Theme.mainColor
+          onClicked: filterPanel.activePreset = isActive ? "" : modelData.id
+        }
+      }
+
+      Label {
+        Layout.fillWidth: true
+        text: qsTr("Criteria")
+        font.pointSize: Theme.secondaryTitleFont.pointSize
+        color: Theme.mainTextColor
+      }
+
+      Label {
+        Layout.fillWidth: true
+        text: qsTr("Search term")
         font.pointSize: Theme.tipFont.pointSize
         color: Theme.mainTextColor
       }
-
-      Switch {
-        id: publicSwitch
-        Layout.alignment: Qt.AlignRight
+      QfTextField {
+        id: searchTermField
+        Layout.fillWidth: true
       }
-    }
 
-    Item {
-      Layout.fillHeight: true
-    }
-
-    RowLayout {
-      Layout.alignment: Qt.AlignRight
-      Layout.topMargin: 8
-      spacing: 10
-
-      QfButton {
-        text: qsTr("Reset")
-        bgcolor: Theme.controlBackgroundDisabledColor
+      Label {
+        Layout.fillWidth: true
+        text: qsTr("Owner")
+        font.pointSize: Theme.tipFont.pointSize
         color: Theme.mainTextColor
-        onClicked: filterPanel.clear()
+      }
+      QfComboBox {
+        id: ownerCombo
+        Layout.fillWidth: true
+        editable: true
       }
 
-      QfButton {
-        text: qsTr("Search")
-        bgcolor: Theme.mainColor
-        color: Theme.mainBackgroundColor
-        onClicked: filterPanel.filterApplied()
+      RowLayout {
+        Layout.fillWidth: true
+        Layout.topMargin: 8
+
+        Label {
+          Layout.fillWidth: true
+          text: qsTr("Include public projects")
+          font.pointSize: Theme.tipFont.pointSize
+          color: Theme.mainTextColor
+        }
+
+        Switch {
+          id: publicSwitch
+          Layout.alignment: Qt.AlignRight
+        }
       }
+    }
+  }
+
+  Rectangle {
+    id: searchButtonRow
+    anchors.bottom: parent.bottom
+    anchors.left: parent.left
+    anchors.right: parent.right
+    height: searchButton.height + 20
+    color: Theme.darkTheme ? Theme.mainBackgroundColorSemiOpaque : Theme.lightestGraySemiOpaque
+
+    QfButton {
+      id: searchButton
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.bottom: parent.bottom
+      anchors.leftMargin: 10
+      anchors.rightMargin: 10
+      anchors.bottomMargin: 10
+      text: qsTr("Search")
+      bgcolor: Theme.mainColor
+      color: Theme.mainBackgroundColor
+      onClicked: filterPanel.filterApplied()
     }
   }
 }

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -11,19 +11,25 @@ Pane {
   signal applyFilter
 
   property string currentUsername: ""
+
   property string activePreset: ""
   readonly property var presets: [
     {
       id: "mine",
       label: qsTr("My Own Projects"),
-      owner: filterPanel.currentUsername,
-      includePublic: false
+      query: "owner:" + filterPanel.currentUsername
     }
   ]
 
   property string queryString: ""
 
-  function updateQueryString() {
+  property bool blockQueryUpdate: false
+
+  function updateQuery() {
+    if (filterPanel.blockQueryUpdate) {
+      return;
+    }
+
     let parts = [];
     if (ownerComboBox.editText !== "") {
       parts.push("owner:" + ownerComboBox.editText);
@@ -35,38 +41,61 @@ Pane {
       parts.push(searchTermTextField.text);
     }
 
-    queryString = parts.join(" ");
+    queryString = parts.join(" ").trim();
+
+    const preset = presets.find(preset => preset.query === queryString);
+    const presetName = preset ? preset.id : "";
+    if (activePreset !== presetName) {
+      activePreset = presetName;
+    }
+  }
+
+  function updateQueryFromString(query) {
+    blockQueryUpdate = true;
+
+    let searchTerm = [];
+    let owner = "";
+    let includePublic = false;
+
+    let parts = query.trim().split(/\s+/);
+    for (const part of parts) {
+      if (part.indexOf("owner:") === 0) {
+        owner = part.substring(6);
+      } else if (part.indexOf("include:public") === 0) {
+        includePublic = true;
+      } else {
+        searchTerm.push(part);
+      }
+    }
+
+    searchTermTextField.text = searchTerm.join(' ');
+    ownerComboBox.editText = owner;
+    includePublicSwitch.checked = includePublic;
+
+    queryString = query;
+
+    blockQueryUpdate = false;
+
+    const preset = presets.find(preset => preset.query === queryString);
+    const presetName = preset ? preset.id : "";
+    if (activePreset !== presetName) {
+      activePreset = presetName;
+    }
   }
 
   function clear() {
-    searchTermTextField.clear();
-    ownerComboBox.editText = "";
-    includePublicSwitch.checked = false;
+    updateQueryFromString("");
     activePreset = "";
   }
 
   onVisibleChanged: {
     if (visible) {
-      const previousOwner = ownerComboBox.currentText;
+      blockQueryUpdate = true;
+      const previousOwner = ownerComboBox.editText;
       ownerComboBox.model = [""].concat(cloudProjectsModel.uniqueOwners());
-      ownerComboBox.editText = ownerComboBox.currentText;
+      ownerComboBox.editText = previousOwner;
+      blockQueryUpdate = false;
     }
-  }
-
-  onActivePresetChanged: {
-    if (!activePreset) {
-      return;
-    }
-
-    const p = presets.find(x => x.id === activePreset);
-    if (!p) {
-      return;
-    }
-
-    ownerComboBox.editText = p.owner;
-    includePublicSwitch.checked = p.includePublic;
-
-    updateQueryString();
   }
 
   padding: 0
@@ -114,6 +143,9 @@ Pane {
           color: isActive ? Theme.mainBackgroundColor : Theme.mainColor
           onClicked: {
             filterPanel.activePreset = modelData.id;
+            if (filterPanel.queryString !== modelData.query) {
+              updateQueryFromString(modelData.query);
+            }
           }
         }
       }
@@ -138,7 +170,7 @@ Pane {
         font: Theme.defaultFont
 
         onTextEdited: {
-          updateQueryString();
+          updateQuery();
         }
       }
 
@@ -157,7 +189,7 @@ Pane {
         font: Theme.defaultFont
 
         onEditTextChanged: {
-          updateQueryString();
+          updateQuery();
         }
       }
 
@@ -177,7 +209,7 @@ Pane {
           Layout.alignment: Qt.AlignRight
 
           onClicked: {
-            updateQueryString();
+            updateQuery();
           }
         }
       }

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -36,6 +36,23 @@ Pane {
     }
   ]
 
+  readonly property string queryString: {
+    const parts = [];
+    if (titleField.text.trim()) {
+      parts.push(titleField.text.trim());
+    }
+    if (ownerCombo.editText.trim()) {
+      parts.push("owner:" + ownerCombo.editText.trim());
+    }
+    if (typeCombo.currentValue) {
+      parts.push("type:" + typeCombo.currentValue);
+    }
+    if (publicSwitch.checked) {
+      parts.push("public");
+    }
+    return parts.join(" ");
+  }
+
   signal filterApplied
 
   function clear() {

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -1,0 +1,6 @@
+import QtQuick
+import QtQuick.Controls
+
+Pane {
+  id: filterPanel
+}

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -8,8 +8,9 @@ import Theme
 Pane {
   id: filterPanel
 
-  property string currentUsername: ""
+  signal applyFilter
 
+  property string currentUsername: ""
   property string activePreset: ""
   readonly property var presets: [
     {
@@ -20,36 +21,35 @@ Pane {
     }
   ]
 
-  readonly property string ownerTerm: ownerCombo.editText.trim()
-  readonly property string searchTerm: searchTermField.text.trim()
-  readonly property bool includePublic: publicSwitch.checked
+  property string queryString: ""
 
-  readonly property string queryString: {
-    const parts = [];
-    if (ownerTerm) {
-      parts.push("owner:" + ownerTerm);
+  function updateQueryString() {
+    let parts = [];
+    if (ownerComboBox.editText !== "") {
+      parts.push("owner:" + ownerComboBox.editText);
     }
-    if (includePublic) {
+    if (includePublicSwitch.checked) {
       parts.push("include:public");
     }
-    if (searchTerm) {
-      parts.push(searchTerm);
+    if (searchTermTextField !== "") {
+      parts.push(searchTermTextField.text);
     }
-    return parts.join(" ");
+
+    queryString = parts.join(" ");
   }
 
-  signal filterApplied
-
   function clear() {
-    searchTermField.clear();
-    ownerCombo.editText = "";
-    publicSwitch.checked = false;
+    searchTermTextField.clear();
+    ownerComboBox.editText = "";
+    includePublicSwitch.checked = false;
     activePreset = "";
   }
 
   onVisibleChanged: {
     if (visible) {
-      ownerCombo.model = cloudProjectsModel.uniqueOwners();
+      const previousOwner = ownerComboBox.currentText;
+      ownerComboBox.model = [""].concat(cloudProjectsModel.uniqueOwners());
+      ownerComboBox.editText = ownerComboBox.currentText;
     }
   }
 
@@ -57,12 +57,16 @@ Pane {
     if (!activePreset) {
       return;
     }
+
     const p = presets.find(x => x.id === activePreset);
     if (!p) {
       return;
     }
-    ownerCombo.editText = p.owner;
-    publicSwitch.checked = p.includePublic;
+
+    ownerComboBox.editText = p.owner;
+    includePublicSwitch.checked = p.includePublic;
+
+    updateQueryString();
   }
 
   padding: 0
@@ -87,7 +91,7 @@ Pane {
       Label {
         Layout.fillWidth: true
         text: qsTr("Predefined Filters")
-        font.pointSize: Theme.secondaryTitleFont.pointSize
+        font: Theme.secondaryTitleFont
         color: Theme.mainTextColor
       }
 
@@ -108,39 +112,53 @@ Pane {
           radius: 4
           bgcolor: isActive ? Theme.mainColor : "transparent"
           color: isActive ? Theme.mainBackgroundColor : Theme.mainColor
-          onClicked: filterPanel.activePreset = isActive ? "" : modelData.id
+          onClicked: {
+            filterPanel.activePreset = modelData.id;
+          }
         }
       }
 
       Label {
         Layout.fillWidth: true
         text: qsTr("Criteria")
-        font.pointSize: Theme.secondaryTitleFont.pointSize
+        font: Theme.secondaryTitleFont
         color: Theme.mainTextColor
       }
 
       Label {
         Layout.fillWidth: true
         text: qsTr("Search term")
-        font.pointSize: Theme.tipFont.pointSize
+        font: Theme.tipFont
         color: Theme.mainTextColor
       }
+
       QfTextField {
-        id: searchTermField
+        id: searchTermTextField
         Layout.fillWidth: true
+        font: Theme.defaultFont
+
+        onTextEdited: {
+          updateQueryString();
+        }
       }
 
       Label {
         Layout.fillWidth: true
         text: qsTr("Owner")
-        font.pointSize: Theme.tipFont.pointSize
+        font: Theme.tipFont
         color: Theme.mainTextColor
       }
+
       QfComboBox {
-        id: ownerCombo
+        id: ownerComboBox
         Layout.fillWidth: true
         editable: true
         Material.accent: Theme.mainColor
+        font: Theme.defaultFont
+
+        onEditTextChanged: {
+          updateQueryString();
+        }
       }
 
       RowLayout {
@@ -150,13 +168,17 @@ Pane {
         Label {
           Layout.fillWidth: true
           text: qsTr("Include public projects")
-          font.pointSize: Theme.tipFont.pointSize
+          font: Theme.tipFont
           color: Theme.mainTextColor
         }
 
         Switch {
-          id: publicSwitch
+          id: includePublicSwitch
           Layout.alignment: Qt.AlignRight
+
+          onClicked: {
+            updateQueryString();
+          }
         }
       }
     }
@@ -181,7 +203,7 @@ Pane {
       text: qsTr("Search")
       bgcolor: Theme.mainColor
       color: Theme.mainBackgroundColor
-      onClicked: filterPanel.filterApplied()
+      onClicked: filterPanel.applyFilter()
     }
   }
 }

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -1,6 +1,123 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
+
+import org.qfield
+import Theme
 
 Pane {
   id: filterPanel
+
+  readonly property var presets: [
+    {label: qsTr("My Own Projects")},
+    {label: qsTr("Projects shared with me")},
+    {label: qsTr("OPENGIS.ch projects")},
+    {label: qsTr("Showcased projects")}
+  ]
+
+  ColumnLayout {
+    anchors.fill: parent
+    anchors.margins: 10
+    spacing: 14
+
+    Label {
+      Layout.fillWidth: true
+      text: qsTr("Predefined Filters")
+      font.pointSize: Theme.secondaryTitleFont.pointSize
+      color: Theme.mainTextColor
+    }
+
+    ListView {
+      Layout.fillWidth: true
+      Layout.preferredHeight: 40
+      orientation: ListView.Horizontal
+      spacing: 10
+      clip: true
+      boundsBehavior: Flickable.StopAtBounds
+      model: filterPanel.presets
+
+      delegate: QfButton {
+        id: presetButtons
+        width: implicitWidth + 32
+        radius: 4
+        //color: Theme.mainColor
+        font.pointSize: Theme.tipFont.pointSize
+        text: modelData.label
+      }
+    }
+
+    Label {
+      Layout.fillWidth: true
+      text: qsTr("Criteria")
+      font.pointSize: Theme.secondaryTitleFont.pointSize
+      color: Theme.mainTextColor
+    }
+
+    Label {
+      Layout.fillWidth: true
+      text: qsTr("Title")
+      font.pointSize: Theme.tipFont.pointSize
+      color: Theme.mainTextColor
+    }
+
+    QfTextField {
+      id: titleField
+      Layout.fillWidth: true
+    }
+
+    Label {
+      Layout.fillWidth: true
+      text: qsTr("Owner")
+      font.pointSize: Theme.tipFont.pointSize
+      color: Theme.mainTextColor
+    }
+
+    QfComboBox {
+      id: ownerCombo
+      Layout.fillWidth: true
+      editable: true
+    }
+
+    Label {
+      Layout.fillWidth: true
+      text: qsTr("Type")
+      font.pointSize: Theme.tipFont.pointSize
+      color: Theme.mainTextColor
+    }
+
+    QfComboBox {
+      id: typeCombo
+      Layout.fillWidth: true
+    }
+
+    RowLayout {
+      Layout.alignment: Qt.AlignRight
+      Layout.topMargin: 8
+
+      Label {
+        Layout.fillWidth: true
+        text: qsTr("Include public projects")
+        font.pointSize: Theme.tipFont.pointSize
+        color: Theme.mainTextColor
+      }
+
+      Switch { id: publicSwitch }
+    }
+
+    RowLayout {
+      Layout.alignment: Qt.AlignRight
+      Layout.topMargin: 8
+      spacing: 10
+
+      QfButton {
+        text: qsTr("Reset")
+        onClicked: filterPanel.clear()
+      }
+
+      QfButton {
+        text: qsTr("Search")
+        onClicked: filterPanel.applied()
+      }
+    }
+  }
 }

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -61,7 +61,7 @@ Pane {
   padding: 0
   background: Rectangle {
     color: Theme.mainBackgroundColor
-    opacity: 0.9
+    opacity: 0.95
   }
 
   ColumnLayout {
@@ -171,6 +171,7 @@ Pane {
 
       Switch {
         id: publicSwitch
+        Layout.alignment: Qt.AlignRight
       }
     }
 

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -101,7 +101,6 @@ Pane {
   padding: 0
   background: Rectangle {
     color: Theme.mainBackgroundColor
-    opacity: 0.95
   }
 
   ScrollView {
@@ -221,21 +220,22 @@ Pane {
     anchors.bottom: parent.bottom
     anchors.left: parent.left
     anchors.right: parent.right
-    height: searchButton.height + 20
-    color: Theme.darkTheme ? Theme.mainBackgroundColorSemiOpaque : Theme.lightestGraySemiOpaque
+    height: searchButton.height + 10
+    color: "transparent"
 
     QfButton {
       id: searchButton
+      anchors.top: parent.top
       anchors.left: parent.left
       anchors.right: parent.right
-      anchors.bottom: parent.bottom
-      anchors.leftMargin: 10
-      anchors.rightMargin: 10
-      anchors.bottomMargin: 10
+      anchors.topMargin: 10
       text: qsTr("Search")
       bgcolor: Theme.mainColor
       color: Theme.mainBackgroundColor
-      onClicked: filterPanel.applyFilter()
+
+      onClicked: {
+        filterPanel.applyFilter();
+      }
     }
   }
 }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -205,7 +205,13 @@ Page {
           id: searchBar
           Layout.fillWidth: true
           Layout.preferredHeight: 41
+          enableFilterButton: true
+          filterActive: projectFilter.visible
           placeHolderText: qsTr("Search for project")
+
+          onFilterClicked: {
+            projectFilter.visible = !projectFilter.visible;
+          }
         }
 
         Item {
@@ -578,6 +584,13 @@ Page {
                   projectActions.popup(mouse.x, mouse.y);
                 }
               }
+            }
+
+            QFieldCloudProjectFilter {
+              id: projectFilter
+              anchors.fill: parent
+              visible: false
+              z: 1
             }
           }
         }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -220,6 +220,15 @@ Page {
           onSearchTriggered: {
             table.model.textFilter = searchBar.searchTerm;
           }
+
+          onCleared: {
+            if (projectFilter.visible) {
+              projectFilter.clear();
+            } else {
+              searchBar.clear();
+              table.model.textFilter = "";
+            }
+          }
         }
 
         Item {

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -211,6 +211,9 @@ Page {
 
           onFilterClicked: {
             projectFilter.visible = !projectFilter.visible;
+            if (projectFilter.visible) {
+              projectFilter.updateQueryFromString(searchBar.searchTerm);
+            }
           }
 
           onSearchTermChanged: {

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -592,6 +592,9 @@ Page {
             anchors.fill: parent
             visible: false
             z: 1
+
+            onQueryStringChanged: searchBar.setSearchTerm(queryString)
+            onFilterApplied: visibile = false
           }
         }
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -603,7 +603,7 @@ Page {
             id: refreshProjectsListBtn
             Layout.fillWidth: true
             text: qsTr("Refresh projects list")
-            enabled: cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
+            enabled: !projectFilter.visible && cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
             onClicked: {
               refreshProjectsList(true);
             }
@@ -611,7 +611,7 @@ Page {
 
           QfToolButton {
             id: scanProjectBtn
-            enabled: cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
+            enabled: !projectFilter.visible && cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
             visible: enabled
 
             bgcolor: "transparent"

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -225,10 +225,6 @@ Page {
             }
           }
 
-          onReturnPressed: {
-            table.model.textFilter = searchBar.searchTerm;
-          }
-
           onSearchTriggered: {
             table.model.textFilter = searchBar.searchTerm;
           }
@@ -237,7 +233,6 @@ Page {
             if (projectFilter.visible) {
               projectFilter.clear();
             } else {
-              searchBar.clear();
               table.model.textFilter = "";
             }
           }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -639,12 +639,13 @@ Page {
         RowLayout {
           Layout.fillWidth: true
           Layout.topMargin: 5
+          visible: !projectFilter.visible
 
           QfButton {
             id: refreshProjectsListBtn
             Layout.fillWidth: true
             text: qsTr("Refresh projects list")
-            enabled: !projectFilter.visible && cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
+            enabled: cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
             onClicked: {
               refreshProjectsList(true);
             }
@@ -652,7 +653,7 @@ Page {
 
           QfToolButton {
             id: scanProjectBtn
-            enabled: !projectFilter.visible && cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
+            enabled: cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
             visible: enabled
 
             bgcolor: "transparent"

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -585,13 +585,13 @@ Page {
                 }
               }
             }
+          }
 
-            QFieldCloudProjectFilter {
-              id: projectFilter
-              anchors.fill: parent
-              visible: false
-              z: 1
-            }
+          QFieldCloudProjectFilter {
+            id: projectFilter
+            anchors.fill: parent
+            visible: false
+            z: 1
           }
         }
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -212,6 +212,14 @@ Page {
           onFilterClicked: {
             projectFilter.visible = !projectFilter.visible;
           }
+
+          onReturnPressed: {
+            table.model.textFilter = searchBar.searchTerm;
+          }
+
+          onSearchTriggered: {
+            table.model.textFilter = searchBar.searchTerm;
+          }
         }
 
         Item {
@@ -224,10 +232,10 @@ Page {
             property bool overshootRefresh: false
 
             model: QFieldCloudProjectsFilterModel {
+              id: filterModel
               projectsModel: cloudProjectsModel
               showLocalOnly: cloudConnection.status !== QFieldCloudConnection.LoggedIn
               showInValidProjects: settings ? settings.valueBool("/QField/showInvalidProjects", false) : false
-              textFilter: searchBar.searchTerm
             }
 
             ScrollBar.vertical: QfScrollBar {
@@ -594,10 +602,15 @@ Page {
             z: 1
 
             currentUsername: cloudConnection.username
-
+            onQueryStringChanged: {
+              if (visible) {
+                searchBar.setSearchTerm(queryString);
+              }
+            }
             onFilterApplied: {
               table.model.includePublic = includePublic;
               searchBar.setSearchTerm(queryString);
+              table.model.textFilter = queryString;
               visible = false;
             }
           }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -213,6 +213,12 @@ Page {
             projectFilter.visible = !projectFilter.visible;
           }
 
+          onSearchTermChanged: {
+            if (!projectFilter.visible) {
+              table.model.textFilter = searchBar.searchTerm;
+            }
+          }
+
           onReturnPressed: {
             table.model.textFilter = searchBar.searchTerm;
           }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -211,9 +211,11 @@ Page {
           parameterKeys: ["owner", "include"]
 
           onFilterClicked: {
-            projectFilter.visible = !projectFilter.visible;
-            if (projectFilter.visible) {
+            if (!projectFilter.visible) {
+              projectFilter.visible = true;
               projectFilter.updateQueryFromString(searchBar.searchTerm);
+            } else {
+              projectFilter.applyFilter();
             }
           }
 
@@ -1002,6 +1004,11 @@ Page {
   Keys.onReleased: event => {
     if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
       event.accepted = true;
+      if (projectFilter.visible) {
+        projectFilter.applyFilter();
+        return;
+      }
+
       header.onFinished();
     }
   }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -393,6 +393,7 @@ Page {
                 ColumnLayout {
                   id: inner
                   width: projectDelegate.width - type.width - menuButton.width - 16
+                  anchors.verticalCenter: line.verticalCenter
 
                   Text {
                     id: projectTitle
@@ -411,7 +412,7 @@ Page {
                     leftPadding: 3
                     text: {
                       if (cloudConnection.status !== QFieldCloudConnection.LoggedIn) {
-                        return qsTr('Available locally');
+                        return StringUtils.snippet(Description);
                       } else {
                         var status = '';
 
@@ -450,26 +451,12 @@ Page {
                           status = qsTr('Uploading error. ') + QFieldCloudUtils.userFriendlyErrorString(ErrorString);
                           break;
                         }
+
                         if (!status) {
-                          switch (Checkout) {
-                          case QFieldCloudProject.LocalCheckout:
-                            status = UserRoleOrigin === "public" ? qsTr('Available locally') : qsTr('Available locally, missing on the cloud');
-                            break;
-                          case QFieldCloudProject.RemoteCheckout:
-                            status = qsTr('Available on the cloud');
-                            break;
-                          case QFieldCloudProject.LocalAndRemoteCheckout:
-                            status = qsTr('Available locally');
-                            if (ProjectOutdated) {
-                              status += qsTr(', updated data available on the cloud');
-                            }
-                            break;
-                          default:
-                            break;
-                          }
+                          status = StringUtils.snippet(Description);
                         }
-                        var localChanges = (LocalDeltasCount > 0) ? qsTr(', has changes locally') : '';
-                        var str = status + localChanges;
+
+                        var str = status;
                         return str.trim();
                       }
                     }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -593,8 +593,13 @@ Page {
             visible: false
             z: 1
 
-            onQueryStringChanged: searchBar.setSearchTerm(queryString)
-            onFilterApplied: visibile = false
+            currentUsername: cloudConnection.username
+
+            onFilterApplied: {
+              table.model.includePublic = includePublic;
+              searchBar.setSearchTerm(queryString);
+              visible = false;
+            }
           }
         }
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -208,6 +208,7 @@ Page {
           enableFilterButton: true
           filterActive: projectFilter.visible
           placeHolderText: qsTr("Search for project")
+          parameterKeys: ["owner", "include"]
 
           onFilterClicked: {
             projectFilter.visible = !projectFilter.visible;

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -549,7 +549,23 @@ Page {
               anchors.fill: parent
               anchors.margins: 20
               visible: cloudConnection.status === QFieldCloudConnection.LoggedIn && parent.count === 0 && filterBar.currentIndex === 0
-              text: cloudProjectsModel.isRefreshing ? qsTr("Refreshing projects list") : qsTr("No cloud projects found. To get started, %1read the documentation%2.").arg("<a href=\"https://docs.qfield.org/get-started/tutorials/get-started-qfc/\">").arg("</a>")
+              text: {
+                let labelText = "";
+                if (cloudProjectsModel.isRefreshing) {
+                  labelText = qsTr("Refreshing projects list...");
+                } else if (table.model.isSearching) {
+                  labelText = qsTr("Searching for projects...");
+                } else if (searchBar.searchTerm !== "") {
+                  labelText = qsTr("No cloud projects found.");
+                  if (searchBar.searchTerm.indexOf("include:public") === -1) {
+                    labelText += "\n\n<i>" + qsTr("Hint: try including public projects.") + "</i>";
+                  }
+                } else {
+                  labelText = qsTr("No cloud projects found.") + "\n\n" + qsTr("To get started, %1read the documentation%2.").arg("<a href=\"https://docs.qfield.org/get-started/tutorials/get-started-qfc/\">").arg("</a>");
+                }
+                return labelText;
+              }
+              textFormat: Text.MarkdownText
               font: Theme.defaultFont
               wrapMode: Text.WordWrap
               horizontalAlignment: Text.AlignHCenter

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -617,15 +617,16 @@ Page {
             z: 1
 
             currentUsername: cloudConnection.username
+
             onQueryStringChanged: {
               if (visible) {
                 searchBar.setSearchTerm(queryString);
               }
             }
-            onFilterApplied: {
-              table.model.includePublic = includePublic;
-              searchBar.setSearchTerm(queryString);
+
+            onApplyFilter: {
               table.model.textFilter = queryString;
+              searchBar.setSearchTerm(queryString);
               visible = false;
             }
           }

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -98,7 +98,7 @@ Item {
           featureListModel.searchTerm = searchTerm;
         }
 
-        onReturnPressed: {
+        onSearchTriggered: {
           if (featureListModel.rowCount() === 1) {
             resultsList.itemAtIndex(0).performClick();
             searchFeaturePopup.close();

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -214,7 +214,7 @@ EditorWidgetBase {
             listModel.setFilterFixedString(searchTerm);
           }
 
-          onReturnPressed: {
+          onSearchTriggered: {
             if (listModel.rowCount() === 1) {
               resultsList.itemAtIndex(0).performClick();
               searchFeaturePopup.close();

--- a/src/qml/imports/Theme/QfSearchBar.qml
+++ b/src/qml/imports/Theme/QfSearchBar.qml
@@ -10,6 +10,7 @@ Item {
 
   property alias searchTerm: searchField.displayText
   property string placeHolderText: qsTr("Search")
+
   property bool enableFilterButton: false
   property bool filterActive: false
   property var parameterKeys: []

--- a/src/qml/imports/Theme/QfSearchBar.qml
+++ b/src/qml/imports/Theme/QfSearchBar.qml
@@ -10,7 +10,7 @@ Item {
 
   property alias searchTerm: searchField.displayText
   property string placeHolderText: qsTr("Search")
-  property bool enableFilterButton: true
+  property bool enableFilterButton: false
   property bool filterActive: false
 
   signal returnPressed

--- a/src/qml/imports/Theme/QfSearchBar.qml
+++ b/src/qml/imports/Theme/QfSearchBar.qml
@@ -10,8 +10,11 @@ Item {
 
   property alias searchTerm: searchField.displayText
   property string placeHolderText: qsTr("Search")
+  property bool enableFilterButton: true
+  property bool filterActive: false
 
   signal returnPressed
+  signal filterClicked
 
   height: childrenRect.height
 
@@ -25,7 +28,7 @@ Item {
 
     QfToolButton {
       id: clearButton
-      anchors.right: parent.right
+      anchors.right: filterButton.visible ? filterButton.left : parent.right
       width: 40
       height: 40
       iconSource: Theme.getThemeVectorIcon('ic_clear_white_24dp')
@@ -35,6 +38,18 @@ Item {
       onClicked: {
         clear();
       }
+    }
+
+    QfToolButton {
+      id: filterButton
+      anchors.right: parent.right
+      width: 40
+      height: 40
+      iconSource: Theme.getThemeVectorIcon("ic_tune_white_24dp")
+      iconColor: searchBar.filterActive ? Theme.mainColor : Theme.mainTextColor
+      bgcolor: "transparent"
+      visible: searchBar.enableFilterButton
+      onClicked: searchBar.filterClicked()
     }
 
     QfToolButton {
@@ -54,7 +69,7 @@ Item {
       id: searchField
       rightPadding: 7
       anchors.left: searchButton.right
-      anchors.right: clearButton.left
+      anchors.right: clearButton.visible ? clearButton.left : (filterButton.visible ? filterButton.left : parent.right)
       anchors.leftMargin: -16
       anchors.rightMargin: 4
       height: 40

--- a/src/qml/imports/Theme/QfSearchBar.qml
+++ b/src/qml/imports/Theme/QfSearchBar.qml
@@ -18,6 +18,7 @@ Item {
   signal returnPressed
   signal filterClicked
   signal searchTriggered
+  signal cleared
 
   height: childrenRect.height
 
@@ -56,9 +57,9 @@ Item {
       iconSource: Theme.getThemeVectorIcon('ic_clear_white_24dp')
       iconColor: Theme.mainTextColor
       bgcolor: "transparent"
-      visible: searchField.text !== ""
+      visible: searchField.text !== "" || searchBar.filterActive
       onClicked: {
-        clear();
+        searchBar.cleared();
       }
     }
 

--- a/src/qml/imports/Theme/QfSearchBar.qml
+++ b/src/qml/imports/Theme/QfSearchBar.qml
@@ -14,7 +14,6 @@ Item {
   property bool filterActive: false
   property var parameterKeys: []
 
-  signal returnPressed
   signal filterClicked
   signal searchTriggered
   signal cleared
@@ -63,9 +62,9 @@ Item {
       iconSource: Theme.getThemeVectorIcon('ic_clear_white_24dp')
       iconColor: Theme.mainTextColor
       bgcolor: "transparent"
-      visible: searchField.text !== "" || searchBar.filterActive
+      visible: searchField.text !== ""
       onClicked: {
-        searchBar.cleared();
+        searchBar.clear();
       }
     }
 
@@ -114,7 +113,7 @@ Item {
       color: highlightOverlay.visible ? "transparent" : Theme.mainTextColor
       Keys.onPressed: event => {
         if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-          searchBar.returnPressed();
+          searchBar.searchTriggered();
         }
       }
     }
@@ -145,5 +144,6 @@ Item {
 
   function clear() {
     searchField.text = '';
+    cleared();
   }
 }

--- a/src/qml/imports/Theme/QfSearchBar.qml
+++ b/src/qml/imports/Theme/QfSearchBar.qml
@@ -12,11 +12,32 @@ Item {
   property string placeHolderText: qsTr("Search")
   property bool enableFilterButton: false
   property bool filterActive: false
+  property var parameterKeys: ["owner", "type"]
 
   signal returnPressed
   signal filterClicked
 
   height: childrenRect.height
+
+  function highlightedText(raw) {
+    if (!raw) {
+      return "";
+    }
+    let html = "";
+    const parts = raw.split(/(\s+)/);
+    for (const part of parts) {
+      const colonIdx = part.indexOf(":");
+      if (colonIdx > 0 && parameterKeys.indexOf(part.slice(0, colonIdx)) !== -1) {
+        const key = part.slice(0, colonIdx + 1);
+        const val = part.slice(colonIdx + 1);
+        html += '<span style="color:' + Theme.mainColor + '">' + key + '</span>' + val;
+      } else {
+        html += part;
+      }
+    }
+
+    return html;
+  }
 
   Rectangle {
     width: parent.width
@@ -84,6 +105,20 @@ Item {
           searchBar.returnPressed();
         }
       }
+    }
+
+    Text {
+      id: highlightOverlay
+      anchors.fill: searchField
+      anchors.leftMargin: searchField.leftPadding
+      anchors.rightMargin: searchField.rightPadding
+      verticalAlignment: Text.AlignVCenter
+      visible: !searchField.activeFocus && searchField.text !== ""
+      textFormat: Text.RichText
+      font: searchField.font
+      color: Theme.mainTextColor
+      elide: Text.ElideRight
+      text: searchBar.highlightedText(searchField.text)
     }
   }
 

--- a/src/qml/imports/Theme/QfSearchBar.qml
+++ b/src/qml/imports/Theme/QfSearchBar.qml
@@ -12,8 +12,7 @@ Item {
   property string placeHolderText: qsTr("Search")
   property bool enableFilterButton: false
   property bool filterActive: false
-  property var parameterKeys: ["owner", "include"]
-  property var parameterFlags: ["public"]
+  property var parameterKeys: []
 
   signal returnPressed
   signal filterClicked
@@ -26,6 +25,13 @@ Item {
     if (!raw) {
       return "";
     }
+
+    // Encode HTML < and > characters to avoid text going missing
+    raw = raw.replace('<', '&lt;').replace('>', '&gt;');
+    if (parameterKeys.length == 0) {
+      return raw;
+    }
+
     let html = "";
     const parts = raw.split(/(\s+)/);
     for (const part of parts) {

--- a/src/qml/imports/Theme/QfSearchBar.qml
+++ b/src/qml/imports/Theme/QfSearchBar.qml
@@ -12,10 +12,12 @@ Item {
   property string placeHolderText: qsTr("Search")
   property bool enableFilterButton: false
   property bool filterActive: false
-  property var parameterKeys: ["owner", "type"]
+  property var parameterKeys: ["owner", "include"]
+  property var parameterFlags: ["public"]
 
   signal returnPressed
   signal filterClicked
+  signal searchTriggered
 
   height: childrenRect.height
 
@@ -35,7 +37,6 @@ Item {
         html += part;
       }
     }
-
     return html;
   }
 
@@ -82,7 +83,11 @@ Item {
       iconSource: Theme.getThemeVectorIcon("ic_baseline_search_white")
       iconColor: Theme.mainTextColor
       onClicked: {
-        searchField.focus = true;
+        if (searchField.text !== "") {
+          searchBar.searchTriggered();
+        } else {
+          searchField.focus = true;
+        }
       }
     }
 
@@ -99,7 +104,7 @@ Item {
       placeholderText: (!searchField.activeFocus && text === "" && displayText === "") ? searchBar.placeHolderText : ""
       background: Item {}
       font: Theme.defaultFont
-
+      color: highlightOverlay.visible ? "transparent" : Theme.mainTextColor
       Keys.onPressed: event => {
         if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
           searchBar.returnPressed();
@@ -118,6 +123,7 @@ Item {
       font: searchField.font
       color: Theme.mainTextColor
       elide: Text.ElideRight
+      clip: true
       text: searchBar.highlightedText(searchField.text)
     }
   }

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -152,6 +152,7 @@
         <file>QFieldCloudDeltaHistory.qml</file>
         <file>QFieldCloudPackageLayersFeedback.qml</file>
         <file>QFieldCloudProjectDetails.qml</file>
+        <file>QFieldCloudProjectFilter.qml</file>
         <file>QFieldLocalDataPickerScreen.qml</file>
         <file>QFieldSketcher.qml</file>
         <file>PluginManagerSettings.qml</file>

--- a/test/qml/tst_editorwidgets.qml
+++ b/test/qml/tst_editorwidgets.qml
@@ -888,7 +888,7 @@ TestCase {
     const valueRelationListComponentParent = valueRelation.children[2];
     const valueRelationRepeater = Utils.findChildren(valueRelationListComponentParent, "ValueRelationRepeater");
     const valueRelationSearchBar = Utils.findChildren(valueRelationListComponentParent, "ValueRelationSearchBar");
-    const searchTextField = valueRelationSearchBar.children[0].children[2];
+    const searchTextField = valueRelationSearchBar.children[0].children[3];
 
     // turn on editable mode
     valueRelation.isEnabled = true;
@@ -965,7 +965,7 @@ TestCase {
     wait(500);
     compare(relationComboBoxParent.searchPopup.opened, true);
     const searchFeaturePopup = relationComboBoxParent.searchPopup.contentItem;
-    const searchBarTextField = searchFeaturePopup.children[0].children[1].children[0].children[0].children[2];
+    const searchBarTextField = searchFeaturePopup.children[0].children[1].children[0].children[0].children[3];
     const searchFeatureResultsList = searchFeaturePopup.children[0].children[1].children[1];
     const featureListModel = searchFeatureResultsList.model;
     compare(searchFeatureResultsList.count, 8);

--- a/test/qml/tst_qfieldCloudScreenUI.qml
+++ b/test/qml/tst_qfieldCloudScreenUI.qml
@@ -73,7 +73,7 @@ TestCase {
   property var projectsSwipeView: mainColumnLayout.children[2]
   property var projectsColumnLayout: projectsSwipeView.contentChildren[0]
   property var filterBar: projectsColumnLayout.children[1]
-  property var searchBarTextArea: projectsColumnLayout.children[2].children[0].children[2]
+  property var searchBarTextArea: projectsColumnLayout.children[2].children[0].children[3]
   property var tableContainer: projectsColumnLayout.children[3]
   property var table: tableContainer.children[0]
   property var projectDetails: projectsSwipeView.contentChildren[1]

--- a/test/qml/tst_qfieldCloudScreenUI.qml
+++ b/test/qml/tst_qfieldCloudScreenUI.qml
@@ -77,6 +77,7 @@ TestCase {
   property var tableContainer: projectsColumnLayout.children[3]
   property var table: tableContainer.children[0]
   property var projectDetails: projectsSwipeView.contentChildren[1]
+  property var searchBar: projectsColumnLayout.children[2]
 
   SignalSpy {
     id: connectionStatusSpy
@@ -254,10 +255,12 @@ TestCase {
     loginAndRefresh(data);
     const initialCount = table.count;
     searchBarTextArea.text = "---";
+    searchBar.searchTriggered();
     wait(300);
     const filteredCount = table.count;
     verify(filteredCount < initialCount);
     searchBarTextArea.text = "";
+    searchBar.searchTriggered();
     wait(300);
     compare(table.count, initialCount);
   }


### PR DESCRIPTION
This PR introduces ta richer filter-and-search experience on the QFieldCloud projects screen. (ping @suricactus @nirvn )

## What we'll see

A new icon "tune" sits to the right of the project search bar. Tapping it opens a filter panel anchored over the project list, with two sections:

1. Predefined Filters: a horizontally-scrollable row of preset buttons(My Own Projects, Projects shared with me, OPENGIS.ch projects, Showcased projects). Tapping a button sets the active preset and pre-fills the form below.

2. Criteria: Title (text), Owner (editable combobox), Type (dropdown: any / project / shared dataset / template), and an Include public projects toggle.

<img width="411" height="727" alt="image" src="https://github.com/user-attachments/assets/8897a16a-688e-48ca-85dd-ad28f2ef8735" />

The search syntax (i.e. 'owner:name searh keywords') can be typed directly in the search bar. The form is the visual training-wheels; the search bar is where power users will type. The parameters are highlighted in the search bar.

## In action

https://github.com/user-attachments/assets/c6ff3dcf-2d65-489d-abfe-c2306a104186

