### PR TITLE
Add smoothing for freehand digitized segments

### DIFF
--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -374,7 +374,6 @@ void RubberbandModel::smoothSegment( qsizetype firstVertex, qsizetype lastVertex
   }
 
   const int previousCurrentIndex = mCurrentCoordinateIndex;
-  const int previousLastIndex = static_cast<int>( mPointList.size() - 1 );
 
   const int removedCount = static_cast<int>( lastVertex - firstVertex + 1 );
   mPointList.remove( static_cast<int>( firstVertex ), removedCount );
@@ -386,13 +385,7 @@ void RubberbandModel::smoothSegment( qsizetype firstVertex, qsizetype lastVertex
   }
   emit verticesInserted( static_cast<int>( firstVertex ), smoothed->numPoints() );
 
-  const int newLastIndex = static_cast<int>( mPointList.size() - 1 );
-
-  if ( previousCurrentIndex == previousLastIndex )
-  {
-    mCurrentCoordinateIndex = newLastIndex;
-  }
-  else if ( previousCurrentIndex == static_cast<int>( lastVertex ) )
+  if ( previousCurrentIndex == static_cast<int>( lastVertex ) )
   {
     mCurrentCoordinateIndex = static_cast<int>( firstVertex ) + smoothed->numPoints() - 1;
   }
@@ -402,7 +395,7 @@ void RubberbandModel::smoothSegment( qsizetype firstVertex, qsizetype lastVertex
   }
   else
   {
-    mCurrentCoordinateIndex = newLastIndex;
+    mCurrentCoordinateIndex = static_cast<int>( mPointList.size() - 1 );
   }
 
   emit vertexCountChanged();

--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -16,6 +16,7 @@
 #include "rubberbandmodel.h"
 #include "snappingutils.h"
 
+#include <qgslinestring.h>
 #include <qgslogger.h>
 #include <qgsproject.h>
 #include <qgsvectorlayer.h>
@@ -341,6 +342,52 @@ void RubberbandModel::reset( bool keepLast )
 
   mFrozen = false;
   emit frozenChanged();
+}
+
+void RubberbandModel::smoothSegment( qsizetype firstVertex, qsizetype lastVertex, double simplificationTolerance )
+{
+  if ( firstVertex < 0 || lastVertex >= mPointList.size() || lastVertex - firstVertex < 2 )
+  {
+    return;
+  }
+
+  QgsPointSequence points;
+  points.reserve( static_cast<int>( lastVertex - firstVertex + 1 ) );
+  for ( qsizetype i = firstVertex; i <= lastVertex; ++i )
+  {
+    points.append( mPointList.at( static_cast<int>( i ) ) );
+  }
+
+  QgsGeometry geom( new QgsLineString( points ) );
+
+  if ( simplificationTolerance > 0.0 )
+  {
+    geom = geom.simplify( simplificationTolerance );
+  }
+
+  geom = geom.smooth();
+
+  const QgsLineString *smoothed = qgsgeometry_cast<const QgsLineString *>( geom.constGet() );
+  if ( !smoothed || smoothed->numPoints() < 2 )
+  {
+    return;
+  }
+
+  const int removedCount = static_cast<int>( lastVertex - firstVertex + 1 );
+  mPointList.remove( static_cast<int>( firstVertex ), removedCount );
+  emit verticesRemoved( static_cast<int>( firstVertex ), removedCount );
+
+  for ( int i = 0; i < smoothed->numPoints(); ++i )
+  {
+    mPointList.insert( static_cast<int>( firstVertex ) + i, smoothed->pointN( i ) );
+  }
+  emit verticesInserted( static_cast<int>( firstVertex ), smoothed->numPoints() );
+
+  mCurrentCoordinateIndex = static_cast<int>( firstVertex ) + smoothed->numPoints() - 1;
+
+  emit vertexCountChanged();
+  emit currentCoordinateIndexChanged();
+  emit currentCoordinateChanged();
 }
 
 void RubberbandModel::setDataFromGeometry( QgsGeometry geometry, const QgsCoordinateReferenceSystem &crs )

--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -373,6 +373,9 @@ void RubberbandModel::smoothSegment( qsizetype firstVertex, qsizetype lastVertex
     return;
   }
 
