### PR TITLE
Adopt vector layers' conditional row styling within the feature list form

### DIFF
--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -59,6 +59,9 @@ class MultiFeatureListModel : public QSortFilterProxyModel
       EditGeometryRole,
       ConditionalTextColorRole,
       ConditionalBackgroundColorRole,
+      ConditionalFontItalicRole,
+      ConditionalFontUnderlineRole,
+      ConditionalFontStrikeOutRole,
     };
 
     explicit MultiFeatureListModel( QObject *parent = nullptr );

--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -56,7 +56,9 @@ class MultiFeatureListModel : public QSortFilterProxyModel
       GeometryRole,
       CrsRole,
       DeleteFeatureRole,
-      EditGeometryRole
+      EditGeometryRole,
+      ConditionalTextColorRole,
+      ConditionalBackgroundColorRole,
     };
 
     explicit MultiFeatureListModel( QObject *parent = nullptr );

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -20,6 +20,7 @@
 #include "multifeaturelistmodel.h"
 #include "multifeaturelistmodelbase.h"
 
+#include <qgsconditionalstyle.h>
 #include <qgscoordinatereferencesystem.h>
 #include <qgsgeometry.h>
 #include <qgsgeometrycollection.h>
@@ -64,6 +65,7 @@ void MultiFeatureListModelBase::setFeatures( const QMap<QgsVectorLayer *, QgsFea
       request.addOrderBy( vl->displayExpression() );
     }
 
+    QgsExpressionContext expressionContext = vl->createExpressionContext();
     QgsFeature feat;
     QgsFeatureIterator fit = vl->getFeatures( request );
     while ( fit.nextFeature( feat ) )
@@ -73,6 +75,7 @@ void MultiFeatureListModelBase::setFeatures( const QMap<QgsVectorLayer *, QgsFea
       connect( vl, &QgsVectorLayer::featureDeleted, this, &MultiFeatureListModelBase::featureDeleted, Qt::UniqueConnection );
       connect( vl, &QgsVectorLayer::attributeValueChanged, this, &MultiFeatureListModelBase::attributeValueChanged, Qt::UniqueConnection );
       connect( vl, &QgsVectorLayer::geometryChanged, this, &MultiFeatureListModelBase::geometryChanged, Qt::UniqueConnection );
+      updateConditionalStylingDetails( vl, feat, expressionContext );
     }
   }
 
