### PR TITLE
Unlock cloud protect QR code that rely on owner name / project nane

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -206,16 +206,25 @@ QModelIndex QFieldCloudProjectsModel::findProjectIndex( const QString &projectId
     return QModelIndex();
   }
 
+  QString projectOwner;
+  QString projectName;
+  const int separator = projectId.indexOf( '/' );
+  if ( separator > 0 )
+  {
+    projectOwner = projectId.mid( 0, separator ).trimmed();
+    projectName = projectId.mid( separator + 1 ).trimmed();
+  }
+  bool matchOwnerAndName = !projectOwner.isEmpty() && !projectName.isEmpty();
+
   for ( int i = 0; i < mProjects.count(); i++ )
   {
-    if ( mProjects.at( i )->id() == projectId )
+    if ( ( !matchOwnerAndName && mProjects.at( i )->id() == projectId ) || ( matchOwnerAndName && mProjects.at( i )->owner() == projectOwner && mProjects.at( i )->name() == projectName ) )
     {
       return createIndex( i, 0 );
     }
   }
 
   QgsLogger::debug( QStringLiteral( "No project found with the provided id: `%1`" ).arg( projectId ) );
-
   return QModelIndex();
 }
 
@@ -245,14 +254,36 @@ void QFieldCloudProjectsModel::appendProject( const QString &projectId )
     return;
   }
 
-  const QString url = QStringLiteral( "/api/v1/projects/%1/" ).arg( projectId );
+  QString projectOwner;
+  QString projectName;
+  const int separator = projectId.indexOf( '/' );
+  if ( separator > 0 )
+  {
+    projectOwner = projectId.mid( 0, separator ).trimmed();
+    projectName = projectId.mid( separator + 1 ).trimmed();
+  }
+
+  QString url;
+  QVariantMap params;
+  if ( !projectOwner.isEmpty() && !projectName.isEmpty() )
+  {
+    params["owner"] = projectOwner;
+    params["name"] = projectName;
+    params["include_public"] = 1;
+    url = QStringLiteral( "/api/v1/projects/" );
+  }
+  else
+  {
+    url = QStringLiteral( "/api/v1/projects/%1/" ).arg( projectId );
+  }
+
   QNetworkRequest request( url );
   request.setHeader( QNetworkRequest::ContentTypeHeader, "application/json" );
   request.setAttribute( QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::RedirectPolicy::NoLessSafeRedirectPolicy );
   request.setAttribute( static_cast<QNetworkRequest::Attribute>( QFieldCloudProjectsModel::ProjectsRequestAttribute::ProjectId ), projectId );
   mCloudConnection->setAuthenticationDetails( request );
 
-  const NetworkReply *reply = mCloudConnection->get( request, url );
+  const NetworkReply *reply = mCloudConnection->get( request, url, params );
   connect( reply, &NetworkReply::finished, this, &QFieldCloudProjectsModel::projectReceived );
 }
 
@@ -509,7 +540,7 @@ void QFieldCloudProjectsModel::projectReceived()
   if ( cloudProject )
   {
     insertProjects( QList<QFieldCloudProject *>() << cloudProject );
-    emit projectAppended( cloudProject->id() );
+    emit projectAppended( projectId );
   }
 }
 

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -534,13 +534,32 @@ void QFieldCloudProjectsModel::projectReceived()
 
   QByteArray response = rawReply->readAll();
   QJsonDocument doc = QJsonDocument::fromJson( response );
-  QVariantHash projectDetails = doc.object().toVariantHash();
-
-  QFieldCloudProject *cloudProject = QFieldCloudProject::fromDetails( projectDetails, mCloudConnection, mGpkgFlusher ); // cppcheck-suppress constVariablePointer
-  if ( cloudProject )
+  QVariantHash projectDetails;
+  if ( doc.isArray() )
   {
-    insertProjects( QList<QFieldCloudProject *>() << cloudProject );
-    emit projectAppended( projectId );
+    QJsonArray projects = doc.array();
+    if ( !projects.isEmpty() )
+    {
+      projectDetails = projects.first().toObject().toVariantHash();
+    }
+  }
+  else
+  {
+    QJsonObject project = doc.object();
+    if ( !project.isEmpty() )
+    {
+      projectDetails = doc.object().toVariantHash();
+    }
+  }
+
+  if ( !projectDetails.isEmpty() )
+  {
+    QFieldCloudProject *cloudProject = QFieldCloudProject::fromDetails( projectDetails, mCloudConnection, mGpkgFlusher ); // cppcheck-suppress constVariablePointer
+    if ( cloudProject )
+    {
+      insertProjects( QList<QFieldCloudProject *>() << cloudProject );
+      emit projectAppended( projectId );
+    }
   }
 }
 

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -537,7 +537,7 @@ void QFieldCloudProjectsModel::projectReceived()
   QVariantHash projectDetails;
   if ( doc.isArray() )
   {
-    QJsonArray projects = doc.array();
+    const QJsonArray projects = doc.array();
     if ( !projects.isEmpty() )
     {
       projectDetails = projects.first().toObject().toVariantHash();
@@ -545,10 +545,10 @@ void QFieldCloudProjectsModel::projectReceived()
   }
   else
   {
-    QJsonObject project = doc.object();
+    const QJsonObject project = doc.object();
     if ( !project.isEmpty() )
     {
-      projectDetails = doc.object().toVariantHash();
+      projectDetails = project.toVariantHash();
     }
   }
 

--- a/src/qml/QFieldCloudProjectDetails.qml
+++ b/src/qml/QFieldCloudProjectDetails.qml
@@ -260,7 +260,7 @@ ColumnLayout {
             sourceSize.width: desiredWidth * Screen.devicePixelRatio
             sourceSize.height: desiredWidth * Screen.devicePixelRatio
             source: cloudProject != undefined ? "image://barcode/?text=" + encodeURIComponent(UrlUtils.createActionUrl("qfield", "cloud", {
-              "project": cloudProject.id
+              "project": cloudProject.owner + '/' + cloudProject.name
             })) + "&color=" + encodeURIComponent(Theme.mainColor) : ""
             property int desiredWidth: Math.min(mainWindow.width - 40, 250)
           }


### PR DESCRIPTION
A fair more user friendly way to refer to a cloud project.

In the past, the QR code for a given cloud project looked like this:

`qfield://cloud?project=2e6e3fc9-8adf-4c27-9348-ad035079a236`

That UUID is not user friendly at all, and we do not expose that to the average user (i.e. it's only visible if you go through `/api/v1/projects`).

Months ago, we added the ability to search for a given project provided a pair of owner and project name. It's been deployed long enough for us to rely on it to support much a friendlier QR code format. This PR enables this as a valid QR code:

`qfield://cloud?project=username/ProjectName`

:partying_face: 

This means when people explore the QR codes we expose in the QField UI, they will more easily be able to make their own.

In addition, for plugins, they can now use iface.itemByName("cloudProjectsModel").appendProject("username/ProjectName"), which is also friendlier than the UUID.