### PR TITLE
Only show 3-dot menu containing remembrance actions when feature form is in addition mode

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -1094,7 +1094,7 @@ Page {
       QfToolButton {
         id: featureFormMenuButton
 
-        property bool isVisible: !setupOnly && form.model.hasRemembrance
+        property bool isVisible: !setupOnly && form.model.hasRemembrance && form.state === 'Add'
 
         Layout.alignment: Qt.AlignTop | Qt.AlignRight
 


### PR DESCRIPTION
Deals with the menu appearing when opening a child feature form in read mode.