### PR TITLE
We store the timestamp value in a track's M dimension as _seconds_ since epoch

### DIFF
--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -1604,7 +1604,7 @@ Page {
                 property bool loaded: false
                 Component.onCompleted: {
                   // This list matches the Tracker::MeasureType enum, with SecondsSinceStart removed
-                  var measurements = [qsTr("Timestamp (milliseconds since epoch)"), qsTr("Ground speed"), qsTr("Bearing"), qsTr("Horizontal accuracy"), qsTr("Vertical accuracy"), qsTr("PDOP"), qsTr("HDOP"), qsTr("VDOP")];
+                  var measurements = [qsTr("Timestamp (seconds since epoch)"), qsTr("Ground speed"), qsTr("Bearing"), qsTr("Horizontal accuracy"), qsTr("Vertical accuracy"), qsTr("PDOP"), qsTr("HDOP"), qsTr("VDOP")];
                   measureComboBox.model = measurements;
                   measureComboBox.currentIndex = positioningSettings.digitizingMeasureType - 1;
                   loaded = true;

--- a/src/qml/TrackerSettings.qml
+++ b/src/qml/TrackerSettings.qml
@@ -522,7 +522,7 @@ QfPopup {
           property bool loaded: false
           Component.onCompleted: {
             // This list matches the Tracker::MeasureType enum
-            var measurements = [qsTr("Elapsed time (seconds since start of tracking)"), qsTr("Timestamp (milliseconds since epoch)"), qsTr("Ground speed"), qsTr("Bearing"), qsTr("Horizontal accuracy"), qsTr("Vertical accuracy"), qsTr("PDOP"), qsTr("HDOP"), qsTr("VDOP")];
+            var measurements = [qsTr("Elapsed time (seconds since start of tracking)"), qsTr("Timestamp (seconds since epoch)"), qsTr("Ground speed"), qsTr("Bearing"), qsTr("Horizontal accuracy"), qsTr("Vertical accuracy"), qsTr("PDOP"), qsTr("HDOP"), qsTr("VDOP")];
             model = measurements;
             loaded = true;
           }


### PR DESCRIPTION
Proof: https://github.com/opengisch/QField/blob/master/src/core/tracker.cpp#L349