### PR TITLE
Hide sensors menu item when project has no sensors

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3579,7 +3579,8 @@ ApplicationWindow {
 
       font: Theme.defaultFont
       icon.source: Theme.getThemeVectorIcon("ic_sensor_on_black_24dp")
-      height: 48
+      height: visible ? 48 : 0
+      visible: sensorListInstantiator.count > 0
       leftPadding: Theme.menuItemLeftPadding
       rightPadding: 40
 
@@ -3627,6 +3628,8 @@ ApplicationWindow {
 
     MenuSeparator {
       width: parent.width
+      visible: sensorListInstantiator.count > 0
+      height: visible ? undefined : 0
     }
 
     MenuItem {


### PR DESCRIPTION
The Sensors entry in the main menu (and its separator) was shown unconditionally, even though most projects have no sensors configured. Tapping it in those cases just showed a "No sensor available" toast.

Bind visibility of both the menu item and its separator to sensorListInstantiator.count > 0 so they only appear when the project actually has sensors.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/opengisch/codesmith/QField/pr/7461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782100977&installation_id=134336693&pr_number=7461&repository=opengisch%2FQField&return_to=https%3A%2F%2Fgithub.com%2Fopengisch%2FQField%2Fpull%2F7461&signature=ef0a7c00f519a78595ae2c8f2d25bc719881550475a734d75d1efcecfcd326f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->