### PR TITLE
Make the cloud project details page a little less intimidating when we don't have to

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -380,7 +380,7 @@ void QFieldCloudProject::setAttachmentsOnDemandEnabled( bool enabled )
   emit attachmentsOnDemandEnabledChanged();
 }
 
-void QFieldCloudProject::setLastLocalPushDeltas( const QString &lastLocalPushDeltas )
+void QFieldCloudProject::setLastLocalPushDeltas( const QDateTime &lastLocalPushDeltas )
 {
   if ( mLastLocalPushDeltas == lastLocalPushDeltas )
     return;
@@ -389,7 +389,7 @@ void QFieldCloudProject::setLastLocalPushDeltas( const QString &lastLocalPushDel
   emit lastLocalPushDeltasChanged();
 }
 
-void QFieldCloudProject::setLastLocalExportedAt( const QString &lastLocalExportedAt )
+void QFieldCloudProject::setLastLocalExportedAt( const QDateTime &lastLocalExportedAt )
 {
   if ( mLastLocalExportedAt == lastLocalExportedAt )
     return;
@@ -913,7 +913,7 @@ void QFieldCloudProject::download()
     }
 
     mLastExportId = packageId;
-    mLastExportedAt = packagedAt;
+    mLastExportedAt = QDateTime::fromString( packagedAt, Qt::ISODate );
 
     if ( !localizedDatasetsFileNames.isEmpty() && !mSharedDatasetsProjectId.isEmpty() )
     {
@@ -1382,16 +1382,16 @@ void QFieldCloudProject::downloadFilesCompleted( bool emptyDownload )
   setErrorStatus( NoErrorStatus );
   setCheckout( ProjectCheckout::LocalAndRemoteCheckout );
   setLocalPath( QFieldCloudUtils::localProjectFilePath( mUsername, mId ) );
-  setLastLocalExportedAt( QDateTime::currentDateTimeUtc().toString( Qt::ISODate ) );
+  setLastLocalExportedAt( QDateTime::currentDateTimeUtc() );
   setLastLocalExportId( QUuid::createUuid().toString( QUuid::WithoutBraces ) );
   setLastLocalDataLastUpdatedAt( mDataLastUpdatedAt );
   setLastLocalRestrictedDataLastUpdatedAt( mRestrictedDataLastUpdatedAt );
   setIsOutdated( false );
   setIsProjectOutdated( false );
 
-  QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastExportedAt" ), mLastExportedAt );
+  QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastExportedAt" ), mLastExportedAt.toString( Qt::ISODate ) );
   QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastExportId" ), mLastExportId );
-  QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalExportedAt" ), mLastLocalExportedAt );
+  QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalExportedAt" ), mLastLocalExportedAt.toString( Qt::ISODate ) );
   QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalExportId" ), mLastLocalExportId );
   QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalDataLastUpdatedAt" ), mLastLocalDataLastUpdatedAt );
   QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalRestrictedDataLastUpdatedAt" ), mLastLocalRestrictedDataLastUpdatedAt );
@@ -1668,7 +1668,7 @@ void QFieldCloudProject::push( bool shouldDownloadUpdates )
       emit modificationChanged();
 
       setStatus( ProjectStatus::Idle );
-      setLastLocalPushDeltas( QDateTime::currentDateTimeUtc().toString( Qt::ISODate ) );
+      setLastLocalPushDeltas( QDateTime::currentDateTimeUtc() );
 
       if ( !isOutdated() )
       {
@@ -1677,7 +1677,7 @@ void QFieldCloudProject::push( bool shouldDownloadUpdates )
         QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalDataLastUpdatedAt" ), mLastLocalDataLastUpdatedAt );
       }
 
-      QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalPushDeltas" ), mLastLocalPushDeltas );
+      QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalPushDeltas" ), mLastLocalPushDeltas.toString( Qt::ISODate ) );
 
       mDeltaFileWrapper->reset();
       mDeltaFileWrapper->resetId();
@@ -1743,9 +1743,9 @@ void QFieldCloudProject::push( bool shouldDownloadUpdates )
         mModification |= RemoteModification;
         emit modificationChanged();
         setStatus( ProjectStatus::Idle );
-        setLastLocalPushDeltas( QDateTime::currentDateTimeUtc().toString( Qt::ISODate ) );
+        setLastLocalPushDeltas( QDateTime::currentDateTimeUtc() );
 
-        QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalPushDeltas" ), mLastLocalPushDeltas );
+        QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "lastLocalPushDeltas" ), mLastLocalPushDeltas.toString( Qt::ISODate ) );
 
         // download the updated files, so the files are for sure the same on the client and on the server
         if ( shouldDownloadUpdates )
