### PR TITLE
Hide register link when server doesn't allow signups

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfieldcloudconnection.cpp
@@ -44,6 +44,11 @@ QFieldCloudConnection::QFieldCloudConnection()
   , mProviderConfigId( QSettings().value( QStringLiteral( "/QFieldCloud/providerConfigId" ) ).toString() )
   , mServerInformation( QSettings().value( QStringLiteral( "/QFieldCloud/serverInformation" ) ).toMap() )
 {
+  if ( mUrl == defaultUrl() && mServerInformation.signupUrl.isEmpty() )
+  {
+    mServerInformation.signupUrl = QStringLiteral( "https://app.qfield.cloud/accounts/signup/" );
+  }
+
   if ( !QgsApplication::authManager()->availableAuthMethodConfigs().contains( mProviderConfigId ) )
   {
     mProviderConfigId.clear();

--- a/src/core/qfieldcloud/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfieldcloudconnection.cpp
@@ -42,8 +42,7 @@ QFieldCloudConnection::QFieldCloudConnection()
   , mTokenConfigId( QSettings().value( QStringLiteral( "/QFieldCloud/tokenConfigId" ) ).toString() )
   , mProvider( QSettings().value( QStringLiteral( "/QFieldCloud/provider" ) ).toString() )
   , mProviderConfigId( QSettings().value( QStringLiteral( "/QFieldCloud/providerConfigId" ) ).toString() )
-  , mWhitelabel( QSettings().value( QStringLiteral( "/QFieldCloud/whitelabel" ) ).toMap() )
-  , mSignupUrl( QSettings().value( QStringLiteral( "/QFieldCloud/signupUrl" ) ).toString() )
+  , mServerInformation( QSettings().value( QStringLiteral( "/QFieldCloud/serverInformation" ) ).toMap() )
 {
   if ( !QgsApplication::authManager()->availableAuthMethodConfigs().contains( mProviderConfigId ) )
   {
@@ -188,18 +187,11 @@ void QFieldCloudConnection::setUrl( const QString &url )
   mUrl = url;
   QSettings().setValue( QStringLiteral( "/QFieldCloud/url" ), url );
 
-  if ( mWhitelabel != CloudWhitelabelInformation() )
+  if ( mServerInformation != CloudServerInformation() )
   {
-    mWhitelabel = CloudWhitelabelInformation();
-    QSettings().remove( QStringLiteral( "/QFieldCloud/whitelabel" ) );
-    emit whitelabelChanged();
-  }
-
-  if ( !mSignupUrl.isEmpty() )
-  {
-    mSignupUrl.clear();
-    QSettings().remove( QStringLiteral( "/QFieldCloud/signupUrl" ) );
-    emit signupUrlChanged();
+    mServerInformation = CloudServerInformation();
+    QSettings().remove( QStringLiteral( "/QFieldCloud/serverInformation" ) );
+    emit serverInformationChanged();
   }
 
   if ( mStatus != ConnectionStatus::Disconnected )
@@ -355,20 +347,12 @@ void QFieldCloudConnection::getServerInformation()
 
     const QVariantMap payload = QJsonDocument::fromJson( rawReply->readAll() ).toVariant().toMap();
 
-    const CloudWhitelabelInformation whitelabel( payload.value( QStringLiteral( "whitelabel" ) ).toMap() );
-    if ( whitelabel != mWhitelabel )
+    const CloudServerInformation serverInformation( payload );
+    if ( serverInformation != mServerInformation )
     {
-      mWhitelabel = whitelabel;
-      QSettings().setValue( QStringLiteral( "/QFieldCloud/whitelabel" ), mWhitelabel.toVariantMap() );
-      emit whitelabelChanged();
-    }
-
-    const QString signupUrl = payload.value( QStringLiteral( "signup_url" ) ).toString();
-    if ( signupUrl != mSignupUrl )
-    {
-      mSignupUrl = signupUrl;
-      QSettings().setValue( QStringLiteral( "/QFieldCloud/signupUrl" ), mSignupUrl );
-      emit signupUrlChanged();
+      mServerInformation = serverInformation;
+      QSettings().setValue( QStringLiteral( "/QFieldCloud/serverInformation" ), mServerInformation.toVariantMap() );
+      emit serverInformationChanged();
     }
 
     const QVariantList providers = payload.value( QStringLiteral( "auth_providers" ) ).toList();

--- a/src/core/qfieldcloud/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfieldcloudconnection.cpp
@@ -43,6 +43,7 @@ QFieldCloudConnection::QFieldCloudConnection()
   , mProvider( QSettings().value( QStringLiteral( "/QFieldCloud/provider" ) ).toString() )
   , mProviderConfigId( QSettings().value( QStringLiteral( "/QFieldCloud/providerConfigId" ) ).toString() )
   , mWhitelabel( QSettings().value( QStringLiteral( "/QFieldCloud/whitelabel" ) ).toMap() )
+  , mSignupUrl( QSettings().value( QStringLiteral( "/QFieldCloud/signupUrl" ) ).toString() )
 {
   if ( !QgsApplication::authManager()->availableAuthMethodConfigs().contains( mProviderConfigId ) )
   {
@@ -192,6 +193,13 @@ void QFieldCloudConnection::setUrl( const QString &url )
     mWhitelabel = CloudWhitelabelInformation();
     QSettings().remove( QStringLiteral( "/QFieldCloud/whitelabel" ) );
     emit whitelabelChanged();
+  }
+
+  if ( !mSignupUrl.isEmpty() )
+  {
+    mSignupUrl.clear();
+    QSettings().remove( QStringLiteral( "/QFieldCloud/signupUrl" ) );
+    emit signupUrlChanged();
   }
 
   if ( mStatus != ConnectionStatus::Disconnected )
@@ -353,6 +361,14 @@ void QFieldCloudConnection::getServerInformation()
       mWhitelabel = whitelabel;
       QSettings().setValue( QStringLiteral( "/QFieldCloud/whitelabel" ), mWhitelabel.toVariantMap() );
       emit whitelabelChanged();
+    }
+
+    const QString signupUrl = payload.value( QStringLiteral( "signup_url" ) ).toString();
+    if ( signupUrl != mSignupUrl )
+    {
+      mSignupUrl = signupUrl;
+      QSettings().setValue( QStringLiteral( "/QFieldCloud/signupUrl" ), mSignupUrl );
+      emit signupUrlChanged();
     }
 
     const QVariantList providers = payload.value( QStringLiteral( "auth_providers" ) ).toList();

--- a/src/core/qfieldcloud/qfieldcloudconnection.h
+++ b/src/core/qfieldcloud/qfieldcloudconnection.h
@@ -87,6 +87,7 @@ class QFieldCloudConnection : public QObject
     Q_PROPERTY( bool isFetchingAvailableProviders READ isFetchingAvailableProviders NOTIFY isFetchingAvailableProvidersChanged )
 
     Q_PROPERTY( CloudWhitelabelInformation whitelabel READ whitelabel NOTIFY whitelabelChanged )
+    Q_PROPERTY( QString signupUrl READ signupUrl NOTIFY signupUrlChanged )
 
     Q_PROPERTY( bool isReachable READ isReachable NOTIFY isReachableChanged )
 
@@ -179,6 +180,7 @@ class QFieldCloudConnection : public QObject
     bool isFetchingAvailableProviders() const;
 
     CloudWhitelabelInformation whitelabel() const { return mWhitelabel; }
+    QString signupUrl() const { return mSignupUrl; }
 
     ConnectionStatus status() const;
     ConnectionState state() const;
@@ -268,6 +270,7 @@ class QFieldCloudConnection : public QObject
     void availableProvidersChanged();
     void isFetchingAvailableProvidersChanged();
     void whitelabelChanged();
+    void signupUrlChanged();
 
     void isReachableChanged();
     void queuedProjectPushRequested( const QString &projectId );
@@ -299,6 +302,7 @@ class QFieldCloudConnection : public QObject
     QString mProviderConfigId;
 
     CloudWhitelabelInformation mWhitelabel;
+    QString mSignupUrl;
 
     QString mAvatarUrl;
     CloudUserInformation mUserInformation;

--- a/src/core/qfieldcloud/qfieldcloudconnection.h
+++ b/src/core/qfieldcloud/qfieldcloudconnection.h
@@ -86,8 +86,7 @@ class QFieldCloudConnection : public QObject
     Q_PROPERTY( QList<AuthenticationProvider> availableProviders READ availableProviders NOTIFY availableProvidersChanged )
     Q_PROPERTY( bool isFetchingAvailableProviders READ isFetchingAvailableProviders NOTIFY isFetchingAvailableProvidersChanged )
 
-    Q_PROPERTY( CloudWhitelabelInformation whitelabel READ whitelabel NOTIFY whitelabelChanged )
-    Q_PROPERTY( QString signupUrl READ signupUrl NOTIFY signupUrlChanged )
+    Q_PROPERTY( CloudServerInformation serverInformation READ serverInformation NOTIFY serverInformationChanged )
 
     Q_PROPERTY( bool isReachable READ isReachable NOTIFY isReachableChanged )
 
@@ -179,8 +178,7 @@ class QFieldCloudConnection : public QObject
     QList<AuthenticationProvider> availableProviders() const;
     bool isFetchingAvailableProviders() const;
 
-    CloudWhitelabelInformation whitelabel() const { return mWhitelabel; }
-    QString signupUrl() const { return mSignupUrl; }
+    CloudServerInformation serverInformation() const { return mServerInformation; }
 
     ConnectionStatus status() const;
     ConnectionState state() const;
@@ -269,8 +267,7 @@ class QFieldCloudConnection : public QObject
 
     void availableProvidersChanged();
     void isFetchingAvailableProvidersChanged();
-    void whitelabelChanged();
-    void signupUrlChanged();
+    void serverInformationChanged();
 
     void isReachableChanged();
     void queuedProjectPushRequested( const QString &projectId );
@@ -301,8 +298,7 @@ class QFieldCloudConnection : public QObject
     QString mProvider;
     QString mProviderConfigId;
 
-    CloudWhitelabelInformation mWhitelabel;
-    QString mSignupUrl;
+    CloudServerInformation mServerInformation;
 
     QString mAvatarUrl;
     CloudUserInformation mUserInformation;

--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -163,6 +163,51 @@ Q_DECLARE_METATYPE( CloudWhitelabelInformation )
 
 /**
  * \ingroup core
+ *
+ * Public information about a QFieldCloud server, including whitelabel
+ * branding and the new-user signup URL.
+ */
+struct CloudServerInformation
+{
+    Q_GADGET
+
+    Q_PROPERTY( CloudWhitelabelInformation whitelabel MEMBER whitelabel )
+    Q_PROPERTY( QString signupUrl MEMBER signupUrl )
+
+  public:
+    CloudServerInformation() = default;
+
+    explicit CloudServerInformation( const QVariantMap &serverInformation )
+      : whitelabel( serverInformation.value( QStringLiteral( "whitelabel" ) ).toMap() )
+      , signupUrl( serverInformation.value( QStringLiteral( "signup_url" ) ).toString() )
+    {}
+
+    bool operator==( const CloudServerInformation &other ) const
+    {
+      return whitelabel == other.whitelabel && signupUrl == other.signupUrl;
+    }
+
+    bool operator!=( const CloudServerInformation &other ) const
+    {
+      return !( *this == other );
+    }
+
+    QVariantMap toVariantMap() const
+    {
+      return {
+        { QStringLiteral( "whitelabel" ), whitelabel.toVariantMap() },
+        { QStringLiteral( "signup_url" ), signupUrl },
+      };
+    }
+
+    CloudWhitelabelInformation whitelabel;
+    QString signupUrl;
+};
+
+Q_DECLARE_METATYPE( CloudServerInformation )
+
+/**
+ * \ingroup core
  */
 class QFieldCloudUtils : public QObject
 {

--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -128,8 +128,9 @@ Item {
         enabled: visible
         font: Theme.defaultFont
         horizontalAlignment: Text.AlignLeft
-
         text: parent.displayText
+        selectionColor: Theme.mainColor
+        selectedTextColor: Theme.light
         onTextChanged: {
           const cleanedText = text.replace(/\s+/g, '');
           if (cleanedText !== cloudConnection.url) {
@@ -263,13 +264,13 @@ Item {
       id: cloudRegisterLabel
       Layout.fillWidth: true
       Layout.topMargin: 16
-      text: qsTr('New user?') + ' <a href="https://app.qfield.cloud/accounts/signup/">' + qsTr('Register an account') + '</a>.'
+      text: cloudConnection.signupUrl !== '' ? qsTr('New user?') + ' <a href="' + cloudConnection.signupUrl + '">' + qsTr('Register an account') + '</a>.' : ''
       horizontalAlignment: Text.AlignHCenter
       font: Theme.defaultFont
       color: Theme.mainTextColor
       textFormat: Text.RichText
       wrapMode: Text.WordWrap
-      visible: cloudConnection.status === QFieldCloudConnection.Disconnected
+      visible: cloudConnection.status === QFieldCloudConnection.Disconnected && cloudConnection.signupUrl !== ''
 
       onLinkActivated: link => {
         if (Qt.platform.os === "ios" || Qt.platform.os === "android") {

--- a/src/qml/QFieldCloudLogin.qml
+++ b/src/qml/QFieldCloudLogin.qml
@@ -36,7 +36,7 @@ Item {
       Layout.maximumHeight: 210
       fillMode: Image.PreserveAspectFit
       smooth: true
-      source: cloudConnection.url != cloudConnection.defaultUrl && cloudConnection.whitelabel.logoMain !== '' ? cloudConnection.whitelabel.logoMain : "qrc:/images/qfieldcloud_logo.svg"
+      source: cloudConnection.url != cloudConnection.defaultUrl && cloudConnection.serverInformation.whitelabel.logoMain !== '' ? cloudConnection.serverInformation.whitelabel.logoMain : "qrc:/images/qfieldcloud_logo.svg"
 
       onStatusChanged: {
         // In case the whitelabel logo fails to load, revert to the default QFieldCloud logo
@@ -87,7 +87,7 @@ Item {
       id: serverUrlLabel
       Layout.fillWidth: true
       visible: cloudConnection.status === QFieldCloudConnection.Disconnected && (cloudConnection.url !== cloudConnection.defaultUrl || isServerUrlEditingActive)
-      text: qsTr("%1Server URL\n(Leave empty to use the default server)").arg(cloudConnection.whitelabel.siteTitle !== '' ? cloudConnection.whitelabel.siteTitle + ' ' : '')
+      text: qsTr("%1Server URL\n(Leave empty to use the default server)").arg(cloudConnection.serverInformation.whitelabel.siteTitle !== '' ? cloudConnection.serverInformation.whitelabel.siteTitle + ' ' : '')
       horizontalAlignment: Text.AlignHCenter
       font: Theme.defaultFont
       color: Theme.secondaryTextColor
@@ -264,13 +264,13 @@ Item {
       id: cloudRegisterLabel
       Layout.fillWidth: true
       Layout.topMargin: 16
-      text: cloudConnection.signupUrl !== '' ? qsTr('New user?') + ' <a href="' + cloudConnection.signupUrl + '">' + qsTr('Register an account') + '</a>.' : ''
+      text: cloudConnection.serverInformation.signupUrl !== '' ? qsTr('New user?') + ' <a href="' + cloudConnection.serverInformation.signupUrl + '">' + qsTr('Register an account') + '</a>.' : ''
       horizontalAlignment: Text.AlignHCenter
       font: Theme.defaultFont
       color: Theme.mainTextColor
       textFormat: Text.RichText
       wrapMode: Text.WordWrap
-      visible: cloudConnection.status === QFieldCloudConnection.Disconnected && cloudConnection.signupUrl !== ''
+      visible: cloudConnection.status === QFieldCloudConnection.Disconnected && cloudConnection.serverInformation.signupUrl !== ''
 
       onLinkActivated: link => {
         if (Qt.platform.os === "ios" || Qt.platform.os === "android") {

--- a/test/qml/tst_qfieldCloudLoginUI.qml
+++ b/test/qml/tst_qfieldCloudLoginUI.qml
@@ -118,8 +118,11 @@ TestCase {
     compare(cloudConnection.status, QFieldCloudConnection.Disconnected);
     verify(usernameField.visible);
     verify(passwordField.visible);
-    verify(cloudRegisterLabel.visible);
+    // Register label requires a signup URL from server info, verify after fetch
     cloudConnection.url = data.url;
+    cloudConnection.getServerInformation();
+    tryCompare(cloudConnection, "isFetchingAvailableProviders", false, 10000);
+    verify(cloudRegisterLabel.visible);
     cloudConnection.username = data.username;
     cloudConnection.login(data.password);
     wait(5000);


### PR DESCRIPTION
Qfield currently always shows a "Register an account" link pointing to a hardcoded app.qfield.cloud URL. Now after a nice update made to qfieldcloudsync here
https://github.com/opengisch/QFieldCloud/pull/1610

This pr wires qfield up to the new `signup_url` field exposed by qfieldcloud `/api/v1/server/info/` endpoint:

- If `signup_url` is a non-empty string, the link is shown and points to that url
- If `signup_url` is null, empty, or missing (older servers), the link is hidden entirely

The value is persisted in QSettings alongside the existing whitelabel info and cleared on server url change, mirroring the whitelabel pattern

> Tested against app.qfield.cloud (link visible, opens the signup page) and against an unreachable url (link correctly hidden after server switch)