### PR TITLE
[Backport release-4_1] Only show 3-dot menu containing remembrance actions when feature form is in addition mode

### DIFF
--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -981,7 +981,7 @@ Page {
       QfToolButton {
         id: featureFormMenuButton
 
-        property bool isVisible: !setupOnly && form.model.hasRemembrance
+        property bool isVisible: !setupOnly && form.model.hasRemembrance && form.state === 'Add'
 
         Layout.alignment: Qt.AlignTop | Qt.AlignRight
 


### PR DESCRIPTION
Backport #7417
 **Authored by:** @nirvn