@@ -83,6 +86,7 @@ void MultiFeatureListModelBase::appendFeatures( const QList<IdentifyTool::Identi
 {
   beginInsertRows( QModelIndex(), static_cast<int>( mFeatures.count() ), static_cast<int>( mFeatures.count() + results.count() ) - 1 );
 
+  QMap<QString, QgsExpressionContext> expressionContext;
   for ( const IdentifyTool::IdentifyResult &result : results )
   {
     if ( QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( result.layer ) )
@@ -91,10 +95,16 @@ void MultiFeatureListModelBase::appendFeatures( const QList<IdentifyTool::Identi
       if ( !mFeatures.contains( item ) )
       {
         mFeatures.append( item );
-        connect( layer, &QObject::destroyed, this, &MultiFeatureListModelBase::layerDeleted, Qt::UniqueConnection );
+        connect( layer, &QgsVectorLayer::destroyed, this, &MultiFeatureListModelBase::layerDeleted, Qt::UniqueConnection );
         connect( layer, &QgsVectorLayer::featureDeleted, this, &MultiFeatureListModelBase::featureDeleted, Qt::UniqueConnection );
         connect( layer, &QgsVectorLayer::attributeValueChanged, this, &MultiFeatureListModelBase::attributeValueChanged, Qt::UniqueConnection );
         connect( layer, &QgsVectorLayer::geometryChanged, this, &MultiFeatureListModelBase::geometryChanged, Qt::UniqueConnection );
+
+        if ( !expressionContext.contains( layer->id() ) )
+        {
+          expressionContext[layer->id()] = layer->createExpressionContext();
+        }
+        updateConditionalStylingDetails( layer, result.feature, expressionContext[layer->id()] );
 
         if ( !mSelectedFeatures.isEmpty() )
         {
@@ -193,6 +203,7 @@ void MultiFeatureListModelBase::clear( const bool keepSelected )
   }
   else
   {
+    mFeaturesConditionalStyle.clear();
     mSelectedFeatures.clear();
 
     for ( QgsVectorLayer *representationalLayer : mRepresentationalLayers.values() )
@@ -262,6 +273,8 @@ QHash<int, QByteArray> MultiFeatureListModelBase::roleNames() const
   roleNames[MultiFeatureListModel::CrsRole] = "crs";
   roleNames[MultiFeatureListModel::DeleteFeatureRole] = "deleteFeatureCapability";
   roleNames[MultiFeatureListModel::EditGeometryRole] = "editGeometryCapability";
+  roleNames[MultiFeatureListModel::ConditionalTextColorRole] = "conditionalTextColor";
+  roleNames[MultiFeatureListModel::ConditionalBackgroundColorRole] = "conditionalBackgroundColor";
 
   return roleNames;
 }
@@ -362,6 +375,32 @@ QVariant MultiFeatureListModelBase::data( const QModelIndex &index, int role ) c
                && !vlayer->customProperty( QStringLiteral( "QFieldSync/is_geometry_editing_locked" ), false ).toBool();
       }
       return false;
+
+    case MultiFeatureListModel::ConditionalBackgroundColorRole:
+      if ( vlayer )
+      {
+        const QString featureUniqueKey = QStringLiteral( "%1:%2" ).arg( vlayer->id(), QString::number( feature->second.id() ) );
+        if ( mFeaturesConditionalStyle.contains( featureUniqueKey ) && mFeaturesConditionalStyle[featureUniqueKey].validBackgroundColor() )
+        {
+          return mFeaturesConditionalStyle[featureUniqueKey].backgroundColor();
+        }
+      }
+
+      return QVariant();
+      break;
+
+    case MultiFeatureListModel::ConditionalTextColorRole:
+      if ( vlayer )
+      {
+        const QString featureUniqueKey = QStringLiteral( "%1:%2" ).arg( vlayer->id(), QString::number( feature->second.id() ) );
+        if ( mFeaturesConditionalStyle.contains( featureUniqueKey ) && mFeaturesConditionalStyle[featureUniqueKey].validTextColor() )
+        {
+          return mFeaturesConditionalStyle[featureUniqueKey].textColor();
+        }
+      }
+
+      return QVariant();
+      break;
   }
 
   return QVariant();
@@ -938,6 +977,8 @@ void MultiFeatureListModelBase::featureDeleted( QgsFeatureId fid )
     }
     ++i;
   }
+
+  mFeaturesConditionalStyle.remove( QStringLiteral( "%1:%2" ).arg( l->id(), QString::number( fid ) ) );
 }
 
 void MultiFeatureListModelBase::attributeValueChanged( QgsFeatureId fid, int idx, const QVariant &value )
