### PR TITLE
Cloud project download, search, and filtering polishing

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -790,7 +790,7 @@ void QFieldCloudProject::packageAndDownload()
 
     setStatus( ProjectStatus::Idle );
 
-    emit downloaded( mName, error );
+    emit downloaded( error );
   } );
 }
 

--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -186,6 +186,15 @@ void QFieldCloudProject::setUpdatedAt( const QDateTime &updatedAt )
   emit updatedAtChanged();
 }
 
+void QFieldCloudProject::setRemoteSizeBytes( qint64 remoteSizeBytes )
+{
+  if ( mRemoteSizeBytes == remoteSizeBytes )
+    return;
+
+  mRemoteSizeBytes = remoteSizeBytes;
+  emit remoteSizeBytesChanged();
+}
+
 void QFieldCloudProject::setDataLastUpdatedAt( const QDateTime &dataLastUpdatedAt )
 {
   if ( mDataLastUpdatedAt == dataLastUpdatedAt )
@@ -2047,6 +2056,7 @@ void QFieldCloudProject::refreshData( ProjectRefreshReason reason )
     setUserRoleOrigin( mUserRoleOrigin = projectData.value( "user_role_origin" ).toString() );
     setCreatedAt( QDateTime::fromString( projectData.value( "created_at" ).toString(), Qt::ISODate ) );
     setUpdatedAt( QDateTime::fromString( projectData.value( "updated_at" ).toString(), Qt::ISODate ) );
+    setRemoteSizeBytes( projectData.value( "file_storage_bytes" ).toInteger() );
     setIsPublic( projectData.value( "is_public" ).toBool() );
     setIsFeatured( projectData.value( "is_featured" ).toBool() );
     setCanRepackage( projectData.value( "can_repackage" ).toBool() );
@@ -2061,6 +2071,7 @@ void QFieldCloudProject::refreshData( ProjectRefreshReason reason )
     QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "userRoleOrigin" ), mUserRoleOrigin );
     QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "createdAt" ), mCreatedAt.toString( Qt::DateFormat::ISODate ) );
     QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "updatedAt" ), mUpdatedAt.toString( Qt::DateFormat::ISODate ) );
+    QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "remoteSizeBytes" ), mRemoteSizeBytes );
     QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "isPublic" ), mIsPublic );
     QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "isFeatured" ), mIsFeatured );
     QFieldCloudUtils::setProjectSetting( mId, QStringLiteral( "canRepackage" ), mCanRepackage );
@@ -2157,6 +2168,7 @@ QFieldCloudProject *QFieldCloudProject::fromDetails( const QVariantHash &details
   project->mStatus = details.value( "status" ).toString() == "failed" ? ProjectStatus::Failing : ProjectStatus::Idle;
   project->mCreatedAt = QDateTime::fromString( details.value( "created_at" ).toString(), Qt::ISODate );
   project->mUpdatedAt = QDateTime::fromString( details.value( "updated_at" ).toString(), Qt::ISODate );
+  project->mRemoteSizeBytes = details.value( "file_storage_bytes" ).toLongLong();
   project->mDataLastUpdatedAt = QDateTime::fromString( details.value( "data_last_updated_at" ).toString(), Qt::ISODate );
   project->mRestrictedDataLastUpdatedAt = QDateTime::fromString( details.value( "restricted_data_last_updated_at" ).toString(), Qt::ISODate );
   project->mCanRepackage = details.value( "can_repackage" ).toBool();
@@ -2172,6 +2184,7 @@ QFieldCloudProject *QFieldCloudProject::fromDetails( const QVariantHash &details
   QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "userRoleOrigin" ), project->userRoleOrigin() );
   QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "createdAt" ), project->createdAt().toString( Qt::DateFormat::ISODate ) );
   QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "updatedAt" ), project->updatedAt().toString( Qt::DateFormat::ISODate ) );
+  QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "remoteSizeBytes" ), project->remoteSizeBytes() );
   QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "canRepackage" ), project->canRepackage() );
   QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "needsRepackaging" ), project->needsRepackaging() );
   QFieldCloudUtils::setProjectSetting( project->id(), QStringLiteral( "sharedDatasetsProjectId" ), project->sharedDatasetsProjectId() );
