### PR TITLE
Add organization presets to QFieldCloud filter panel

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfieldcloudconnection.cpp
@@ -597,7 +597,7 @@ void QFieldCloudConnection::getUserOrganizations( const QString &user )
     const QJsonArray array = doc.array();
 
     QStringList organizations;
-    for ( const QJsonValue &value : array )
+    for ( const auto &value : array )
     {
       const QString username = value.toObject().value( QStringLiteral( "username" ) ).toString();
       if ( !username.isEmpty() )

--- a/src/core/qfieldcloud/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfieldcloudconnection.cpp
@@ -574,6 +574,42 @@ void QFieldCloudConnection::logout()
   setStatus( ConnectionStatus::Disconnected );
 }
 
+void QFieldCloudConnection::getUserOrganizations( const QString &user )
+{
+  if ( mStatus != ConnectionStatus::LoggedIn )
+  {
+    return;
+  }
+
+  NetworkReply *reply = get( QStringLiteral( "/api/v1/users/%1/organizations/" ).arg( user ) );
+
+  connect( reply, &NetworkReply::finished, this, [this, reply]() {
+    QNetworkReply *rawReply = reply->currentRawReply();
+    reply->deleteLater();
+
+    if ( rawReply->error() != QNetworkReply::NoError )
+    {
+      QgsMessageLog::logMessage( QStringLiteral( "Failed to fetch user organizations: %1" ).arg( rawReply->errorString() ), QStringLiteral( "QFieldCloud" ) );
+      return;
+    }
+
+    const QJsonDocument doc = QJsonDocument::fromJson( rawReply->readAll() );
+    const QJsonArray array = doc.array();
+
+    QStringList organizations;
+    for ( const QJsonValue &value : array )
+    {
+      const QString username = value.toObject().value( QStringLiteral( "username" ) ).toString();
+      if ( !username.isEmpty() )
+      {
+        organizations.append( username );
+      }
+    }
+
+    emit userOrganizationsReceived( organizations );
+  } );
+}
+
 void QFieldCloudConnection::getSubscriptionInformation( const QString &user )
 {
   if ( mStatus != ConnectionStatus::LoggedIn )

--- a/src/core/qfieldcloud/qfieldcloudconnection.h
+++ b/src/core/qfieldcloud/qfieldcloudconnection.h
@@ -171,6 +171,7 @@ class QFieldCloudConnection : public QObject
     Q_INVOKABLE void login( const QString &password = QString() );
     Q_INVOKABLE void logout();
 
+    Q_INVOKABLE void getUserOrganizations( const QString &user );
     Q_INVOKABLE void getSubscriptionInformation( const QString &user );
 
     Q_INVOKABLE void getServerInformation();
@@ -271,6 +272,7 @@ class QFieldCloudConnection : public QObject
     void isReachableChanged();
     void queuedProjectPushRequested( const QString &projectId );
 
+    void userOrganizationsReceived( const QStringList &organizations );
     void subscriptionInformationReceived( const CloudSubscriptionInformation &subscriptionInformation );
 
   private:

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -41,6 +41,9 @@ Pane {
     function onUserOrganizationsReceived(organizations) {
       filterPanel.organizations = organizations;
     }
+    function onUsernameChanged() {
+      filterPanel.organizations = [];
+    }
   }
 
   function updateQuery() {
@@ -113,10 +116,6 @@ Pane {
       ownerComboBox.model = [""].concat(cloudProjectsModel.uniqueOwners());
       ownerComboBox.editText = previousOwner;
       blockQueryUpdate = false;
-
-      if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
-        cloudConnection.getUserOrganizations(cloudConnection.username);
-      }
     }
   }
 

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -11,19 +11,37 @@ Pane {
   signal applyFilter
 
   property string currentUsername: ""
+  property var organizations: []
 
   property string activePreset: ""
-  readonly property var presets: [
-    {
-      id: "mine",
-      label: qsTr("My Own Projects"),
-      query: "owner:" + filterPanel.currentUsername
+  readonly property var presets: {
+    const list = [
+      {
+        id: "mine",
+        label: qsTr("My Own Projects"),
+        query: "owner:" + filterPanel.currentUsername
+      }
+    ];
+    for (const org of filterPanel.organizations) {
+      list.push({
+        id: "org_" + org,
+        label: qsTr("%1's projects").arg(org),
+        query: "owner:" + org
+      });
     }
-  ]
+    return list;
+  }
 
   property string queryString: ""
 
   property bool blockQueryUpdate: false
+
+  Connections {
+    target: cloudConnection
+    function onUserOrganizationsReceived(organizations) {
+      filterPanel.organizations = organizations;
+    }
+  }
 
   function updateQuery() {
     if (filterPanel.blockQueryUpdate) {
@@ -95,6 +113,10 @@ Pane {
       ownerComboBox.model = [""].concat(cloudProjectsModel.uniqueOwners());
       ownerComboBox.editText = previousOwner;
       blockQueryUpdate = false;
+
+      if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
+        cloudConnection.getUserOrganizations(cloudConnection.username);
+      }
     }
   }
 

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -12,7 +12,7 @@ Pane {
 
   property string currentUsername: ""
   property var organizations: []
-
+  property bool organizationsFetched: false
   property string activePreset: ""
   readonly property var presets: {
     const list = [
@@ -43,6 +43,7 @@ Pane {
     }
     function onUsernameChanged() {
       filterPanel.organizations = [];
+      filterPanel.organizationsFetched = false;
     }
   }
 
@@ -116,6 +117,11 @@ Pane {
       ownerComboBox.model = [""].concat(cloudProjectsModel.uniqueOwners());
       ownerComboBox.editText = previousOwner;
       blockQueryUpdate = false;
+
+      if (!filterPanel.organizationsFetched && cloudConnection.status === QFieldCloudConnection.LoggedIn) {
+        cloudConnection.getUserOrganizations(filterPanel.currentUsername);
+        filterPanel.organizationsFetched = true;
+      }
     }
   }
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -901,7 +901,6 @@ Page {
     function onStatusChanged() {
       if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
         prepareCloudScreen();
-        cloudConnection.getUserOrganizations(cloudConnection.username);
       } else if (cloudConnection.status === QFieldCloudConnection.Disconnected) {
         if (table.count === 0) {
           projectsSwipeView.visible = false;

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -901,6 +901,7 @@ Page {
     function onStatusChanged() {
       if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
         prepareCloudScreen();
+        cloudConnection.getUserOrganizations(cloudConnection.username);
       } else if (cloudConnection.status === QFieldCloudConnection.Disconnected) {
         if (table.count === 0) {
           projectsSwipeView.visible = false;

--- a/test/qml/tst_qfieldCloudScreenUI.qml
+++ b/test/qml/tst_qfieldCloudScreenUI.qml
@@ -172,7 +172,7 @@ TestCase {
   // Helper: Login and refresh projects list
   function loginAndRefresh(data) {
     loginToServer(data);
-    cloudProjectsModel.refreshProjectsList(true, false, 0);
+    cloudProjectsModel.refreshProjectsList(true);
     tryCompare(cloudProjectsModel, "isRefreshing", true, 5000);
     tryCompare(cloudProjectsModel, "isRefreshing", false, 30000);
     wait(500);


### PR DESCRIPTION
Adds QFieldCloudConnection::getUserOrganizations(user), fetches /api/v1/users/{user}/organizations/ and emits userOrganizationsReceived(QStringList) with the organization handles.

Filter listens for the signal and dynamically appends one preset per organization to the predefined filters row, alongside the existing "My Own Projects" preset
[ My Own Projects ] [ OrgA's projects ] [ OrgB's projects ] [ OrgC's projects ]

Each preset sets the query to owner:<organization>, which the proxy then filters on (organization-owned projects have the org's handle in their owner field)

follow up to interesting feature added: #7414 