### PR TITLE
Fix a couple of UI papercuts 

### DIFF
--- a/src/qml/BusyOverlay.qml
+++ b/src/qml/BusyOverlay.qml
@@ -95,7 +95,7 @@ Rectangle {
   Rectangle {
     id: busyCard
     anchors.centerIn: parent
-    width: Math.min(parent.width * 0.8, 320)
+    width: Math.min(parent.width * 0.8, 420)
     height: contentColumn.height + 24
     color: Theme.mainBackgroundColor
     radius: 12
@@ -114,7 +114,7 @@ Rectangle {
         font: Theme.defaultFont
         color: Theme.mainTextColor
         text: ''
-        wrapMode: Text.WordWrap
+        wrapMode: Text.Wrap
         visible: text.length > 0
       }
 

--- a/src/qml/QFieldCloudPackageLayersFeedback.qml
+++ b/src/qml/QFieldCloudPackageLayersFeedback.qml
@@ -16,33 +16,54 @@ QfDialog {
   width: mainWindow.width - Theme.popupScreenEdgeVerticalMargin * 2
   height: Math.min(300 + packagedLayersListView.contentHeight, mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
 
-  title: qsTr("QFieldCloud had troubles packaging your project")
-
   ColumnLayout {
     id: layout
     anchors.fill: parent
 
     Label {
       Layout.fillWidth: true
-      text: qsTr("Some layers have not been packaged correctly on QFieldCloud. These layers might be misconfigured or their data source is not accessible from the QFieldCloud server. Please check the logs of the latest packaging job on the qfield.cloud website.")
+      text: qsTr("Some layers have not been packaged correctly. These layers might be misconfigured or their data source is not accessible from the QFieldCloud server.")
+      font: Theme.defaultFont
       wrapMode: Text.WordWrap
     }
 
-    ListView {
-      id: packagedLayersListView
-      model: []
+    Label {
+      Layout.fillWidth: true
+      text: qsTr("Please check the detailed feedback below and the latest packaging job logs on the QFieldCloud website.")
+      font: Theme.defaultFont
+      wrapMode: Text.WordWrap
+    }
 
+    Rectangle {
       Layout.fillWidth: true
       Layout.fillHeight: true
       Layout.topMargin: 10
-      Layout.preferredHeight: contentHeight
+      Layout.preferredHeight: packagedLayersListView.contentHeight
+      color: Theme.controlBackgroundColor
+      border.color: Theme.controlBorderColor
+      border.width: 1
 
-      delegate: Text {
-        width: parent.width
-        text: modelData
-        font: Theme.resultFont
-        color: Theme.secondaryTextColor
-        wrapMode: Text.WordWrap
+      ListView {
+        id: packagedLayersListView
+        anchors.fill: parent
+        clip: true
+
+        model: []
+
+        delegate: Item {
+          width: ListView.view.width
+          height: descriptionText.contentHeight + 10
+
+          Text {
+            id: descriptionText
+            anchors.centerIn: parent
+            width: parent.width - 20
+            text: modelData
+            font: Theme.resultFont
+            color: Theme.secondaryTextColor
+            wrapMode: Text.Wrap
+          }
+        }
       }
     }
   }

--- a/src/qml/QFieldCloudProjectFilter.qml
+++ b/src/qml/QFieldCloudProjectFilter.qml
@@ -18,7 +18,7 @@ Pane {
     const list = [
       {
         id: "mine",
-        label: qsTr("My Own Projects"),
+        label: qsTr("My own projects"),
         query: "owner:" + filterPanel.currentUsername
       }
     ];

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -656,7 +656,7 @@ Page {
             Layout.fillWidth: true
             text: qsTr("Refresh projects list")
             enabled: cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudConnection.state === QFieldCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
-            showProgress: cloudProjectsModel.isRefreshing
+            showProgress: cloudProjectsModel.isRefreshing || table.model.isSearching
             progressValue: 0
             onClicked: {
               refreshProjectsList(true);


### PR DESCRIPTION
Stumbled upon when testing current build on master.

The one I'm really happy to see gone is this horror:

<img width="779" height="376" alt="Screenshot From 2026-05-19 10-46-07" src="https://github.com/user-attachments/assets/20d06c39-5a12-4d18-afaa-1e678411197c" />

With PR:

<img width="779" height="376" alt="Screenshot From 2026-05-19 10-47-12" src="https://github.com/user-attachments/assets/6cff749e-d42c-44fe-8873-749feede04a5" />