@@ -2216,6 +2229,7 @@ QFieldCloudProject *QFieldCloudProject::fromLocalSettings( const QString &id, QF
   const QString userRoleOrigin = QFieldCloudUtils::projectSetting( id, QStringLiteral( "userRoleOrigin" ) ).toString();
   const QDateTime createdAt = QDateTime::fromString( QFieldCloudUtils::projectSetting( id, QStringLiteral( "createdAt" ) ).toString(), Qt::DateFormat::ISODate );
   const QDateTime updatedAt = QDateTime::fromString( QFieldCloudUtils::projectSetting( id, QStringLiteral( "updatedAt" ) ).toString(), Qt::DateFormat::ISODate );
+  const qint64 remoteSizeBytes = QFieldCloudUtils::projectSetting( id, QStringLiteral( "remoteSizeBytes" ) ).toLongLong();
   const QString sharedDatasetsProjectId = QFieldCloudUtils::projectSetting( id, QStringLiteral( "sharedDatasetsProjectId" ) ).toString();
   const bool isSharedDatasetsProject = QFieldCloudUtils::projectSetting( id, QStringLiteral( "isSharedDatasetsProject" ) ).toBool();
   const bool isAttachmentDownloadOnDemand = QFieldCloudUtils::projectSetting( id, QStringLiteral( "isAttachmentDownloadOnDemand" ) ).toBool();
@@ -2234,6 +2248,7 @@ QFieldCloudProject *QFieldCloudProject::fromLocalSettings( const QString &id, QF
   project->mStatus = status == "failed" ? ProjectStatus::Failing : ProjectStatus::Idle;
   project->mCreatedAt = createdAt;
   project->mUpdatedAt = updatedAt;
+  project->mRemoteSizeBytes = remoteSizeBytes;
   project->mDataLastUpdatedAt = dataLastUpdatedAt;
   project->mRestrictedDataLastUpdatedAt = restrictedDataLastUpdatedAt;
   project->mCanRepackage = false;

--- a/src/core/qfieldcloud/qfieldcloudproject.h
+++ b/src/core/qfieldcloud/qfieldcloudproject.h
@@ -455,7 +455,7 @@ class QFieldCloudProject : public QObject
 
     void downloadAttachmentFinished( const QString &fileName, const QString &error = QString() );
     void downloadFinished( const QString &error = QString() );
-    void downloaded( const QString &name, const QString &error = QString() );
+    void downloaded( const QString &error = QString() );
 
     void pushFinished( bool isDownloading, const QString &error = QString() );
 

--- a/src/core/qfieldcloud/qfieldcloudproject.h
+++ b/src/core/qfieldcloud/qfieldcloudproject.h
@@ -47,6 +47,7 @@ class QFieldCloudProject : public QObject
 
     Q_PROPERTY( QDateTime createdAt READ createdAt NOTIFY createdAtChanged )
     Q_PROPERTY( QDateTime updatedAt READ updatedAt NOTIFY updatedAtChanged )
+    Q_PROPERTY( qint64 remoteSizeBytes READ remoteSizeBytes NOTIFY remoteSizeBytesChanged )
 
     Q_PROPERTY( ProjectStatus status READ status NOTIFY statusChanged )
     Q_PROPERTY( PackagingStatus packagingStatus READ packagingStatus NOTIFY packagingStatusChanged )
@@ -259,6 +260,9 @@ class QFieldCloudProject : public QObject
     QDateTime updatedAt() const { return mUpdatedAt; }
     void setUpdatedAt( const QDateTime &updatedAt );
 
+    qint64 remoteSizeBytes() const { return mRemoteSizeBytes; }
+    void setRemoteSizeBytes( qint64 remoteSizeBytes );
+
     QDateTime dataLastUpdatedAt() const { return mDataLastUpdatedAt; }
     void setDataLastUpdatedAt( const QDateTime &dataLastUpdatedAt );
 
@@ -400,6 +404,8 @@ class QFieldCloudProject : public QObject
 
     void createdAtChanged();
     void updatedAtChanged();
+    void remoteSizeBytesChanged();
+
     void dataLastUpdatedAtChanged();
     void restrictedDataLastUpdatedAtChanged();
 
@@ -526,6 +532,7 @@ class QFieldCloudProject : public QObject
     ProjectStatus mStatus = ProjectStatus::Idle;
     QDateTime mCreatedAt;
     QDateTime mUpdatedAt;
+    qint64 mRemoteSizeBytes = 0;
     QDateTime mDataLastUpdatedAt;
     QDateTime mRestrictedDataLastUpdatedAt;
     bool mCanRepackage = false;

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -651,6 +651,7 @@ void QFieldCloudProjectsModel::insertProjects( const QList<QFieldCloudProject *>
           mProjects[i]->setUserRoleOrigin( project->userRoleOrigin() );
           mProjects[i]->setCreatedAt( project->createdAt() );
           mProjects[i]->setUpdatedAt( project->updatedAt() );
+          mProjects[i]->setRemoteSizeBytes( project->remoteSizeBytes() );
           mProjects[i]->setCanRepackage( project->canRepackage() );
           mProjects[i]->setNeedsRepackaging( project->needsRepackaging() );
           mProjects[i]->setSharedDatasetsProjectId( project->sharedDatasetsProjectId() );

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1285,36 +1285,49 @@ bool QFieldCloudProjectsFilterModel::lessThan( const QModelIndex &sourceLeft, co
 bool QFieldCloudProjectsFilterModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
 {
   const QModelIndex currentRowIndex = mSourceModel->index( source_row, 0, source_parent );
-
-  if ( mShowLocalOnly && mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::LocalPathRole ).toString().isEmpty() )
+  const QFieldCloudProject *project = mSourceModel->findProject( mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::IdRole ).toString() );
+  if ( !project )
   {
     return false;
   }
 
-  if ( !mIncludePublic )
+  if ( mShowLocalOnly && project->localPath().isEmpty() )
   {
-    if ( mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::UserRoleOriginRole ).toString() == QStringLiteral( "public" ) && mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::LocalPathRole ).toString().isEmpty() )
+    return false;
+  }
+
+  const bool isPublic = project->localPath().isEmpty() && project->userRoleOrigin() == QStringLiteral( "public" );
+  if ( mIncludePublic )
+  {
+    if ( project->remoteSizeBytes() == 0 && isPublic && project->updatedAt().toSecsSinceEpoch() - project->createdAt().toSecsSinceEpoch() < 300 )
+    {
+      // This is most likely an empty project, skip
+      return false;
+    }
+  }
+  else
+  {
+    if ( isPublic )
     {
       return false;
     }
   }
 
-  if ( !mShowInValidProjects && mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::StatusRole ).toInt() == static_cast<int>( QFieldCloudProject::ProjectStatus::Failing ) )
+  if ( !mShowInValidProjects && project->status() == QFieldCloudProject::ProjectStatus::Failing )
   {
     return false;
   }
 
   if ( !mOwnerFilter.isEmpty() )
   {
-    const QString owner = mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::OwnerRole ).toString();
-    if ( owner.compare( mOwnerFilter, Qt::CaseInsensitive ) != 0 )
+    if ( project->owner().compare( mOwnerFilter, Qt::CaseInsensitive ) != 0 )
     {
       return false;
     }
   }
 