@@ -2257,10 +2257,10 @@ QFieldCloudProject *QFieldCloudProject::fromLocalSettings( const QString &id, QF
 void QFieldCloudProject::restoreLocalSettings( QFieldCloudProject *project, const QDir &localPath )
 {
   project->mLastExportId = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastExportId" ) ).toString();
-  project->mLastExportedAt = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastExportedAt" ) ).toString();
+  project->mLastExportedAt = QDateTime::fromString( QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastExportedAt" ) ).toString(), Qt::ISODate );
   project->mLastLocalExportId = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastLocalExportId" ) ).toString();
-  project->mLastLocalExportedAt = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastLocalExportedAt" ) ).toString();
-  project->mLastLocalPushDeltas = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastLocalPushDeltas" ) ).toString();
+  project->mLastLocalExportedAt = QDateTime::fromString( QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastLocalExportedAt" ) ).toString(), Qt::ISODate );
+  project->mLastLocalPushDeltas = QDateTime::fromString( QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastLocalPushDeltas" ) ).toString(), Qt::ISODate );
   project->mLastLocalDataLastUpdatedAt = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastLocalDataLastUpdatedAt" ) ).toDateTime();
   project->mLastLocalRestrictedDataLastUpdatedAt = QFieldCloudUtils::projectSetting( project->id(), QStringLiteral( "lastLocalRestrictedDataLastUpdatedAt" ) ).toDateTime();
   project->mIsOutdated = project->mDataLastUpdatedAt > project->mLastLocalDataLastUpdatedAt;

--- a/src/core/qfieldcloud/qfieldcloudproject.h
+++ b/src/core/qfieldcloud/qfieldcloudproject.h
@@ -72,8 +72,8 @@ class QFieldCloudProject : public QObject
 
     Q_PROPERTY( bool attachmentsOnDemandEnabled READ attachmentsOnDemandEnabled WRITE setAttachmentsOnDemandEnabled NOTIFY attachmentsOnDemandEnabledChanged )
 
-    Q_PROPERTY( QString lastLocalPushDeltas READ lastLocalPushDeltas NOTIFY lastLocalPushDeltasChanged )
-    Q_PROPERTY( QString lastLocalExportedAt READ lastLocalExportedAt NOTIFY lastLocalExportedAtChanged )
+    Q_PROPERTY( QDateTime lastLocalPushDeltas READ lastLocalPushDeltas NOTIFY lastLocalPushDeltasChanged )
+    Q_PROPERTY( QDateTime lastLocalExportedAt READ lastLocalExportedAt NOTIFY lastLocalExportedAtChanged )
 
     Q_PROPERTY( bool isPublic READ isPublic NOTIFY isPublicChanged )
     Q_PROPERTY( bool isFeatured READ isFeatured NOTIFY isFeaturedChanged )
@@ -324,11 +324,11 @@ class QFieldCloudProject : public QObject
     bool attachmentsOnDemandEnabled() const { return mAttachmentsOnDemandEnabled; }
     void setAttachmentsOnDemandEnabled( bool enabled );
 
-    QString lastLocalPushDeltas() const { return mLastLocalPushDeltas; }
-    void setLastLocalPushDeltas( const QString &lastLocalPushDeltas );
+    QDateTime lastLocalPushDeltas() const { return mLastLocalPushDeltas; }
+    void setLastLocalPushDeltas( const QDateTime &lastLocalPushDeltas );
 
-    QString lastLocalExportedAt() const { return mLastLocalExportedAt; }
-    void setLastLocalExportedAt( const QString &lastLocalExportedAt );
+    QDateTime lastLocalExportedAt() const { return mLastLocalExportedAt; }
+    void setLastLocalExportedAt( const QDateTime &lastLocalExportedAt );
 
     QString lastLocalExportId() const { return mLastLocalExportId; }
     void setLastLocalExportId( const QString &lastLocalExportId );
@@ -569,11 +569,11 @@ class QFieldCloudProject : public QObject
 
     QString mThumbnailPath;
 
-    QString mLastExportedAt;
+    QDateTime mLastExportedAt;
     QString mLastExportId;
-    QString mLastLocalExportedAt;
+    QDateTime mLastLocalExportedAt;
     QString mLastLocalExportId;
-    QString mLastLocalPushDeltas;
+    QDateTime mLastLocalPushDeltas;
 
     QDateTime mLastLocalDataLastUpdatedAt;
     QDateTime mLastLocalRestrictedDataLastUpdatedAt;

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -583,34 +583,36 @@ Popup {
               if (!cloudProjectsModel.currentProject) {
                 return '';
               }
-              var exportText = '';
-              var exportDt = cloudProjectsModel.currentProject.lastLocalExportedAt;
-              var timeDeltaMinutes = null;
-              if (exportDt) {
-                exportDt = new Date(exportDt);
-                timeDeltaMinutes = parseInt(Math.max(new Date() - exportDt, 0) / (60 * 1000));
-                if (timeDeltaMinutes < 1)
+
+              let timeDeltaMinutes = 0;
+              let exportText = '';
+              let exportDt = cloudProjectsModel.currentProject.lastLocalExportedAt;
+              timeDeltaMinutes = parseInt(Math.max(new Date() - exportDt, 0) / (60 * 1000));
+              if (!isNaN(timeDeltaMinutes)) {
+                if (timeDeltaMinutes < 1) {
                   exportText = qsTr('Last synchronized just now');
-                else if (timeDeltaMinutes < 60)
+                } else if (timeDeltaMinutes < 60) {
                   exportText = qsTr('Last synchronized %1 minutes ago').arg(timeDeltaMinutes);
-                else if (exportDt.toLocaleDateString() === new Date().toLocaleDateString())
+                } else if (exportDt.toLocaleDateString() === new Date().toLocaleDateString()) {
                   exportText = qsTr('Last synchronized at %1').arg(exportDt.toLocaleTimeString());
-                else
+                } else {
                   exportText = qsTr('Last synchronized on %1').arg(exportDt.toLocaleString());
+                }
               }
-              var pushText = '';
-              var pushDt = cloudProjectsModel.currentProject.lastLocalPushDeltas;
-              if (pushDt) {
-                pushDt = new Date(pushDt);
-                timeDeltaMinutes = parseInt(Math.max(new Date() - pushDt, 0) / (60 * 1000));
-                if (timeDeltaMinutes < 1)
+
+              let pushText = '';
+              let pushDt = cloudProjectsModel.currentProject.lastLocalPushDeltas;
+              timeDeltaMinutes = parseInt(Math.max(new Date() - pushDt, 0) / (60 * 1000));
+              if (!isNaN(timeDeltaMinutes)) {
+                if (timeDeltaMinutes < 1) {
                   pushText = qsTr('Last changes pushed just now');
-                else if (timeDeltaMinutes < 60)
+                } else if (timeDeltaMinutes < 60) {
                   pushText = qsTr('Last changes pushed %1 minutes ago').arg(timeDeltaMinutes);
-                else if (pushDt.toLocaleDateString() === new Date().toLocaleDateString())
+                } else if (pushDt.toLocaleDateString() === new Date().toLocaleDateString()) {
                   pushText = qsTr('Last changes pushed at %1').arg(pushDt.toLocaleTimeString());
-                else
+                } else {
                   pushText = qsTr('Last changes pushed on %1').arg(pushDt.toLocaleString());
+                }
               } else {
                 pushText = qsTr('No changes pushed yet');
               }

--- a/src/qml/QFieldCloudProjectDetails.qml
+++ b/src/qml/QFieldCloudProjectDetails.qml
@@ -263,6 +263,8 @@ ColumnLayout {
       id: syncButton
       Layout.fillWidth: true
       Layout.preferredWidth: 1
+      enabled: cloudProject != undefined && cloudProject.deltaFileWrapper !== null && cloudProject.status === QFieldCloudProject.Idle && !cloudProject.deltaFileWrapper.hasError
+      visible: true
       progressValue: cloudProject != undefined && cloudProject.localPath !== "" ? cloudProject.downloadProgress : 0
       showProgress: cloudProject != undefined && cloudProject.localPath !== "" && cloudProject.status === QFieldCloudProject.ProjectStatus.Downloading
       text: {
@@ -275,8 +277,6 @@ ColumnLayout {
         }
         return qsTr('Synchronize');
       }
-      visible: true
-      enabled: cloudProject != undefined && cloudProject.status === QFieldCloudProject.Idle && cloudProject.deltaFileWrapper !== null && !cloudProject.deltaFileWrapper.hasError
 
       onClicked: {
         synchronize();
@@ -288,8 +288,8 @@ ColumnLayout {
       Layout.fillWidth: true
       Layout.preferredWidth: 1
       enabled: cloudProject != undefined && cloudProject.deltaFileWrapper !== undefined && cloudProject.deltasCount > 0 && cloudProject.status === QFieldCloudProject.Idle && !cloudProject.deltaFileWrapper.hasError
+      visible: cloudProject != undefined && cloudProject.userRole !== "reader"
       text: qsTr('Push changes')
-      visible: true
 
       onClicked: {
         pushChanges();

--- a/src/qml/QFieldCloudProjectDetails.qml
+++ b/src/qml/QFieldCloudProjectDetails.qml
@@ -256,15 +256,14 @@ ColumnLayout {
   }
 
   RowLayout {
-    visible: openProjectBtn.visible
     Layout.fillWidth: true
+    visible: cloudProject != undefined && cloudProject.localPath !== "" && (((Date.now() - cloudProject.lastLocalExportedAt) / 1000 > 60) || (cloudProject.deltaFileWrapper === undefined || cloudProject.deltasCount > 0))
 
     QfButton {
       id: syncButton
       Layout.fillWidth: true
       Layout.preferredWidth: 1
       enabled: cloudProject != undefined && cloudProject.deltaFileWrapper !== null && cloudProject.status === QFieldCloudProject.Idle && !cloudProject.deltaFileWrapper.hasError
-      visible: true
       progressValue: cloudProject != undefined && cloudProject.localPath !== "" ? cloudProject.downloadProgress : 0
       showProgress: cloudProject != undefined && cloudProject.localPath !== "" && cloudProject.status === QFieldCloudProject.ProjectStatus.Downloading
       text: {


### PR DESCRIPTION
Until now, when someone downloads a cloud project via its details page, immediately after the download the user is presented with three buttons spread over two rows: 

```
----
synchronize | push changes
----
open project
----
```

This feels needlessly crowded at best, and risks being intimidating and confusing for newcomers.

Solution: avoid showing the sync. and push changes when we just downloaded the project (< 60 seconds ago). 