### PR TITLE
Properly join and leave multicast group when using the UDP receiver

### DIFF
--- a/src/core/positioning/udpreceiver.cpp
+++ b/src/core/positioning/udpreceiver.cpp
@@ -38,16 +38,7 @@ UdpReceiver::UdpReceiver( const QString &address, const int port, QObject *paren
 #endif
 
   connect( mSocket, qOverload<QAbstractSocket::SocketError>( &QAbstractSocket::errorOccurred ), this, &UdpReceiver::handleError );
-  connect( mSocket, &QUdpSocket::stateChanged, this, [this]( QAbstractSocket::SocketState state ) {
-    if ( state == QAbstractSocket::SocketState::UnconnectedState && mReconnectOnDisconnect )
-    {
-      mReconnectTimer.start( 2000 );
-    }
-    else
-    {
-      setSocketState( state );
-    }
-  } );
+  connect( mSocket, &QUdpSocket::stateChanged, this, &UdpReceiver::handleStateChanged );
 
   connect( mSocket, &QUdpSocket::readyRead, this, [this]() {
     QByteArray datagram;
@@ -92,7 +83,6 @@ void UdpReceiver::handleConnectDevice()
   mReconnectOnDisconnect = true;
   mBuffer->open( QIODevice::ReadWrite );
   mSocket->bind( QHostAddress( mAddress ), mPort, QAbstractSocket::ShareAddress | QAbstractSocket::ReuseAddressHint );
-  mSocket->joinMulticastGroup( QHostAddress( mAddress ) );
 }
 
 void UdpReceiver::handleDisconnectDevice()
@@ -111,6 +101,33 @@ QString UdpReceiver::socketStateString()
     socketStateString.append( QStringLiteral( ": %1" ).arg( mSocket->errorString() ) );
   }
   return socketStateString;
+}
+
+void UdpReceiver::handleStateChanged( QAbstractSocket::SocketState state )
+{
+  switch ( state )
+  {
+    case QAbstractSocket::SocketState::UnconnectedState:
+      if ( mReconnectOnDisconnect )
+      {
+        mReconnectTimer.start( 2000 );
+      }
+      break;
+
+    case QAbstractSocket::BoundState:
+      mSocket->joinMulticastGroup( QHostAddress( mAddress ) );
+      break;
+
+    case QAbstractSocket::ClosingState:
+      mSocket->leaveMulticastGroup( QHostAddress( mAddress ) );
+      break;
+
+    case QAbstractSocket::HostLookupState:
+    case QAbstractSocket::ConnectingState:
+    case QAbstractSocket::ConnectedState:
+    case QAbstractSocket::ListeningState:
+      break;
+  }
 }
 
 void UdpReceiver::handleError( QAbstractSocket::SocketError error )

--- a/src/core/positioning/udpreceiver.h
+++ b/src/core/positioning/udpreceiver.h
@@ -45,6 +45,7 @@ class UdpReceiver : public NmeaGnssReceiver
     void handleConnectDevice() override;
     void handleDisconnectDevice() override;
     void handleError( QAbstractSocket::SocketError error );
+    void handleStateChanged( QAbstractSocket::SocketState state );
 
     QString mAddress;
     int mPort = 0;


### PR DESCRIPTION
It was not preventing us from connecting before, but Qt was throwing warnings. It can't hurt us doing it the right way :)