-  const QString name = mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::NameRole ).toString();
-  const QString description = mSourceModel->data( currentRowIndex, QFieldCloudProjectsModel::DescriptionRole ).toString();
+  const QString name = project->name();
+  const QString description = project->description();
 
   if ( !mKeywordFilter.isEmpty() )
   {

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1401,7 +1401,7 @@ void QFieldCloudProjectsFilterModel::setTextFilter( const QString &text )
   mOwnerFilter = owner;
   mIncludePublic = includePublic;
 
-  if ( mSourceModel && ( !mOwnerFilter.isEmpty() || !mKeywordFilter.isEmpty() ) )
+  if ( mSourceModel && ( !mOwnerFilter.isEmpty() || searchTerm.size() > 1 ) )
   {
     mIsSearching = true;
     emit isSearchingChanged();

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -684,10 +684,10 @@ void QFieldCloudProjectsModel::setupProjectConnections( QFieldCloudProject *proj
     emit dataChanged( idx, idx, QVector<int>() << ProjectFileOutdatedRole );
   } );
 
-  connect( project, &QFieldCloudProject::downloaded, this, [this]( const QString &name, const QString &error ) {
+  connect( project, &QFieldCloudProject::downloaded, this, [this]( const QString &error ) {
     const QFieldCloudProject *p = static_cast<QFieldCloudProject *>( sender() );
     const QModelIndex idx = findProjectIndex( p->id() );
-    emit projectDownloaded( p->id(), name, !error.isEmpty(), error );
+    emit projectDownloaded( p->id(), p->name(), p->owner(), !error.isEmpty(), error );
     emit dataChanged( idx, idx, QVector<int>() << StatusRole << PackagingStatusRole << ErrorStatusRole << ErrorStringRole );
   } );
 

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -218,7 +218,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void projectCreated( const QString &projectId, const bool hasError = false, const QString &errorString = QString() );
     void projectAppended( const QString &projectId, const bool hasError = false, const QString &errorString = QString() );
     void projectsAppended( const QString &owner, const QString &search, const bool hasError = false, const QString &errorString = QString() );
-    void projectDownloaded( const QString &projectId, const QString &projectName, const bool hasError = false, const QString &errorString = QString() );
+    void projectDownloaded( const QString &projectId, const QString &projectName, const QString &projectOwner, const bool hasError = false, const QString &errorString = QString() );
     void pushFinished( const QString &projectId, bool isDownloadingProject, bool hasError = false, const QString &errorString = QString() );
 
     void deltaListModelChanged();

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -105,6 +105,10 @@ QString QFieldCloudUtils::userFriendlyErrorString( const QString &errorString )
   {
     resultErrorString = tr( "The project owner's available storage is full." );
   }
+  else if ( errorString.contains( errorCodePlanInsufficient() ) )
+  {
+    resultErrorString = tr( "The project owner's subscription plan is insufficient." );
+  }
 
   return resultErrorString;
 }
@@ -115,6 +119,7 @@ QString QFieldCloudUtils::documentationFromErrorString( const QString &errorStri
   {
     return QStringLiteral( "https://docs.qfield.org/get-started/storage-qfc/#adding-qfieldcloud-storage" );
   }
+
   return QString();
 }
 

--- a/src/core/utils/qfieldcloudutils.cpp
+++ b/src/core/utils/qfieldcloudutils.cpp
@@ -103,7 +103,7 @@ QString QFieldCloudUtils::userFriendlyErrorString( const QString &errorString )
 
   if ( errorString.contains( errorCodeOverQuota() ) )
   {
-    resultErrorString = tr( "Your account's available storage is full." );
+    resultErrorString = tr( "The project owner's available storage is full." );
   }
 
   return resultErrorString;

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -169,6 +169,7 @@ class QFieldCloudUtils : public QObject
     Q_OBJECT
 
     Q_PROPERTY( QString errorCodeOverQuota READ errorCodeOverQuota CONSTANT )
+    Q_PROPERTY( QString errorCodePlanInsufficient READ errorCodePlanInsufficient CONSTANT )
 
   public:
     /**
@@ -263,6 +264,7 @@ class QFieldCloudUtils : public QObject
     static void writeFileDetails( const QString &fileName, const QString &projectId, const QHash<QString, QString> *fileChecksumMap, const bool &checkSumCheck, QTextStream &attachmentsStream );
 
     static inline const QString errorCodeOverQuota() { return QStringLiteral( "over_quota" ); };
+    static inline const QString errorCodePlanInsufficient() { return QStringLiteral( "permission_denied_plan_insufficient" ); };
 };
 
 #endif // QFIELDCLOUDUTILS_H

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -764,7 +764,7 @@ Popup {
       }
     }
 
-    function onProjectDownloaded(projectId, projectName, hasError, errorString) {
+    function onProjectDownloaded(projectId, projectName, projectOwner, hasError, errorString) {
       if (hasError) {
         if (errorString.indexOf(`"code":"${QFieldCloudUtils.errorCodeOverQuota}"`) >= 0) {
           // Let the storage meter and the toast message inviting users to upgrade subscription
@@ -897,11 +897,11 @@ Popup {
   function projectPush(shouldDownloadUpdates) {
     if (shouldDownloadUpdates && storageMeterBar.value >= 1.0) {
       if (storageMeterBar.relatedUrl != "") {
-        displayToast(qsTr("Project %1 cannot be packaged as your account's available storage is full.").arg(ProjectUtils.title(qgisProject)), 'info', qsTr('Upgrade storage'), function () {
+        displayToast(qsTr("Project %1 cannot be packaged as yours available storage is full.").arg(ProjectUtils.title(qgisProject)), 'info', qsTr('Upgrade storage'), function () {
           Qt.openUrlExternally(storageMeterBar.relatedUrl);
         });
       } else {
-        displayToast(qsTr("Project %1 cannot be packaged as your account's available storage is full.").arg(ProjectUtils.title(qgisProject)), 'warning');
+        displayToast(qsTr("Project %1 cannot be packaged as the project owner's available storage is full.").arg(ProjectUtils.title(qgisProject)), 'warning');
       }
       return;
     }

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -897,7 +897,7 @@ Popup {
   function projectPush(shouldDownloadUpdates) {
     if (shouldDownloadUpdates && storageMeterBar.value >= 1.0) {
       if (storageMeterBar.relatedUrl != "") {
-        displayToast(qsTr("Project %1 cannot be packaged as yours available storage is full.").arg(ProjectUtils.title(qgisProject)), 'info', qsTr('Upgrade storage'), function () {
+        displayToast(qsTr("Project %1 cannot be packaged as your available storage is full.").arg(ProjectUtils.title(qgisProject)), 'info', qsTr('Upgrade storage'), function () {
           Qt.openUrlExternally(storageMeterBar.relatedUrl);
         });
       } else {

--- a/src/qml/QFieldCloudProjectDetails.qml
+++ b/src/qml/QFieldCloudProjectDetails.qml
@@ -132,6 +132,7 @@ ColumnLayout {
           color: Theme.mainTextColor
           wrapMode: Text.WordWrap
           textFormat: Text.MarkdownText
+          visible: text !== ""
 
           text: cloudProject != undefined ? cloudProject.description.trim() : ""
 

--- a/src/qml/QFieldCloudProjectDetails.qml
+++ b/src/qml/QFieldCloudProjectDetails.qml
@@ -145,6 +145,30 @@ ColumnLayout {
           spacing: 5
 
           Text {
+            id: projectDetailsStorageSizeLabel
+            Layout.fillWidth: true
+            font: Theme.strongFont
+            color: Theme.mainTextColor
+
+            text: qsTr("Storage size")
+          }
+
+          Text {
+            id: projectDetailsStorageSize
+            Layout.fillWidth: true
+            font: Theme.defaultFont
+            color: Theme.secondaryTextColor
+            wrapMode: Text.WordWrap
+
+            text: cloudProject != undefined ? FileUtils.representFileSize(cloudProject.remoteSizeBytes) : ""
+          }
+        }
+
+        ColumnLayout {
+          Layout.fillWidth: true
+          spacing: 5
+
+          Text {
             id: projectDetailsOwnerLabel
             Layout.fillWidth: true
             font: Theme.strongFont

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -213,6 +213,7 @@ Pane {
         editable: true
         Material.accent: Theme.mainColor
         font: Theme.defaultFont
+        inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
 
         onEditTextChanged: {
           updateQuery();

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -75,27 +75,12 @@ Pane {
   function updateQueryFromString(query) {
     blockQueryUpdate = true;
 
-    let searchTerm = [];
-    let owner = "";
-    let includePublic = false;
-
-    let parts = query.trim().split(/\s+/);
-    for (const part of parts) {
-      if (part.indexOf("owner:") === 0) {
-        owner = part.substring(6);
-      } else if (part.indexOf("include:public") === 0) {
-        includePublic = true;
-      } else {
-        searchTerm.push(part);
-      }
-    }
-
-    searchTermTextField.text = searchTerm.join(' ');
-    ownerComboBox.editText = owner;
-    includePublicSwitch.checked = includePublic;
+    const parameters = getQueryParametersFromString(query);
+    searchTermTextField.text = parameters["searchTerm"];
+    ownerComboBox.editText = parameters["owner"];
+    includePublicSwitch.checked = parameters["includePublic"];
 
     queryString = query;
-
     blockQueryUpdate = false;
 
     const preset = presets.find(preset => preset.query === queryString);
@@ -103,6 +88,29 @@ Pane {
     if (activePreset !== presetName) {
       activePreset = presetName;
     }
+  }
+
+  function getQueryParametersFromString(query) {
+    let parameters = {
+      "searchTerm": "",
+      "owner": "",
+      "includePublic": false
+    };
+
+    let searchTerm = [];
+    let parts = query.trim().split(/\s+/);
+    for (const part of parts) {
+      if (part.indexOf("owner:") === 0) {
+        parameters["owner"] = part.substring(6);
+      } else if (part.indexOf("include:public") === 0) {
+        parameters["includePublic"] = true;
+      } else {
+        searchTerm.push(part);
+      }
+    }
+    parameters["searchTerm"] = searchTerm.join(" ");
+
+    return parameters;
   }
 
   function clear() {

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -138,9 +138,7 @@ Pane {
     clip: true
 
     ColumnLayout {
-      width: filterPanel.width - 32
-      x: 16
-      y: 16
+      width: filterPanel.width
       spacing: 14
 
       Label {
@@ -247,7 +245,7 @@ Pane {
     anchors.bottom: parent.bottom
     anchors.left: parent.left
     anchors.right: parent.right
-    height: searchButton.height + 10
+    height: searchButton.height + 12
     color: "transparent"
 
     QfButton {

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -169,6 +169,8 @@ Pane {
             filterPanel.activePreset = modelData.id;
             if (filterPanel.queryString !== modelData.query) {
               updateQueryFromString(modelData.query);
+            } else {
+              filterPanel.applyFilter();
             }
           }
         }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -601,7 +601,7 @@ Page {
                 const parameters = projectFilter.getQueryParametersFromString(searchBar.searchTerm);
                 if (parameters["includePublic"] === false) {
                   if (cloudConnection.url == cloudConnection.defaultUrl) {
-                    labelText += "\n\n" + qsTr("Try to %1include public projects%2 and see what the commmunity has to offer.").arg("<a href=\"#includePublic\">").arg("</a>");
+                    labelText += "\n\n" + qsTr("Try to %1include public projects%2 and see what the community has to offer.").arg("<a href=\"#includePublic\">").arg("</a>");
                   } else {
                     labelText += "\n\n" + qsTr("Try to %1include public projects%2.").arg("<a href=\"#includePublic\">").arg("</a>");
                   }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -618,7 +618,6 @@ Page {
             id: projectFilter
             anchors.fill: parent
             visible: false
-            z: 1
 
             currentUsername: cloudConnection.username
 

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -532,34 +532,6 @@ Page {
               }
             }
 
-            Label {
-              anchors.fill: parent
-              anchors.margins: 20
-              visible: cloudConnection.status === QFieldCloudConnection.LoggedIn && parent.count === 0 && filterBar.currentIndex === 0
-              text: {
-                let labelText = "";
-                if (cloudProjectsModel.isRefreshing) {
-                  labelText = qsTr("Refreshing projects list...");
-                } else if (table.model.isSearching) {
-                  labelText = qsTr("Searching for projects...");
-                } else if (searchBar.searchTerm !== "") {
-                  labelText = qsTr("No cloud projects found.");
-                  if (searchBar.searchTerm.indexOf("include:public") === -1) {
-                    labelText += "\n\n<i>" + qsTr("Hint: try including public projects.") + "</i>";
-                  }
-                } else {
-                  labelText = qsTr("No cloud projects found.") + "\n\n" + qsTr("To get started, %1read the documentation%2.").arg("<a href=\"https://docs.qfield.org/get-started/tutorials/get-started-qfc/\">").arg("</a>");
-                }
-                return labelText;
-              }
-              textFormat: Text.MarkdownText
-              font: Theme.defaultFont
-              wrapMode: Text.WordWrap
-              horizontalAlignment: Text.AlignHCenter
-              verticalAlignment: Text.AlignVCenter
-              onLinkActivated: link => Qt.openUrlExternally(link)
-            }
-
             MouseArea {
               property Item pressedItem
               propagateComposedEvents: false
@@ -610,6 +582,45 @@ Page {
                   removeProject.visible = item.projectLocalPath !== '';
                   projectActions.popup(mouse.x, mouse.y);
                 }
+              }
+            }
+          }
+
+          Label {
+            anchors.fill: parent
+            anchors.margins: 20
+            visible: cloudConnection.status === QFieldCloudConnection.LoggedIn && filterBar.currentIndex === 0 && table.count === 0
+            text: {
+              let labelText = "";
+              if (cloudProjectsModel.isRefreshing) {
+                labelText = qsTr("Refreshing projects list...");
+              } else if (table.model.isSearching) {
+                labelText = qsTr("Searching for projects...");
+              } else if (searchBar.searchTerm.trim() !== "") {
+                labelText = qsTr("No cloud projects found.");
+                const parameters = projectFilter.getQueryParametersFromString(searchBar.searchTerm);
+                if (parameters["includePublic"] === false) {
+                  if (cloudConnection.url == cloudConnection.defaultUrl) {
+                    labelText += "\n\n" + qsTr("Try to %1include public projects%2 and see what the commmunity has to offer.").arg("<a href=\"#includePublic\">").arg("</a>");
+                  } else {
+                    labelText += "\n\n" + qsTr("Try to %1include public projects%2.").arg("<a href=\"#includePublic\">").arg("</a>");
+                  }
+                }
+              } else {
+                labelText = qsTr("No cloud projects found.") + "\n\n" + qsTr("To get started, %1read the documentation%2.").arg("<a href=\"https://docs.qfield.org/get-started/tutorials/get-started-qfc/\">").arg("</a>");
+              }
+              return labelText;
+            }
+            textFormat: Text.MarkdownText
+            font: Theme.defaultFont
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            onLinkActivated: link => {
+              if (link === "#includePublic") {
+                searchBar.setSearchTerm("include:public " + searchBar.searchTerm.trim());
+              } else {
+                Qt.openUrlExternally(link);
               }
             }
           }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -5155,15 +5155,15 @@ ApplicationWindow {
     layerObserver: layerObserverAlias
     gpkgFlusher: gpkgFlusherAlias
 
-    onProjectDownloaded: (projectId, projectName, hasError, errorString) => {
+    onProjectDownloaded: (projectId, projectName, projectOwner, hasError, errorString) => {
       if (hasError) {
         if (errorString.indexOf(`"code":"${QFieldCloudUtils.errorCodeOverQuota}"`) >= 0) {
-          if (cloudConnection.url == QFieldCloudConnection.defaultUrl) {
-            displayToast(qsTr("Project %1 cannot be packaged as your account's available storage is full.").arg(projectName), 'info', qsTr('Upgrade storage'), function () {
+          if (cloudConnection.username === projectOwner && cloudConnection.url == cloudConnection.defaultUrl) {
+            displayToast(qsTr("Project %1 cannot be packaged as your available storage is full.").arg(projectName), 'info', qsTr('Upgrade storage'), function () {
               Qt.openUrlExternally('https://app.qfield.cloud/plans');
             });
           } else {
-            displayToast(qsTr("Project %1 cannot be packaged as your account's available storage is full.").arg(projectName), 'warning');
+            displayToast(qsTr("Project %1 cannot be packaged as the project owner's available storage is full.").arg(projectName), 'warning');
           }
         } else {
           displayToast(qsTr("Project %1 failed to download").arg(projectName), 'error');

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -5157,13 +5157,22 @@ ApplicationWindow {
 
     onProjectDownloaded: (projectId, projectName, projectOwner, hasError, errorString) => {
       if (hasError) {
+        const ownerIsUser = cloudConnection.username === projectOwner;
         if (errorString.indexOf(`"code":"${QFieldCloudUtils.errorCodeOverQuota}"`) >= 0) {
-          if (cloudConnection.username === projectOwner && cloudConnection.url == cloudConnection.defaultUrl) {
+          if (ownerIsUser && cloudConnection.url == cloudConnection.defaultUrl) {
             displayToast(qsTr("Project %1 cannot be packaged as your available storage is full.").arg(projectName), 'info', qsTr('Upgrade storage'), function () {
               Qt.openUrlExternally('https://app.qfield.cloud/plans');
             });
           } else {
             displayToast(qsTr("Project %1 cannot be packaged as the project owner's available storage is full.").arg(projectName), 'warning');
+          }
+        } else if (errorString.indexOf(`"code":"${QFieldCloudUtils.errorCodePlanInsufficient}"`) >= 0) {
+          if (ownerIsUser && cloudConnection.url == cloudConnection.defaultUrl) {
+            displayToast(qsTr("Project %1 cannot be downloaded as your subscription plan is insufficient.").arg(projectName), 'info', qsTr('Upgrade plan'), function () {
+              Qt.openUrlExternally('https://app.qfield.cloud/plans');
+            });
+          } else {
+            displayToast(qsTr("Project %1 cannot be downloaded as the project owner's subscription plan is insufficient.").arg(projectName), 'warning');
           }
         } else {
           displayToast(qsTr("Project %1 failed to download").arg(projectName), 'error');


### PR DESCRIPTION
This fixes a couple of paper cuts I stumbled on when testing the functionality, as well as adding some nice tiny UI/UX improvements here and there.

Highlights include:
- when tapping twice on a predefined filter, QField will apply that filter and remove the need to manually click on the search button
- when searching for public projects, we now have a bit of logic to avoid showing countless empty projects
- the cloud project details page now includes storage file size information
- out of storage toast message now properly identify whether the logged in user is running out of storage vs. a different project owner