+  const int previousCurrentIndex = mCurrentCoordinateIndex;
+  const int previousLastIndex = static_cast<int>( mPointList.size() - 1 );
+
   const int removedCount = static_cast<int>( lastVertex - firstVertex + 1 );
   mPointList.remove( static_cast<int>( firstVertex ), removedCount );
   emit verticesRemoved( static_cast<int>( firstVertex ), removedCount );
@@ -383,7 +386,24 @@ void RubberbandModel::smoothSegment( qsizetype firstVertex, qsizetype lastVertex
   }
   emit verticesInserted( static_cast<int>( firstVertex ), smoothed->numPoints() );
 
-  mCurrentCoordinateIndex = static_cast<int>( firstVertex ) + smoothed->numPoints() - 1;
+  const int newLastIndex = static_cast<int>( mPointList.size() - 1 );
+
+  if ( previousCurrentIndex == previousLastIndex )
+  {
+    mCurrentCoordinateIndex = newLastIndex;
+  }
+  else if ( previousCurrentIndex == static_cast<int>( lastVertex ) )
+  {
+    mCurrentCoordinateIndex = static_cast<int>( firstVertex ) + smoothed->numPoints() - 1;
+  }
+  else if ( previousCurrentIndex == static_cast<int>( firstVertex ) )
+  {
+    mCurrentCoordinateIndex = static_cast<int>( firstVertex );
+  }
+  else
+  {
+    mCurrentCoordinateIndex = newLastIndex;
+  }
 
   emit vertexCountChanged();
   emit currentCoordinateIndexChanged();

--- a/src/core/rubberbandmodel.h
+++ b/src/core/rubberbandmodel.h
@@ -158,6 +158,11 @@ class QFIELD_CORE_EXPORT RubberbandModel : public QObject
     Q_INVOKABLE void reset( bool keepLast = true );
 
     /**
+     * Smooths the sub-line formed by the vertices between \a firstVertex and \a lastVertex.
+     */
+    Q_INVOKABLE void smoothSegment( qsizetype firstVertex, qsizetype lastVertex, double simplificationTolerance = 0.0 );
+
+    /**
      * Sets the model data to match a given \a geometry
      * \note rings and multiparts are discarded
      */

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -524,6 +524,7 @@ ApplicationWindow {
     DragHandler {
       id: freehandHandler
       property bool isDigitizing: false
+      property int freehandStartVertexIndex: -1
       enabled: freehandButton.visible && freehandButton.freehandDigitizing && !digitizingToolbar.cogoEnabled && !digitizingToolbar.rubberbandModel.frozen && ((!featureListForm.visible && digitizingToolbar.digitizingAllowed) || digitizingToolbar.geometryRequested)
       acceptedDevices: !qfieldSettings.mouseAsTouchScreen ? PointerDevice.Stylus | PointerDevice.Mouse : PointerDevice.Stylus
       grabPermissions: PointerHandler.CanTakeOverFromHandlersOfSameType | PointerHandler.CanTakeOverFromHandlersOfDifferentType | PointerHandler.ApprovesTakeOverByAnything
@@ -531,8 +532,10 @@ ApplicationWindow {
 
       onActiveChanged: {
         if (active) {
+          freehandStartVertexIndex = digitizingToolbar.rubberbandModel.currentCoordinateIndex + 1;
           geometryEditorsToolbar.canvasFreehandBegin();
         } else {
+          digitizingToolbar.rubberbandModel.smoothSegment(freehandStartVertexIndex, digitizingToolbar.rubberbandModel.currentCoordinateIndex, mapCanvas.mapSettings.mapUnitsPerPoint);
           geometryEditorsToolbar.canvasFreehandEnd();
           var screenLocation = centroid.position;
           var screenFraction = settings.value("/QField/Digitizing/FreehandRecenterScreenFraction", 5);


### PR DESCRIPTION
## 🚀 Description

When digitizing a line or polygon with the freehand tool (stylus or mouse drag), the captured stretch of vertices tends to be noisy and over-dense. The resulting geometry looks jagged and is not pleasant to work with.
This PR post-processes each freehand stretch as soon as the user lifts the pointer

## ✨ Key Changes

- **Add `RubberbandModel::smoothSegment(firstVertex, lastVertex, simplificationTolerance)`**
  — new `Q_INVOKABLE` method

## Demo


https://github.com/user-attachments/assets/30bc6312-6895-405b-94aa-81e11c9ad6bf

---

🔗 Task linked: [QF-7794](https://app.clickup.com/t/2192114/QF-7794)
