### PR TITLE
Mitigate scenarios in which merged polygon geometries can result in a GeometryCollection of polygons and lines

### DIFF
--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -613,7 +613,20 @@ bool MultiFeatureListModelBase::mergeSelection()
     }
   }
 
-  if ( !QgsWkbTypes::isMultiType( vlayer->wkbType() ) )
+  if ( QgsWkbTypes::isMultiType( vlayer->wkbType() ) )
+  {
+    // Attempt to fix merged geometries resulting in a GeometryCollection of mixed geometries
+    if ( QgsWkbTypes::flatType( combinedGeometry.wkbType() ) == Qgis::WkbType::GeometryCollection )
+    {
+      const QgsGeometryCollection *geometryCollection = qgsgeometry_cast<const QgsGeometryCollection *>( combinedGeometry.constGet() );
+      QgsGeometry fixedGeometry = QgsGeometry( geometryCollection->extractPartsByType( QgsWkbTypes::singleType( vlayer->wkbType() ) ) );
+      if ( combinedGeometry.isEmpty() )
+      {
+        isSuccess = false;
+      }
+    }
+  }
+  else
   {
     const QgsGeometryCollection *geometryCollection = qgsgeometry_cast<const QgsGeometryCollection *>( combinedGeometry.constGet() );
     if ( ( geometryCollection && geometryCollection->partCount() > 1 ) || !combinedGeometry.convertToSingleType() )


### PR DESCRIPTION
While I've not been able to replicate the circumstances leading to merged polygons resulting in a GeometryCollection, this code cleans up such a resulting geometry to give us a MultiPolygon. 

