### PR TITLE
Reduce the number of progress indicators in the cloud projects panel & improve QfButton visual progress report

### DIFF
--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -28,7 +28,7 @@ Page {
     showCancelButton: false
     showMenuButton: true
 
-    busyIndicatorState: cloudConnection.status === QFieldCloudConnection.Connecting || cloudConnection.state === QFieldCloudConnection.Busy ? 'on' : 'off' || cloudProjectsModel.busyProjectIds.length > 0
+    busyIndicatorState: cloudConnection.status === QFieldCloudConnection.Connecting ? 'on' : 'off'
     busyIndicatorValue: busyIndicatorState === 'on' ? 0 : 1
 
     topMargin: mainWindow.sceneTopMargin
@@ -656,6 +656,8 @@ Page {
             Layout.fillWidth: true
             text: qsTr("Refresh projects list")
             enabled: cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
+            showProgress: cloudProjectsModel.isRefreshing
+            progressValue: 0
             onClicked: {
               refreshProjectsList(true);
             }

--- a/src/qml/imports/Theme/QfButton.qml
+++ b/src/qml/imports/Theme/QfButton.qml
@@ -56,56 +56,99 @@ Button {
 
     Loader {
       active: showProgress
-      sourceComponent: progressValue == 0.0 ? indeterminateProgressComponent : progressComponent
+      sourceComponent: progressComponent
     }
 
     Component {
       id: progressComponent
-      Rectangle {
-        width: Math.max(24, backgroundRectangle.width * progressValue)
-        height: backgroundRectangle.height
-        topLeftRadius: backgroundRectangle.radius
-        bottomLeftRadius: backgroundRectangle.radius
-        topRightRadius: width >= backgroundRectangle.width - 24 ? 24 : 0
-        bottomRightRadius: width >= backgroundRectangle.width - 24 ? 24 : 0
-        color: Theme.mainColor
-        clip: true
 
-        Behavior on width {
-          NumberAnimation {
-            duration: 200
+      Shape {
+        x: progressPath.strokeWidth / 2
+        y: progressPath.strokeWidth / 2
+        ShapePath {
+          id: progressPath
+          strokeColor: Theme.mainColor
+          strokeWidth: 2
+          strokeStyle: ShapePath.DashLine
+          fillColor: "transparent"
+          capStyle: ShapePath.RoundCap
+
+          property real shapeWidth: button.width - progressPath.strokeWidth
+          property real shapeHeight: button.height - progressPath.strokeWidth
+          property real shapeRadius: button.radius - progressPath.strokeWidth
+          property real shapeLength: {
+            const circumferenceLength = 2 * Math.PI * progressPath.shapeRadius;
+            const straightLinesLength = 2 * (progressPath.shapeWidth - (2 * progressPath.shapeRadius)) + 2 * (progressPath.shapeHeight - (2 * progressPath.shapeRadius));
+            return (circumferenceLength + straightLinesLength) / progressPath.strokeWidth;
           }
-        }
-      }
-    }
-    Component {
-      id: indeterminateProgressComponent
-      Item {
-        width: backgroundRectangle.width
-        height: backgroundRectangle.height
-        clip: true
 
-        Rectangle {
-          id: bar
-          width: parent.width * 0.3
-          height: parent.height
-          radius: backgroundRectangle.radius
-          color: Theme.mainColor
-          opacity: 0.9
-          SequentialAnimation on x {
+          dashPattern: dashAnimation.running ? [progressPath.shapeLength * 0.2, progressPath.shapeLength - progressPath.shapeLength * 0.2] : [progressPath.shapeLength, progressPath.shapeLength * 2]
+          dashOffset: dashAnimation.running ? progressPath.shapeLength * progressPath.dashOffsetMultiplier : progressPath.shapeLength * (1 - button.progressValue)
+          property real dashOffsetMultiplier: 1
+          NumberAnimation on dashOffsetMultiplier {
+            id: dashAnimation
+            running: button.progressValue == 0
+            from: 1
+            to: 0
+            duration: 3000
             loops: Animation.Infinite
-            NumberAnimation {
-              from: -bar.width
-              to: parent.width
-              duration: 2000
-              easing.type: Easing.Linear
-            }
-            NumberAnimation {
-              from: parent.width
-              to: -bar.width
-              duration: 2000
-              easing.type: Easing.Linear
-            }
+            easing.type: Easing.Linear
+          }
+
+          startX: progressPath.shapeRadius
+          startY: 0
+
+          PathLine {
+            x: progressPath.shapeWidth - progressPath.shapeRadius
+            y: 0
+          }
+
+          PathArc {
+            x: progressPath.shapeWidth
+            y: progressPath.shapeRadius
+            radiusX: progressPath.shapeRadius
+            radiusY: progressPath.shapeRadius
+            useLargeArc: false
+            direction: PathArc.Clockwise
+          }
+
+          PathLine {
+            x: progressPath.shapeWidth
+            y: progressPath.shapeHeight - progressPath.shapeRadius
+          }
+
+          PathArc {
+            x: progressPath.shapeWidth - progressPath.shapeRadius
+            y: progressPath.shapeHeight
+            radiusX: progressPath.shapeRadius
+            radiusY: progressPath.shapeRadius
+            direction: PathArc.Clockwise
+          }
+
+          PathLine {
+            x: progressPath.shapeRadius
+            y: progressPath.shapeHeight
+          }
+
+          PathArc {
+            x: 0
+            y: progressPath.shapeHeight - progressPath.shapeRadius
+            radiusX: progressPath.shapeRadius
+            radiusY: progressPath.shapeRadius
+            direction: PathArc.Clockwise
+          }
+
+          PathLine {
+            x: 0
+            y: progressPath.shapeRadius
+          }
+
+          PathArc {
+            x: progressPath.shapeRadius
+            y: 0
+            radiusX: progressPath.shapeRadius
+            radiusY: progressPath.shapeRadius
+            direction: PathArc.Clockwise
           }
         }
       }


### PR DESCRIPTION
At any given time, the cloud projects panel was at risk of showing _multiple_ progress reports (sometimes even a mix of definite vs indefinite progress). This PR addresses that.

In addition, the PR improves the QfButton progress report by using an outer ring to show progress instead of a progressive button fill. Main positives include:

- We never impact the readability of the button label, which is a huge plus (the download project % label would get lost when we reached 70%+ progress for e.g.)
- When we get towards the 80-90%, nobody can mistake that progress for a re-enabled button
- A slightly less in-your-face / busy visual feedback
- Plays _a lot better_ alongside our curved corner button (the old style had a straight corner fill which was ... disturbing :) )

How it looks now:

https://github.com/user-attachments/assets/c863d283-2783-4ebf-9e5b-8caa6a928d8f
