### PR TITLE
When synchronizing a cloud project, insure a single project qgs/qgz file remain

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -852,6 +852,26 @@ void QFieldCloudProject::download()
       const QString cloudEtag = fileObject.value( QStringLiteral( "md5sum" ) ).toString();
       const QString localEtag = FileUtils::fileEtag( projectFileName );
 
+      QFileInfo fileInfo( projectFileName );
+      if ( fileInfo.suffix().toLower() == QStringLiteral( "qgs" ) || fileInfo.suffix().toLower() == QStringLiteral( "qgz" ) )
+      {
+        // Clear up all pre-exsting project files to insure the presence of a single, up-to-date project file
+        QDirIterator projectDirIterator( QStringLiteral( "%1/%2/%3" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, mId ), { "*.qgs", "*.qgz" }, QDir::Files, QDirIterator::Subdirectories );
+        while ( projectDirIterator.hasNext() )
+        {
+          projectDirIterator.next();
+          QFileInfo projectFileInfo = projectDirIterator.fileInfo();
+          if ( projectFileInfo.absoluteFilePath() != fileInfo.absoluteFilePath() )
+          {
+#ifdef Q_OS_WIN
+            QFile::setPermissions( projectFileInfo.absoluteFilePath(), QFileDevice::ReadUser | QFileDevice::WriteUser | QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ReadGroup | QFileDevice::WriteGroup );
+#endif
+            QFile::remove( projectFileInfo.absoluteFilePath() );
+          }
+        }
+        setLocalPath( QFieldCloudUtils::localProjectFilePath( mUsername, mId ) );
+      }
+
       if ( !fileObject.value( QStringLiteral( "size" ) ).isDouble() || fileName.isEmpty() || cloudEtag.isEmpty() )
       {
         QgsLogger::debug( QStringLiteral( "Project %1: package in \"files\" list does not contain the expected fields: size(int), name(string), md5sum(string)" ).arg( mId ) );
@@ -1383,7 +1403,7 @@ void QFieldCloudProject::downloadFilesCompleted( bool emptyDownload )
         }
       }
 
-      AppInterface::instance()->reloadProject();
+      AppInterface::instance()->loadFile( QFieldCloudUtils::localProjectFilePath( mUsername, mId ), mName );
     }
   }
 
@@ -1466,7 +1486,6 @@ bool QFieldCloudProject::moveDownloadedFilesToPermanentStorage()
 {
   bool hasError = false;
   const QStringList fileKeys = mDownloadFileTransfers.keys();
-
   for ( const QString &fileKey : fileKeys )
   {
     const FileTransfer &fileTransfer = mDownloadFileTransfers[fileKey];


### PR DESCRIPTION
Important fix for a long standing issue that started impacting way more people.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opengisch/codesmith/QField/pr/7455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782019140&installation_id=134336693&pr_number=7455&repository=opengisch%2FQField&return_to=https%3A%2F%2Fgithub.com%2Fopengisch%2FQField%2Fpull%2F7455&signature=54978ec8dafd5763e55758a2d19408e35ceb6d1e7782c648a408fbe6c3ffdced"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->