### PR TITLE
[iOS] Add native project folder and archive import

### DIFF
--- a/src/core/platforms/ios/iosplatformutilities.h
+++ b/src/core/platforms/ios/iosplatformutilities.h
@@ -37,6 +37,7 @@ class IosPlatformUtilities : public PlatformUtilities
     QStringList rootDirectories() const override { return QStringList(); }
 
     void importProjectFolder() const override;
+    void importProjectArchive() const override;
 
     void setScreenLockPermission( const bool allowLock ) override;
     virtual ResourceSource *getCameraPicture( const QString &prefix,

--- a/src/core/platforms/ios/iosplatformutilities.h
+++ b/src/core/platforms/ios/iosplatformutilities.h
@@ -36,6 +36,8 @@ class IosPlatformUtilities : public PlatformUtilities
     QStringList appDataDirs() const override;
     QStringList rootDirectories() const override { return QStringList(); }
 
+    void importProjectFolder() const override;
+
     void setScreenLockPermission( const bool allowLock ) override;
     virtual ResourceSource *getCameraPicture( const QString &prefix,
                                               const QString &pictureFilePath,

--- a/src/core/platforms/ios/iosplatformutilities.h
+++ b/src/core/platforms/ios/iosplatformutilities.h
@@ -38,6 +38,7 @@ class IosPlatformUtilities : public PlatformUtilities
 
     void importProjectFolder() const override;
     void importProjectArchive() const override;
+    void importDatasets() const override;
 
     void setScreenLockPermission( const bool allowLock ) override;
     virtual ResourceSource *getCameraPicture( const QString &prefix,

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -331,11 +331,7 @@ static void copyDirectoryContents(NSURL *sourceURL, NSString *destinationPath) {
 
 @end
 
-- (void)documentPickerWasCancelled:
-    (UIDocumentPickerViewController *)controller {
-}
-
-@end void IosPlatformUtilities::importProjectFolder() const {
+void IosPlatformUtilities::importProjectFolder() const {
   QString appDir = applicationDirectory();
   NSString *importBasePath =
       (appDir + QStringLiteral("/Imported Projects/")).toNSString();
@@ -367,8 +363,9 @@ void IosPlatformUtilities::importProjectArchive() const {
       firstObject] rootViewController];
 
   UIDocumentPickerViewController *picker =
-      [[UIDocumentPickerViewController alloc]
-          initForOpeningContentTypes:@[ UTTypeZipArchive ]];
+      [[UIDocumentPickerViewController alloc] initForOpeningContentTypes:@[
+        [UTType typeWithIdentifier:@"public.zip-archive"]
+      ]];
   picker.allowsMultipleSelection = NO;
 
   IosImportDelegate *delegate = [[IosImportDelegate alloc] init];

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -322,6 +322,26 @@ static void copyDirectoryContents(NSURL *sourceURL, NSString *destinationPath) {
     if (AppInterface::instance()) {
       emit AppInterface::instance()->openPath(destDir);
     }
+  } else if ([_mode isEqualToString:@"datasets"]) {
+    [fileManager createDirectoryAtPath:_importPath
+           withIntermediateDirectories:YES
+                            attributes:nil
+                                 error:nil];
+    [url stopAccessingSecurityScopedResource];
+
+    for (NSURL *fileUrl in urls) {
+      [fileUrl startAccessingSecurityScopedResource];
+      NSString *destFile = [_importPath
+          stringByAppendingPathComponent:fileUrl.lastPathComponent];
+      [fileManager removeItemAtPath:destFile error:nil];
+      [fileManager copyItemAtPath:fileUrl.path toPath:destFile error:nil];
+      [fileUrl stopAccessingSecurityScopedResource];
+    }
+
+    QString importedPath = QString::fromNSString(_importPath);
+    if (AppInterface::instance()) {
+      emit AppInterface::instance()->openPath(importedPath);
+    }
   }
 }
 
@@ -371,6 +391,29 @@ void IosPlatformUtilities::importProjectArchive() const {
   IosImportDelegate *delegate = [[IosImportDelegate alloc] init];
   delegate.importPath = importBasePath;
   delegate.mode = @"projectArchive";
+  picker.delegate = delegate;
+  objc_setAssociatedObject(picker, &kIosImportDelegateKey, delegate,
+                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+  [root presentViewController:picker animated:YES completion:nil];
+}
+
+void IosPlatformUtilities::importDatasets() const {
+  QString appDir = applicationDirectory();
+  NSString *importBasePath =
+      (appDir + QStringLiteral("/Imported Datasets/")).toNSString();
+
+  UIViewController *root = [[[[UIApplication sharedApplication] windows]
+      firstObject] rootViewController];
+
+  UIDocumentPickerViewController *picker =
+      [[UIDocumentPickerViewController alloc]
+          initForOpeningContentTypes:@[ UTTypeData ]];
+  picker.allowsMultipleSelection = YES;
+
+  IosImportDelegate *delegate = [[IosImportDelegate alloc] init];
+  delegate.importPath = importBasePath;
+  delegate.mode = @"datasets";
   picker.delegate = delegate;
   objc_setAssociatedObject(picker, &kIosImportDelegateKey, delegate,
                            OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -17,6 +17,7 @@
  ***************************************************************************/
 
 #include "iosplatformutilities.h"
+#include "appinterface.h"
 #include "iosprojectsource.h"
 #include "iosresourcesource.h"
 #include "qfield.h"
@@ -30,6 +31,7 @@
 
 #include <QGuiApplication>
 #include <QStandardPaths>
+#include <objc/runtime.h>
 #include <qpa/qplatformnativeinterface.h>
 
 #include <QtGui>
@@ -244,17 +246,88 @@ void IosPlatformUtilities::requestMicrophonePermission(
                            }];
 }
 
+static char kIosImportDelegateKey;
+
+static void copyDirectoryContents(NSURL *sourceURL, NSString *destinationPath) {
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  [fileManager createDirectoryAtPath:destinationPath
+         withIntermediateDirectories:YES
+                          attributes:nil
+                               error:nil];
+  NSArray *contents = [fileManager contentsOfDirectoryAtURL:sourceURL
+                                 includingPropertiesForKeys:nil
+                                                    options:0
+                                                      error:nil];
+  for (NSURL *item in contents) {
+    NSString *destPath =
+        [destinationPath stringByAppendingPathComponent:item.lastPathComponent];
+    BOOL isDir = NO;
+    [fileManager fileExistsAtPath:item.path isDirectory:&isDir];
+    if (isDir) {
+      copyDirectoryContents(item, destPath);
+    } else {
+      [fileManager removeItemAtPath:destPath error:nil];
+      [fileManager copyItemAtPath:item.path toPath:destPath error:nil];
+    }
+  }
+}
+
+@interface IosImportDelegate : NSObject <UIDocumentPickerDelegate>
+@property(nonatomic, strong) NSString *importPath;
+@end
+
+@implementation IosImportDelegate
+
+- (void)documentPicker:(UIDocumentPickerViewController *)controller
+    didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
+  if (urls.count == 0) {
+    return;
+  }
+
+  NSURL *url = urls.firstObject;
+  [url startAccessingSecurityScopedResource];
+
+  NSString *folderName = url.lastPathComponent;
+  NSString *destPath = [_importPath stringByAppendingPathComponent:folderName];
+
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  [fileManager createDirectoryAtPath:_importPath
+         withIntermediateDirectories:YES
+                          attributes:nil
+                               error:nil];
+
+  copyDirectoryContents(url, destPath);
+  [url stopAccessingSecurityScopedResource];
+
+  QString importedPath = QString::fromNSString(destPath);
+  if (AppInterface::instance()) {
+    emit AppInterface::instance()->openPath(importedPath);
+  }
+}
+
+- (void)documentPickerWasCancelled:
+    (UIDocumentPickerViewController *)controller {
+}
+
+@end
 void IosPlatformUtilities::importProjectFolder() const {
-  qDebug() << "1";
+  QString appDir = applicationDirectory();
+  NSString *importBasePath =
+      (appDir + QStringLiteral("/Imported Projects/")).toNSString();
+
   UIViewController *root = [[[[UIApplication sharedApplication] windows]
       firstObject] rootViewController];
 
-  qDebug() << "2";
   UIDocumentPickerViewController *picker =
       [[UIDocumentPickerViewController alloc]
           initForOpeningContentTypes:@[ UTTypeFolder ]];
   picker.allowsMultipleSelection = NO;
 
-  qDebug() << "3";
+  IosImportDelegate *delegate = [[IosImportDelegate alloc] init];
+  delegate.importPath = importBasePath;
+  picker.delegate = delegate;
+  objc_setAssociatedObject(picker, &kIosImportDelegateKey, delegate,
+                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
   [root presentViewController:picker animated:YES completion:nil];
 }

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -18,6 +18,7 @@
 
 #include "iosplatformutilities.h"
 #include "appinterface.h"
+#include "fileutils.h"
 #include "iosprojectsource.h"
 #include "iosresourcesource.h"
 #include "qfield.h"
@@ -274,6 +275,7 @@ static void copyDirectoryContents(NSURL *sourceURL, NSString *destinationPath) {
 
 @interface IosImportDelegate : NSObject <UIDocumentPickerDelegate>
 @property(nonatomic, strong) NSString *importPath;
+@property(nonatomic, strong) NSString *mode;
 @end
 
 @implementation IosImportDelegate
@@ -286,22 +288,40 @@ static void copyDirectoryContents(NSURL *sourceURL, NSString *destinationPath) {
 
   NSURL *url = urls.firstObject;
   [url startAccessingSecurityScopedResource];
-
-  NSString *folderName = url.lastPathComponent;
-  NSString *destPath = [_importPath stringByAppendingPathComponent:folderName];
-
   NSFileManager *fileManager = [NSFileManager defaultManager];
-  [fileManager createDirectoryAtPath:_importPath
-         withIntermediateDirectories:YES
-                          attributes:nil
-                               error:nil];
 
-  copyDirectoryContents(url, destPath);
-  [url stopAccessingSecurityScopedResource];
+  if ([_mode isEqualToString:@"projectFolder"]) {
+    NSString *folderName = url.lastPathComponent;
+    NSString *destPath =
+        [_importPath stringByAppendingPathComponent:folderName];
+    [fileManager createDirectoryAtPath:_importPath
+           withIntermediateDirectories:YES
+                            attributes:nil
+                                 error:nil];
+    copyDirectoryContents(url, destPath);
+    [url stopAccessingSecurityScopedResource];
 
-  QString importedPath = QString::fromNSString(destPath);
-  if (AppInterface::instance()) {
-    emit AppInterface::instance()->openPath(importedPath);
+    QString importedPath = QString::fromNSString(destPath);
+    if (AppInterface::instance()) {
+      emit AppInterface::instance()->openPath(importedPath);
+    }
+  } else if ([_mode isEqualToString:@"projectArchive"]) {
+    NSString *baseName = [url.lastPathComponent stringByDeletingPathExtension];
+    NSString *destPath = [_importPath stringByAppendingPathComponent:baseName];
+    [fileManager createDirectoryAtPath:destPath
+           withIntermediateDirectories:YES
+                            attributes:nil
+                                 error:nil];
+
+    QString zipPath = QString::fromNSString(url.path);
+    QString destDir = QString::fromNSString(destPath);
+    QStringList extractedFiles;
+    FileUtils::unzip(zipPath, destDir, extractedFiles, false);
+    [url stopAccessingSecurityScopedResource];
+
+    if (AppInterface::instance()) {
+      emit AppInterface::instance()->openPath(destDir);
+    }
   }
 }
 
@@ -310,7 +330,12 @@ static void copyDirectoryContents(NSURL *sourceURL, NSString *destinationPath) {
 }
 
 @end
-void IosPlatformUtilities::importProjectFolder() const {
+
+- (void)documentPickerWasCancelled:
+    (UIDocumentPickerViewController *)controller {
+}
+
+@end void IosPlatformUtilities::importProjectFolder() const {
   QString appDir = applicationDirectory();
   NSString *importBasePath =
       (appDir + QStringLiteral("/Imported Projects/")).toNSString();
@@ -325,6 +350,30 @@ void IosPlatformUtilities::importProjectFolder() const {
 
   IosImportDelegate *delegate = [[IosImportDelegate alloc] init];
   delegate.importPath = importBasePath;
+  delegate.mode = @"projectFolder";
+  picker.delegate = delegate;
+  objc_setAssociatedObject(picker, &kIosImportDelegateKey, delegate,
+                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+  [root presentViewController:picker animated:YES completion:nil];
+}
+
+void IosPlatformUtilities::importProjectArchive() const {
+  QString appDir = applicationDirectory();
+  NSString *importBasePath =
+      (appDir + QStringLiteral("/Imported Projects/")).toNSString();
+
+  UIViewController *root = [[[[UIApplication sharedApplication] windows]
+      firstObject] rootViewController];
+
+  UIDocumentPickerViewController *picker =
+      [[UIDocumentPickerViewController alloc]
+          initForOpeningContentTypes:@[ UTTypeZipArchive ]];
+  picker.allowsMultipleSelection = NO;
+
+  IosImportDelegate *delegate = [[IosImportDelegate alloc] init];
+  delegate.importPath = importBasePath;
+  delegate.mode = @"projectArchive";
   picker.delegate = delegate;
   objc_setAssociatedObject(picker, &kIosImportDelegateKey, delegate,
                            OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -26,6 +26,7 @@
 #include <MobileCoreServices/MobileCoreServices.h>
 #include <UIKit/UIDocumentInteractionController.h>
 #include <UIKit/UIKit.h>
+#include <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 #include <QGuiApplication>
 #include <QStandardPaths>
@@ -241,4 +242,19 @@ void IosPlatformUtilities::requestMicrophonePermission(
                                func(granted ? Qt::PermissionStatus::Granted
                                             : Qt::PermissionStatus::Denied);
                            }];
+}
+
+void IosPlatformUtilities::importProjectFolder() const {
+  qDebug() << "1";
+  UIViewController *root = [[[[UIApplication sharedApplication] windows]
+      firstObject] rootViewController];
+
+  qDebug() << "2";
+  UIDocumentPickerViewController *picker =
+      [[UIDocumentPickerViewController alloc]
+          initForOpeningContentTypes:@[ UTTypeFolder ]];
+  picker.allowsMultipleSelection = NO;
+
+  qDebug() << "3";
+  [root presentViewController:picker animated:YES completion:nil];
 }

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -64,8 +64,9 @@ IosPlatformUtilities::IosPlatformUtilities() : PlatformUtilities() {
 }
 
 PlatformUtilities::Capabilities IosPlatformUtilities::capabilities() const {
-  PlatformUtilities::Capabilities capabilities =
-      Capabilities() | NativeCamera | AdjustBrightness | FilePicker;
+  PlatformUtilities::Capabilities capabilities = Capabilities() | NativeCamera |
+                                                 AdjustBrightness | FilePicker |
+                                                 CustomImport;
 #if WITH_SENTRY
   capabilities |= SentryFramework;
 #endif


### PR DESCRIPTION
### 🚀 Description

Implements native iOS import support for QField projects using `UIDocumentPickerViewController`. Users can now import a project directly from the iOS Files app — either as a `folder` or as a `.zip` archive.


### ✨ Key Changes

- Enable `CustomImport` capability flag on iOS so the UI surfaces the import actions.
- Add `importProjectFolder()` — opens a folder picker, copies the selected folder into `Imported Projects/` inside the app sandbox.
- Add `importProjectArchive()` — opens a `.zip` file picker, extracts the archive into `Imported Projects/`.
- Add `IosImportDelegate` Objective-C class implementing `UIDocumentPickerDelegate` to handle picker results for both flows.


### iOS Demo

https://github.com/user-attachments/assets/d18f1aa8-5962-463d-b13d-70025e89e3a0