@@ -945,12 +986,15 @@ void MultiFeatureListModelBase::attributeValueChanged( QgsFeatureId fid, int idx
   QgsVectorLayer *l = qobject_cast<QgsVectorLayer *>( sender() );
   Q_ASSERT( l );
 
+  QgsExpressionContext expressionContext = l->createExpressionContext();
   int i = 0;
   for ( auto &pair : mFeatures )
   {
     if ( pair.first == l && pair.second.id() == fid )
     {
       pair.second.setAttribute( idx, value );
+
+      updateConditionalStylingDetails( l, pair.second, expressionContext );
 
       QModelIndex indexChanged = createIndex( i, 0 );
       emit dataChanged( indexChanged, indexChanged );
@@ -978,6 +1022,7 @@ void MultiFeatureListModelBase::geometryChanged( QgsFeatureId fid, const QgsGeom
   QgsVectorLayer *l = qobject_cast<QgsVectorLayer *>( sender() );
   Q_ASSERT( l );
 
+  QgsExpressionContext expressionContext = l->createExpressionContext();
   int i = 0;
   for ( auto &pair : mFeatures )
   {
@@ -985,8 +1030,10 @@ void MultiFeatureListModelBase::geometryChanged( QgsFeatureId fid, const QgsGeom
     {
       pair.second.setGeometry( geometry );
 
+      updateConditionalStylingDetails( l, pair.second, expressionContext );
+
       QModelIndex indexChanged = createIndex( i, 0 );
-      emit dataChanged( indexChanged, indexChanged, QVector<int>() << MultiFeatureListModel::GeometryRole << MultiFeatureListModel::FeatureSelectedRole );
+      emit dataChanged( indexChanged, indexChanged, QVector<int>() << MultiFeatureListModel::GeometryRole << MultiFeatureListModel::FeatureSelectedRole << MultiFeatureListModel::ConditionalBackgroundColorRole << MultiFeatureListModel::ConditionalTextColorRole << MultiFeatureListModel::FeatureNameRole );
 
       break;
     }
@@ -1002,6 +1049,26 @@ void MultiFeatureListModelBase::geometryChanged( QgsFeatureId fid, const QgsGeom
       emit selectedCountChanged();
 
       break;
+    }
+  }
+}
+
+void MultiFeatureListModelBase::updateConditionalStylingDetails( QgsVectorLayer *vectorLayer, const QgsFeature &feature, QgsExpressionContext &expressionContext )
+{
+  if ( !vectorLayer->conditionalStyles()->rowStyles().isEmpty() )
+  {
+    const QString featureUniqueKey = QStringLiteral( "%1:%2" ).arg( vectorLayer->id(), QString::number( feature.id() ) );
+
+    expressionContext.setFeature( feature );
+    const QList<QgsConditionalStyle> styles = QgsConditionalStyle::matchingConditionalStyles( vectorLayer->conditionalStyles()->rowStyles(), QVariant(), expressionContext );
+    if ( !styles.isEmpty() )
+    {
+      QgsConditionalStyle rowStyle = QgsConditionalStyle::compressStyles( styles );
+      mFeaturesConditionalStyle[featureUniqueKey] = rowStyle;
+    }
+    else
+    {
+      mFeaturesConditionalStyle.remove( featureUniqueKey );
     }
   }
 }

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -275,6 +275,9 @@ QHash<int, QByteArray> MultiFeatureListModelBase::roleNames() const
   roleNames[MultiFeatureListModel::EditGeometryRole] = "editGeometryCapability";
   roleNames[MultiFeatureListModel::ConditionalTextColorRole] = "conditionalTextColor";
   roleNames[MultiFeatureListModel::ConditionalBackgroundColorRole] = "conditionalBackgroundColor";
+  roleNames[MultiFeatureListModel::ConditionalFontUnderlineRole] = "conditionalFontUnderline";
+  roleNames[MultiFeatureListModel::ConditionalFontStrikeOutRole] = "conditionalFontStrikeOut";
+  roleNames[MultiFeatureListModel::ConditionalFontItalicRole] = "conditionalFontItalic";
 
   return roleNames;
 }
@@ -400,6 +403,45 @@ QVariant MultiFeatureListModelBase::data( const QModelIndex &index, int role ) c
       }
 
       return QVariant();
+      break;
+
+    case MultiFeatureListModel::ConditionalFontItalicRole:
+      if ( vlayer )
+      {
+        const QString featureUniqueKey = QStringLiteral( "%1:%2" ).arg( vlayer->id(), QString::number( feature->second.id() ) );
+        if ( mFeaturesConditionalStyle.contains( featureUniqueKey ) )
+        {
+          return mFeaturesConditionalStyle[featureUniqueKey].font().italic();
+        }
+      }
+
+      return false;
+      break;
+
+    case MultiFeatureListModel::ConditionalFontUnderlineRole:
+      if ( vlayer )
+      {
+        const QString featureUniqueKey = QStringLiteral( "%1:%2" ).arg( vlayer->id(), QString::number( feature->second.id() ) );
+        if ( mFeaturesConditionalStyle.contains( featureUniqueKey ) )
+        {
+          return mFeaturesConditionalStyle[featureUniqueKey].font().underline();
+        }
+      }
+
+      return false;
+      break;
+
+    case MultiFeatureListModel::ConditionalFontStrikeOutRole:
+      if ( vlayer )
+      {
+        const QString featureUniqueKey = QStringLiteral( "%1:%2" ).arg( vlayer->id(), QString::number( feature->second.id() ) );
+        if ( mFeaturesConditionalStyle.contains( featureUniqueKey ) )
+        {
+          return mFeaturesConditionalStyle[featureUniqueKey].font().strikeOut();
+        }
+      }
+
+      return false;
       break;
   }
 
@@ -994,10 +1036,22 @@ void MultiFeatureListModelBase::attributeValueChanged( QgsFeatureId fid, int idx
     {
       pair.second.setAttribute( idx, value );
 
-      updateConditionalStylingDetails( l, pair.second, expressionContext );
+      QList<int> rolesChanged = QVector<int>() << MultiFeatureListModel::FeatureRole
+                                               << MultiFeatureListModel::FeatureNameRole
+                                               << MultiFeatureListModel::DeleteFeatureRole
+                                               << MultiFeatureListModel::EditGeometryRole;
+
+      if ( updateConditionalStylingDetails( l, pair.second, expressionContext ) )
+      {
+        rolesChanged << MultiFeatureListModel::ConditionalBackgroundColorRole
+                     << MultiFeatureListModel::ConditionalTextColorRole
+                     << MultiFeatureListModel::ConditionalFontItalicRole
+                     << MultiFeatureListModel::ConditionalFontUnderlineRole
+                     << MultiFeatureListModel::ConditionalFontStrikeOutRole;
+      }
 
       QModelIndex indexChanged = createIndex( i, 0 );
-      emit dataChanged( indexChanged, indexChanged );
+      emit dataChanged( indexChanged, indexChanged, rolesChanged );
 
       break;
     }
@@ -1029,11 +1083,23 @@ void MultiFeatureListModelBase::geometryChanged( QgsFeatureId fid, const QgsGeom
     if ( pair.first == l && pair.second.id() == fid )
     {
       pair.second.setGeometry( geometry );
+      QList<int> rolesChanged = QVector<int>() << MultiFeatureListModel::FeatureRole
+                                               << MultiFeatureListModel::FeatureNameRole
+                                               << MultiFeatureListModel::GeometryRole
+                                               << MultiFeatureListModel::DeleteFeatureRole
+                                               << MultiFeatureListModel::EditGeometryRole;
 
-      updateConditionalStylingDetails( l, pair.second, expressionContext );
+      if ( updateConditionalStylingDetails( l, pair.second, expressionContext ) )
+      {
+        rolesChanged << MultiFeatureListModel::ConditionalBackgroundColorRole
+                     << MultiFeatureListModel::ConditionalTextColorRole
+                     << MultiFeatureListModel::ConditionalFontItalicRole
+                     << MultiFeatureListModel::ConditionalFontUnderlineRole
+                     << MultiFeatureListModel::ConditionalFontStrikeOutRole;
+      }
 
       QModelIndex indexChanged = createIndex( i, 0 );
-      emit dataChanged( indexChanged, indexChanged, QVector<int>() << MultiFeatureListModel::GeometryRole << MultiFeatureListModel::FeatureSelectedRole << MultiFeatureListModel::ConditionalBackgroundColorRole << MultiFeatureListModel::ConditionalTextColorRole << MultiFeatureListModel::FeatureNameRole );
+      emit dataChanged( indexChanged, indexChanged, rolesChanged );
 
       break;
     }
@@ -1053,7 +1119,7 @@ void MultiFeatureListModelBase::geometryChanged( QgsFeatureId fid, const QgsGeom
   }
 }
 
-void MultiFeatureListModelBase::updateConditionalStylingDetails( QgsVectorLayer *vectorLayer, const QgsFeature &feature, QgsExpressionContext &expressionContext )
+bool MultiFeatureListModelBase::updateConditionalStylingDetails( QgsVectorLayer *vectorLayer, const QgsFeature &feature, QgsExpressionContext &expressionContext )
 {
   if ( !vectorLayer->conditionalStyles()->rowStyles().isEmpty() )
   {
@@ -1070,5 +1136,9 @@ void MultiFeatureListModelBase::updateConditionalStylingDetails( QgsVectorLayer 
     {
       mFeaturesConditionalStyle.remove( featureUniqueKey );
     }
+
+    return true;
   }
+
+  return false;
 }

--- a/src/core/multifeaturelistmodelbase.h
+++ b/src/core/multifeaturelistmodelbase.h
@@ -22,6 +22,7 @@
 
 #include <QAbstractItemModel>
 #include <qgis.h>
+#include <qgsconditionalstyle.h>
 #include <qgsfeaturerequest.h>
 
 /**
@@ -143,6 +144,8 @@ class MultiFeatureListModelBase : public QAbstractItemModel
     void geometryChanged( QgsFeatureId fid, const QgsGeometry &geometry );
 
   private:
+    void updateConditionalStylingDetails( QgsVectorLayer *vectorLayer, const QgsFeature &feature, QgsExpressionContext &expressionContext );
+
     inline QPair<QgsMapLayer *, QgsFeature> *toFeature( const QModelIndex &index ) const
     {
       return static_cast<QPair<QgsMapLayer *, QgsFeature> *>( index.internalPointer() );
@@ -150,6 +153,8 @@ class MultiFeatureListModelBase : public QAbstractItemModel
 
     QList<QPair<QgsMapLayer *, QgsFeature>> mFeatures;
     QList<QPair<QgsMapLayer *, QgsFeature>> mSelectedFeatures;
+
+    QMap<QString, QgsConditionalStyle> mFeaturesConditionalStyle;
 
     QMap<QString, QgsVectorLayer *> mRepresentationalLayers;
 };

--- a/src/core/multifeaturelistmodelbase.h
+++ b/src/core/multifeaturelistmodelbase.h
@@ -144,7 +144,7 @@ class MultiFeatureListModelBase : public QAbstractItemModel
     void geometryChanged( QgsFeatureId fid, const QgsGeometry &geometry );
 
   private:
-    void updateConditionalStylingDetails( QgsVectorLayer *vectorLayer, const QgsFeature &feature, QgsExpressionContext &expressionContext );
+    bool updateConditionalStylingDetails( QgsVectorLayer *vectorLayer, const QgsFeature &feature, QgsExpressionContext &expressionContext );
 
     inline QPair<QgsMapLayer *, QgsFeature> *toFeature( const QModelIndex &index ) const
     {

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -345,6 +345,9 @@ Pane {
         }
         font.bold: true
         font.pointSize: Theme.resultFont.pointSize
+        font.italic: conditionalFontItalic
+        font.underline: conditionalFontUnderline
+        font.strikeout: conditionalFontStrikeOut
         color: conditionalTextColor !== undefined ? conditionalTextColor : Theme.mainTextColor
         text: display
         wrapMode: Text.WordWrap

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -312,7 +312,7 @@ Pane {
         right: parent ? parent.right : undefined
       }
       height: Math.max(48, featureText.height)
-      color: "transparent"
+      color: conditionalBackgroundColor !== undefined ? conditionalBackgroundColor : "transparent"
 
       Ripple {
         clip: true
@@ -345,7 +345,7 @@ Pane {
         }
         font.bold: true
         font.pointSize: Theme.resultFont.pointSize
-        color: Theme.mainTextColor
+        color: conditionalTextColor !== undefined ? conditionalTextColor : Theme.mainTextColor
         text: display
         wrapMode: Text.WordWrap
       }


### PR DESCRIPTION
This PR has QField leverage vector layers' conditional _row_ styling within its feature list form. This allows for a really nice visual feedback when browsing features via the list.

E.g.:

<img width="1063" height="498" alt="Screenshot From 2026-05-12 12-19-29" src="https://github.com/user-attachments/assets/bdea03ac-31aa-49f2-a93c-28e81d5f0598" />

Here's how the configuration looks like on the QGIS side of things:

<img width="788" height="373" alt="image" src="https://github.com/user-attachments/assets/9a1fc4dc-3af6-49d8-88c6-7f7d8bf71616" />

It's always a good day when QField adopts a long pre-existing QGIS functionality :)