### PR TITLE
Add GNSS device battery level reporting, plug in for BLE devices

### DIFF
--- a/src/core/positioning/abstractgnssreceiver.h
+++ b/src/core/positioning/abstractgnssreceiver.h
@@ -57,6 +57,8 @@ class AbstractGnssReceiver : public QObject
 
     QString lastError() const { return mLastError; }
 
+    double barreryLevel() const { return mBatteryLevel; }
+
     /**
      * Returns extra details (such as hdop, vdop, pdop) provided by the positioning device.
      */
@@ -73,6 +75,7 @@ class AbstractGnssReceiver : public QObject
     void socketStateChanged( const QAbstractSocket::SocketState socketState );
     void socketStateStringChanged( const QString &socketStateString );
     void lastErrorChanged( const QString &lastError );
+    void batteryLevelChanged( const double batteryLevel );
 
   public slots:
     virtual void onCorrectionDataReceived( const QByteArray &data ) {}
@@ -97,6 +100,7 @@ class AbstractGnssReceiver : public QObject
     GnssPositionInformation mLastGnssPositionInformation;
     QAbstractSocket::SocketState mSocketState = QAbstractSocket::UnconnectedState;
     QString mLastError;
+    double mBatteryLevel = std::numeric_limits<double>::quiet_NaN();
 };
 
 Q_DECLARE_METATYPE( AbstractGnssReceiver )

--- a/src/core/positioning/abstractgnssreceiver.h
+++ b/src/core/positioning/abstractgnssreceiver.h
@@ -57,7 +57,7 @@ class AbstractGnssReceiver : public QObject
 
     QString lastError() const { return mLastError; }
 
-    double barreryLevel() const { return mBatteryLevel; }
+    double batteryLevel() const { return mBatteryLevel; }
 
     /**
      * Returns extra details (such as hdop, vdop, pdop) provided by the positioning device.

--- a/src/core/positioning/bluetoothdevicemodel.cpp
+++ b/src/core/positioning/bluetoothdevicemodel.cpp
@@ -187,38 +187,21 @@ void BluetoothDeviceModel::deviceDiscovered( const QBluetoothDeviceInfo &info )
                .arg( info.name(), info.address().toString() )
                .arg( mLocalDevice->pairingStatus( info.address() ) );
 
-  const int index = static_cast<int>( mDiscoveredDevices.size() );
-  const bool paired = mLocalDevice->pairingStatus( info.address() ) != QBluetoothLocalDevice::Unpaired;
-  const bool lowEnergySupport = ( info.coreConfigurations() & QBluetoothDeviceInfo::LowEnergyCoreConfiguration );
 #if defined( Q_OS_ANDROID )
   // Only list paired devices users have control over it.
-  if ( paired )
+  const bool paired = mLocalDevice->pairingStatus( info.address() ) != QBluetoothLocalDevice::Unpaired;
+  if ( !paired )
   {
-    beginInsertRows( QModelIndex(), index, index );
-    mDiscoveredDevices.append( info );
-    endInsertRows();
-
-    mLastDiscoveredCount++;
+    return;
   }
-#elif defined( Q_OS_IOS )
-  // Only list paired, BLE devices users have control over it.
-  if ( paired && lowEnergySupport )
-  {
-    beginInsertRows( QModelIndex(), index, index );
-    mDiscoveredDevices.append( info );
-    endInsertRows();
+#endif
 
-    mLastDiscoveredCount++;
-  }
-#else
-  Q_UNUSED( paired )
-  Q_UNUSED( lowEnergySupport )
+  const int index = static_cast<int>( mDiscoveredDevices.size() );
   beginInsertRows( QModelIndex(), index, index );
   mDiscoveredDevices.append( info );
   endInsertRows();
 
   mLastDiscoveredCount++;
-#endif
 }
 
 int BluetoothDeviceModel::findIndexFromAddress( const QString &address ) const

--- a/src/core/positioning/bluetoothdevicemodel.cpp
+++ b/src/core/positioning/bluetoothdevicemodel.cpp
@@ -145,7 +145,12 @@ void BluetoothDeviceModel::startDeviceDiscovery()
 
   // set scanning status _prior to_ start as start itself can error and then we get a broken status sequence
   setScanningStatus( Discovering );
+
+#if defined( Q_OS_IOS )
+  mDeviceDiscoveryAgent->start( QBluetoothDeviceDiscoveryAgent::LowEnergyMethod );
+#else
   mDeviceDiscoveryAgent->start();
+#endif
 }
 
 void BluetoothDeviceModel::stopDeviceDiscovery()

--- a/src/core/positioning/bluetoothdevicemodel.cpp
+++ b/src/core/positioning/bluetoothdevicemodel.cpp
@@ -169,10 +169,14 @@ void BluetoothDeviceModel::deviceDiscovered( const QBluetoothDeviceInfo &info )
 {
   for ( qsizetype i = 0; i < mDiscoveredDevices.size(); i++ )
   {
+#if defined( Q_OS_IOS ) || defined( Q_OS_MACOS )
+    if ( mDiscoveredDevices[i].deviceUuid() == info.deviceUuid() )
+#else
     if ( mDiscoveredDevices[i].address() == info.address() )
+#endif
     {
-      qInfo() << QStringLiteral( "Bluetooth device information updated: name %1, address %2, pairing status %3" )
-                   .arg( info.name(), info.address().toString() )
+      qInfo() << QStringLiteral( "Bluetooth device information updated: name %1, address %2 deviceUuid %3, pairing status %4" )
+                   .arg( info.name(), info.address().toString(), info.deviceUuid().toString() )
                    .arg( mLocalDevice->pairingStatus( info.address() ) );
 
       mDiscoveredDevices.replace( i, info );
@@ -183,8 +187,8 @@ void BluetoothDeviceModel::deviceDiscovered( const QBluetoothDeviceInfo &info )
     }
   }
 
-  qInfo() << QStringLiteral( "Bluetooth device information discovered: name %1, address %2, pairing status %3" )
-               .arg( info.name(), info.address().toString() )
+  qInfo() << QStringLiteral( "Bluetooth device information discovered: name %1, address %2 deviceUuid %3, pairing status %4" )
+               .arg( info.name(), info.address().toString(), info.deviceUuid().toString() )
                .arg( mLocalDevice->pairingStatus( info.address() ) );
 
 #if defined( Q_OS_ANDROID )
@@ -208,7 +212,11 @@ int BluetoothDeviceModel::findIndexFromAddress( const QString &address ) const
 {
   for ( int i = 0; i < mDiscoveredDevices.size(); i++ )
   {
+#if defined( Q_OS_IOS ) || defined( Q_OS_MACOS )
+    if ( mDiscoveredDevices.at( i ).deviceUuid().toString() == address )
+#else
     if ( mDiscoveredDevices.at( i ).address().toString() == address )
+#endif
     {
       return i;
     }
@@ -233,10 +241,18 @@ QVariant BluetoothDeviceModel::data( const QModelIndex &index, int role ) const
   switch ( role )
   {
     case Qt::DisplayRole:
+#if defined( Q_OS_IOS ) || defined( Q_OS_MACOS )
+      return QStringLiteral( "%1" ).arg( !info.name().isEmpty() ? info.name().trimmed() : info.deviceUuid().toString() );
+#else
       return QStringLiteral( "%1" ).arg( !info.name().isEmpty() ? info.name().trimmed() : info.address().toString() );
+#endif
 
     case DeviceAddressRole:
+#if defined( Q_OS_IOS ) || defined( Q_OS_MACOS )
+      return info.deviceUuid().toString();
+#else
       return info.address().toString();
+#endif
 
     case DeviceNameRole:
       return info.name();
@@ -305,7 +321,11 @@ int BluetoothDeviceModel::addDevice( const QString &name, const QString &address
 
   for ( int i = 0; i < mDiscoveredDevices.size(); i++ )
   {
+#if defined( Q_OS_IOS ) || defined( Q_OS_MACOS )
+    if ( mDiscoveredDevices.at( i ).name() == name && mDiscoveredDevices.at( i ).deviceUuid().toString() == address )
+#else
     if ( mDiscoveredDevices.at( i ).name() == name && mDiscoveredDevices.at( i ).address().toString() == address )
+#endif
     {
       return i;
     }
@@ -313,7 +333,11 @@ int BluetoothDeviceModel::addDevice( const QString &name, const QString &address
 
   const int index = static_cast<int>( mDiscoveredDevices.size() );
   beginInsertRows( QModelIndex(), index, index );
+#if defined( Q_OS_IOS ) || defined( Q_OS_MACOS )
+  mDiscoveredDevices << QBluetoothDeviceInfo( QBluetoothUuid( address ), name, 0 );
+#else
   mDiscoveredDevices << QBluetoothDeviceInfo( QBluetoothAddress( address ), name, 0 );
+#endif
   endInsertRows();
 
   return index;

--- a/src/core/positioning/bluetoothdevicemodel.cpp
+++ b/src/core/positioning/bluetoothdevicemodel.cpp
@@ -169,14 +169,10 @@ void BluetoothDeviceModel::deviceDiscovered( const QBluetoothDeviceInfo &info )
 {
   for ( qsizetype i = 0; i < mDiscoveredDevices.size(); i++ )
   {
-#if defined( Q_OS_IOS ) || defined( Q_OS_MACOS )
-    if ( mDiscoveredDevices[i].deviceUuid() == info.deviceUuid() )
-#else
-    if ( mDiscoveredDevices[i].address() == info.address() )
-#endif
+    if ( deviceAddress( mDiscoveredDevices[i] ) == deviceAddress( info ) )
     {
-      qInfo() << QStringLiteral( "Bluetooth device information updated: name %1, address %2 deviceUuid %3, pairing status %4" )
-                   .arg( info.name(), info.address().toString(), info.deviceUuid().toString() )
+      qInfo() << QStringLiteral( "Bluetooth device information updated: name %1, address %2, pairing status %3" )
+                   .arg( info.name(), info.address().toString(), deviceAddress( info ) )
                    .arg( mLocalDevice->pairingStatus( info.address() ) );
 
       mDiscoveredDevices.replace( i, info );
@@ -187,8 +183,8 @@ void BluetoothDeviceModel::deviceDiscovered( const QBluetoothDeviceInfo &info )
     }
   }
 
-  qInfo() << QStringLiteral( "Bluetooth device information discovered: name %1, address %2 deviceUuid %3, pairing status %4" )
-               .arg( info.name(), info.address().toString(), info.deviceUuid().toString() )
+  qInfo() << QStringLiteral( "Bluetooth device information discovered: name %1, address %2, pairing status %3" )
+               .arg( info.name(), info.address().toString(), deviceAddress( info ) )
                .arg( mLocalDevice->pairingStatus( info.address() ) );
 
 #if defined( Q_OS_ANDROID )
@@ -212,11 +208,7 @@ int BluetoothDeviceModel::findIndexFromAddress( const QString &address ) const
 {
   for ( int i = 0; i < mDiscoveredDevices.size(); i++ )
   {
-#if defined( Q_OS_IOS ) || defined( Q_OS_MACOS )
-    if ( mDiscoveredDevices.at( i ).deviceUuid().toString() == address )
-#else
-    if ( mDiscoveredDevices.at( i ).address().toString() == address )
-#endif
+    if ( deviceAddress( mDiscoveredDevices.at( i ) ) == address )
     {
       return i;
     }
@@ -241,18 +233,10 @@ QVariant BluetoothDeviceModel::data( const QModelIndex &index, int role ) const
   switch ( role )
   {
     case Qt::DisplayRole:
-#if defined( Q_OS_IOS ) || defined( Q_OS_MACOS )
-      return QStringLiteral( "%1" ).arg( !info.name().isEmpty() ? info.name().trimmed() : info.deviceUuid().toString() );
-#else
-      return QStringLiteral( "%1" ).arg( !info.name().isEmpty() ? info.name().trimmed() : info.address().toString() );
-#endif
+      return QStringLiteral( "%1" ).arg( !info.name().isEmpty() ? info.name().trimmed() : deviceAddress( info ) );
 
     case DeviceAddressRole:
-#if defined( Q_OS_IOS ) || defined( Q_OS_MACOS )
-      return info.deviceUuid().toString();
-#else
-      return info.address().toString();
-#endif
+      return deviceAddress( info );
 
     case DeviceNameRole:
       return info.name();
@@ -321,11 +305,7 @@ int BluetoothDeviceModel::addDevice( const QString &name, const QString &address
 
   for ( int i = 0; i < mDiscoveredDevices.size(); i++ )
   {
-#if defined( Q_OS_IOS ) || defined( Q_OS_MACOS )
-    if ( mDiscoveredDevices.at( i ).name() == name && mDiscoveredDevices.at( i ).deviceUuid().toString() == address )
-#else
-    if ( mDiscoveredDevices.at( i ).name() == name && mDiscoveredDevices.at( i ).address().toString() == address )
-#endif
+    if ( mDiscoveredDevices.at( i ).name() == name && deviceAddress( mDiscoveredDevices.at( i ) ) == address )
     {
       return i;
     }
@@ -341,4 +321,13 @@ int BluetoothDeviceModel::addDevice( const QString &name, const QString &address
   endInsertRows();
 
   return index;
+}
+
+QString BluetoothDeviceModel::deviceAddress( const QBluetoothDeviceInfo &info ) const
+{
+#if defined( Q_OS_IOS ) || defined( Q_OS_MACOS )
+  return info.deviceUuid().toString();
+#else
+  return info.address().toString();
+#endif
 }

--- a/src/core/positioning/bluetoothdevicemodel.h
+++ b/src/core/positioning/bluetoothdevicemodel.h
@@ -21,6 +21,7 @@
 #include <QtBluetooth/QBluetoothDeviceDiscoveryAgent>
 #include <QtBluetooth/QBluetoothDeviceInfo>
 #include <QtBluetooth/QBluetoothLocalDevice>
+#include <QtBluetooth/QBluetoothUuid>
 
 /**
  * A model that provides all paired bluetooth devices name/address that are accessible over the serial port.

--- a/src/core/positioning/bluetoothdevicemodel.h
+++ b/src/core/positioning/bluetoothdevicemodel.h
@@ -23,6 +23,7 @@
 #include <QtBluetooth/QBluetoothLocalDevice>
 #include <QtBluetooth/QBluetoothUuid>
 
+
 /**
  * A model that provides all paired bluetooth devices name/address that are accessible over the serial port.
  * \ingroup core
@@ -97,6 +98,8 @@ class BluetoothDeviceModel : public QAbstractListModel
     qsizetype lastDiscoveredCount() const { return mLastDiscoveredCount; }
 
     QString lastError() const { return mLastError; };
+
+    QString deviceAddress( const QBluetoothDeviceInfo &info ) const;
 
   signals:
 

--- a/src/core/positioning/bluetoothlowenergyreceiver.cpp
+++ b/src/core/positioning/bluetoothlowenergyreceiver.cpp
@@ -356,7 +356,7 @@ void BluetoothLowEnergyReceiver::onCorrectionDataReceived( const QByteArray &dat
   }
 
   QByteArray finalizedData;
-  if ( mAddress.startsWith( "C8:47:8C" ) ) // Beken Corp. handling
+  if ( mService->serviceUuid() == QBluetoothUuid( "0000ffe0-0000-1000-8000-00805f9b34fb" ) ) // Beken Corp.
   {
     auto shortToByteArray = []( qint16 s ) -> QByteArray {
       QByteArray targets;

--- a/src/core/positioning/bluetoothlowenergyreceiver.cpp
+++ b/src/core/positioning/bluetoothlowenergyreceiver.cpp
@@ -355,65 +355,12 @@ void BluetoothLowEnergyReceiver::onCorrectionDataReceived( const QByteArray &dat
     return;
   }
 
-  QByteArray finalizedData;
-  if ( mService->serviceUuid() == QBluetoothUuid( "0000ffe0-0000-1000-8000-00805f9b34fb" ) ) // Beken Corp.
-  {
-    auto shortToByteArray = []( qint16 s ) -> QByteArray {
-      QByteArray targets;
-      targets.resize( 2 );
-      for ( int i = 0; i < targets.length(); i++ )
-      {
-        int offset = ( targets.length() - 1 - i ) * 8;
-        targets[i] = static_cast<char>( ( static_cast<quint16>( s ) >> offset ) & 0xFF );
-      }
-      return targets;
-    };
-
-    const QByteArray headByte = QStringLiteral( "$$GI" ).toUtf8();
-    qint16 length = static_cast<qint16>( data.length() + 1 );
-    QByteArray lengthByte = shortToByteArray( length );
-    std::reverse( lengthByte.begin(), lengthByte.end() );
-
-    char startOfData = 0x02;
-    int checkCode = 0;
-    for ( int i = 0; i < headByte.length(); i++ )
-    {
-      checkCode ^= static_cast<quint8>( 0xFF & headByte[i] );
-    }
-
-    checkCode ^= static_cast<quint8>( 0xFF & lengthByte[0] );
-    checkCode ^= static_cast<quint8>( 0xFF & lengthByte[1] );
-    checkCode ^= static_cast<quint8>( 0xFF & startOfData );
-
-    for ( int i = 0; i < data.length(); i++ )
-    {
-      checkCode ^= static_cast<quint8>( 0xFF & data[i] );
-    }
-    char checkChar = static_cast<char>( checkCode );
-
-    QByteArray packet;
-    packet.reserve( headByte.length() + lengthByte.length() + 1 + data.length() + 1 + 2 );
-
-    packet.append( headByte );
-    packet.append( lengthByte );
-    packet.append( startOfData );
-    packet.append( data );
-    packet.append( checkChar );
-    packet.append( "\r\n" );
-
-    finalizedData = packet;
-  }
-  else // Generic handling
-  {
-    finalizedData = data;
-  }
-
   // Payloag must not be longer than 20 bytes
   // https://doc.qt.io/qt-6/qlowenergyservice.html#WriteMode-enum
   const int chunkSize = 20;
-  for ( int i = 0; i < finalizedData.length(); i += chunkSize )
+  for ( int i = 0; i < data.length(); i += chunkSize )
   {
-    QByteArray chunk = finalizedData.mid( i, chunkSize );
+    QByteArray chunk = data.mid( i, chunkSize );
     mService->writeCharacteristic( mTxCharacteristic, chunk, QLowEnergyService::WriteWithoutResponse );
   }
 }

--- a/src/core/positioning/bluetoothlowenergyreceiver.cpp
+++ b/src/core/positioning/bluetoothlowenergyreceiver.cpp
@@ -104,7 +104,11 @@ void BluetoothLowEnergyReceiver::doConnectDevice()
 {
   if ( !mController )
   {
+#if defined( Q_OS_IOS ) || defined( Q_OS_MACOS )
+    QBluetoothDeviceInfo deviceInfo( QBluetoothUuid( mAddress ), QString(), 0 );
+#else
     QBluetoothDeviceInfo deviceInfo( QBluetoothAddress( mAddress ), QString(), 0 );
+#endif
     mController = QLowEnergyController::createCentral( deviceInfo, this );
 
     connect( mController, &QLowEnergyController::connected, this, &BluetoothLowEnergyReceiver::deviceConnected );

--- a/src/core/positioning/bluetoothlowenergyreceiver.cpp
+++ b/src/core/positioning/bluetoothlowenergyreceiver.cpp
@@ -175,7 +175,6 @@ void BluetoothLowEnergyReceiver::serviceDiscoveryFinished()
   }
 
   clearService();
-  mService = nullptr;
 
   const QList<QBluetoothUuid> controllerServices = mController->services();
   if ( !controllerServices.isEmpty() )
@@ -190,7 +189,15 @@ void BluetoothLowEnergyReceiver::serviceDiscoveryFinished()
     }
   }
 
-  if ( !mService )
+  if ( mService )
+  {
+    connect( mService, &QLowEnergyService::stateChanged, this, &BluetoothLowEnergyReceiver::serviceStateChanged );
+    connect( mService, qOverload<QLowEnergyService::ServiceError>( &QLowEnergyService::errorOccurred ), this, &BluetoothLowEnergyReceiver::serviceErrorOccurred );
+    connect( mService, &QLowEnergyService::characteristicChanged, this, &BluetoothLowEnergyReceiver::characteristicChanged );
+
+    mService->discoverDetails();
+  }
+  else
   {
     mLastError = "BluetoothLowEnergyReceiver: Required target service not found on device.";
     qWarning() << mLastError;
@@ -198,53 +205,81 @@ void BluetoothLowEnergyReceiver::serviceDiscoveryFinished()
     handleDisconnectDevice();
     return;
   }
-
-  connect( mService, &QLowEnergyService::stateChanged, this, &BluetoothLowEnergyReceiver::serviceStateChanged );
-  connect( mService, qOverload<QLowEnergyService::ServiceError>( &QLowEnergyService::errorOccurred ), this, &BluetoothLowEnergyReceiver::serviceErrorOccurred );
-  connect( mService, &QLowEnergyService::characteristicChanged, this, &BluetoothLowEnergyReceiver::characteristicChanged );
-
-  mService->discoverDetails();
 }
 
-void BluetoothLowEnergyReceiver::serviceStateChanged( QLowEnergyService::ServiceState s )
+void BluetoothLowEnergyReceiver::serviceStateChanged( QLowEnergyService::ServiceState state )
 {
-  if ( s == QLowEnergyService::RemoteServiceDiscovered )
+  if ( sender() == mService )
   {
-    mRxCharacteristic = mService->characteristic( serviceChars[mService->serviceUuid()].first );
-    mTxCharacteristic = mService->characteristic( serviceChars[mService->serviceUuid()].second );
-
-    if ( mRxCharacteristic.isValid() )
+    if ( state == QLowEnergyService::RemoteServiceDiscovered )
     {
-      QLowEnergyDescriptor notificationDesc = mRxCharacteristic.descriptor( QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration );
-      if ( notificationDesc.isValid() )
+      mRxCharacteristic = mService->characteristic( serviceChars[mService->serviceUuid()].first );
+      mTxCharacteristic = mService->characteristic( serviceChars[mService->serviceUuid()].second );
+
+      if ( mRxCharacteristic.isValid() )
       {
-        mService->writeDescriptor( notificationDesc, QByteArray::fromHex( "0100" ) );
-        qInfo() << "BluetoothLowEnergyReceiver: Subscribed to RX characteristic notifications.";
+        QLowEnergyDescriptor notificationDesc = mRxCharacteristic.descriptor( QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration );
+        if ( notificationDesc.isValid() )
+        {
+          mService->writeDescriptor( notificationDesc, QByteArray::fromHex( "0100" ) );
+          qInfo() << "BluetoothLowEnergyReceiver: Subscribed to RX characteristic notifications.";
+        }
+
+        mBufferData.clear();
+        mBuffer->open( QIODevice::ReadWrite );
+
+        setSocketState( QAbstractSocket::ConnectedState );
+      }
+      else
+      {
+        qWarning() << "BluetoothLowEnergyReceiver: RX Characteristic not found!";
+        handleDisconnectDevice();
       }
 
-      mBufferData.clear();
-      mBuffer->open( QIODevice::ReadWrite );
+      mBatteryService = mController->createServiceObject( QBluetoothUuid::ServiceClassUuid::BatteryService, this );
 
-      setSocketState( QAbstractSocket::ConnectedState );
+      if ( mBatteryService )
+      {
+        qInfo() << "BluetoothLowEnergyReceiver: Battery service initiating";
+        connect( mBatteryService, &QLowEnergyService::stateChanged, this, &BluetoothLowEnergyReceiver::serviceStateChanged );
+        connect( mBatteryService, &QLowEnergyService::characteristicChanged, this, &BluetoothLowEnergyReceiver::characteristicChanged );
+
+        mBatteryService->discoverDetails();
+      }
     }
-    else
+  }
+  else if ( sender() == mBatteryService )
+  {
+    if ( state == QLowEnergyService::RemoteServiceDiscovered )
     {
-      qWarning() << "BluetoothLowEnergyReceiver: RX Characteristic not found!";
-      handleDisconnectDevice();
+      mBatteryCharacteristic = mBatteryService->characteristic( QBluetoothUuid::CharacteristicType::BatteryLevel );
+
+      if ( mBatteryCharacteristic.isValid() )
+      {
+        qInfo() << "BluetoothLowEnergyReceiver: Subscribing to battery level characteristic notification";
+        QLowEnergyDescriptor notificationDesc = mBatteryCharacteristic.descriptor( QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration );
+        if ( notificationDesc.isValid() )
+        {
+          mBatteryService->writeDescriptor( notificationDesc, QByteArray::fromHex( "0100" ) );
+          qInfo() << "BluetoothLowEnergyReceiver: Subscribed to battery level characteristic notifications.";
+        }
+
+        mBatteryService->readCharacteristic( mBatteryCharacteristic );
+      }
     }
   }
 }
 
-void BluetoothLowEnergyReceiver::serviceErrorOccurred( QLowEnergyService::ServiceError e )
+void BluetoothLowEnergyReceiver::serviceErrorOccurred( QLowEnergyService::ServiceError error )
 {
-  mLastError = QStringLiteral( "Service Error: %1" ).arg( QMetaEnum::fromType<QLowEnergyService::ServiceError>().valueToKey( static_cast<int>( e ) ) );
+  mLastError = QStringLiteral( "Service Error: %1" ).arg( QMetaEnum::fromType<QLowEnergyService::ServiceError>().valueToKey( static_cast<int>( error ) ) );
   qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: %1" ).arg( mLastError );
   emit lastErrorChanged( mLastError );
 }
 
-void BluetoothLowEnergyReceiver::characteristicChanged( const QLowEnergyCharacteristic &c, const QByteArray &value )
+void BluetoothLowEnergyReceiver::characteristicChanged( const QLowEnergyCharacteristic &characteristic, const QByteArray &value )
 {
-  if ( c.uuid() == mRxCharacteristic.uuid() )
+  if ( characteristic.uuid() == mRxCharacteristic.uuid() )
   {
     mBufferData.append( value );
     int endSentenceIndex = mBufferData.lastIndexOf( QLatin1String( "\r\n" ) );
@@ -256,6 +291,15 @@ void BluetoothLowEnergyReceiver::characteristicChanged( const QLowEnergyCharacte
       mBuffer->seek( 0 );
 
       mBufferData = mBufferData.mid( endSentenceIndex + 2 );
+    }
+  }
+  else if ( characteristic.uuid() == mBatteryCharacteristic.uuid() )
+  {
+    if ( !value.isEmpty() )
+    {
+      const int batteryPercentage = static_cast<quint8>( value[0] );
+      mBatteryLevel = batteryPercentage / 100.0;
+      emit batteryLevelChanged( mBatteryLevel );
     }
   }
 }
@@ -276,6 +320,14 @@ void BluetoothLowEnergyReceiver::clearService()
 
   mRxCharacteristic = QLowEnergyCharacteristic();
   mTxCharacteristic = QLowEnergyCharacteristic();
+
+  if ( mBatteryService )
+  {
+    mBatteryService->deleteLater();
+    mBatteryService = nullptr;
+  }
+
+  mBatteryCharacteristic = QLowEnergyCharacteristic();
 }
 
 QString BluetoothLowEnergyReceiver::socketStateString()

--- a/src/core/positioning/bluetoothlowenergyreceiver.h
+++ b/src/core/positioning/bluetoothlowenergyreceiver.h
@@ -60,9 +60,9 @@ class BluetoothLowEnergyReceiver : public NmeaGnssReceiver
     void serviceDiscoveryFinished();
 
     // BLE Service slots
-    void serviceStateChanged( QLowEnergyService::ServiceState s );
-    void serviceErrorOccurred( QLowEnergyService::ServiceError e );
-    void characteristicChanged( const QLowEnergyCharacteristic &c, const QByteArray &value );
+    void serviceStateChanged( QLowEnergyService::ServiceState state );
+    void serviceErrorOccurred( QLowEnergyService::ServiceError error );
+    void characteristicChanged( const QLowEnergyCharacteristic &characteristic, const QByteArray &value );
 
     //! Used to wait for previous connection to finish disconnecting
     void doConnectDevice();
@@ -73,9 +73,13 @@ class BluetoothLowEnergyReceiver : public NmeaGnssReceiver
     QString mAddress;
 
     QLowEnergyController *mController = nullptr;
+
     QLowEnergyService *mService = nullptr;
     QLowEnergyCharacteristic mRxCharacteristic;
     QLowEnergyCharacteristic mTxCharacteristic;
+
+    QLowEnergyService *mBatteryService = nullptr;
+    QLowEnergyCharacteristic mBatteryCharacteristic;
 
     QBuffer *mBuffer = nullptr;
     QByteArray mBufferData;

--- a/src/core/positioning/bluetoothlowenergyreceiver.h
+++ b/src/core/positioning/bluetoothlowenergyreceiver.h
@@ -21,6 +21,7 @@
 
 #include <QBuffer>
 #include <QObject>
+#include <QtBluetooth/QBluetoothUuid>
 #include <QtBluetooth/QLowEnergyController>
 #include <QtBluetooth/QLowEnergyService>
 

--- a/src/core/positioning/positioning.cpp
+++ b/src/core/positioning/positioning.cpp
@@ -354,6 +354,11 @@ QString Positioning::deviceSocketStateString() const
   return isSourceAvailable() ? mPositioningSourceReplica->property( "deviceSocketStateString" ).toString() : QString();
 }
 
+double Positioning::deviceBatteryLevel() const
+{
+  return isSourceAvailable() ? mPositioningSourceReplica->property( "deviceBatteryLevel" ).toDouble() : std::numeric_limits<double>::quiet_NaN();
+}
+
 GnssPositionDetails Positioning::deviceDetails() const
 {
   GnssPositionDetails list;

--- a/src/core/positioning/positioning.h
+++ b/src/core/positioning/positioning.h
@@ -46,6 +46,7 @@ class Positioning : public QObject
     Q_PROPERTY( QString deviceLastError READ deviceLastError NOTIFY deviceLastErrorChanged )
     Q_PROPERTY( QAbstractSocket::SocketState deviceSocketState READ deviceSocketState NOTIFY deviceSocketStateChanged )
     Q_PROPERTY( QString deviceSocketStateString READ deviceSocketStateString NOTIFY deviceSocketStateStringChanged )
+    Q_PROPERTY( double deviceBatteryLevel READ deviceBatteryLevel NOTIFY deviceBatteryLevelChanged )
 
     Q_PROPERTY( QgsQuickCoordinateTransformer *coordinateTransformer READ coordinateTransformer WRITE setCoordinateTransformer NOTIFY coordinateTransformerChanged )
 
@@ -133,6 +134,11 @@ class Positioning : public QObject
      * \see deviceSocketState
      */
     QString deviceSocketStateString() const;
+
+    /**
+     * Returns the device current battery level as a 0.0 to 1.0 double range.
+     */
+    double deviceBatteryLevel() const;
 
     /**
      * Sets the positioning device \a id used to fetch position information.
@@ -367,6 +373,7 @@ class Positioning : public QObject
     void deviceLastErrorChanged();
     void deviceSocketStateChanged();
     void deviceSocketStateStringChanged();
+    void deviceBatteryLevelChanged();
     void orientationChanged();
 
     //Ntrip client signals

--- a/src/core/positioning/positioningsource.cpp
+++ b/src/core/positioning/positioningsource.cpp
@@ -263,11 +263,14 @@ void PositioningSource::setupDevice()
   {
     triggerDisconnectDevice();
     mReceiver->stopLogging();
+
     disconnect( mReceiver.get(), &AbstractGnssReceiver::lastGnssPositionInformationChanged, this, &PositioningSource::lastGnssPositionInformationChanged );
     disconnect( mReceiver.get(), &AbstractGnssReceiver::lastErrorChanged, this, &PositioningSource::deviceLastErrorChanged );
     disconnect( mReceiver.get(), &AbstractGnssReceiver::socketStateChanged, this, &PositioningSource::deviceSocketStateChanged );
     disconnect( mReceiver.get(), &AbstractGnssReceiver::socketStateStringChanged, this, &PositioningSource::deviceSocketStateStringChanged );
     disconnect( mReceiver.get(), &AbstractGnssReceiver::socketStateChanged, this, &PositioningSource::onDeviceSocketStateChanged );
+    disconnect( mReceiver.get(), &AbstractGnssReceiver::batteryLevelChanged, this, &PositioningSource::deviceBatteryLevelChanged );
+
     mReceiver->deleteLater();
     mReceiver.reset();
     stopNtripClient();
@@ -340,9 +343,12 @@ void PositioningSource::setupDevice()
   connect( mReceiver.get(), &AbstractGnssReceiver::socketStateChanged, this, &PositioningSource::deviceSocketStateChanged );
   connect( mReceiver.get(), &AbstractGnssReceiver::socketStateChanged, this, &PositioningSource::onDeviceSocketStateChanged );
   connect( mReceiver.get(), &AbstractGnssReceiver::socketStateStringChanged, this, &PositioningSource::deviceSocketStateStringChanged );
+  connect( mReceiver.get(), &AbstractGnssReceiver::batteryLevelChanged, this, &PositioningSource::deviceBatteryLevelChanged );
+
   setValid( mReceiver->valid() );
 
   emit deviceChanged();
+  emit deviceBatteryLevelChanged();
 
   if ( mLogging && !mLoggingPath.isEmpty() )
   {

--- a/src/core/positioning/positioningsource.h
+++ b/src/core/positioning/positioningsource.h
@@ -44,6 +44,7 @@ class PositioningSource : public QObject
     Q_PROPERTY( QString deviceLastError READ deviceLastError NOTIFY deviceLastErrorChanged )
     Q_PROPERTY( QAbstractSocket::SocketState deviceSocketState READ deviceSocketState NOTIFY deviceSocketStateChanged )
     Q_PROPERTY( QString deviceSocketStateString READ deviceSocketStateString NOTIFY deviceSocketStateStringChanged )
+    Q_PROPERTY( double deviceBatteryLevel READ deviceBatteryLevel NOTIFY deviceBatteryLevelChanged )
 
     Q_PROPERTY( GnssPositionInformation positionInformation READ positionInformation NOTIFY positionInformationChanged )
 
@@ -159,6 +160,11 @@ class PositioningSource : public QObject
      * \see deviceSocketState
      */
     QString deviceSocketStateString() const { return mReceiver ? mReceiver->socketStateString() : QString(); }
+
+    /**
+     * Returns the device current battery level as a 0.0 to 1.0 double range.
+     */
+    double deviceBatteryLevel() const { return mReceiver ? mReceiver->barreryLevel() : std::numeric_limits<double>::quiet_NaN(); }
 
     /**
      * Returns a GnssPositionInformation position information object.
@@ -294,6 +300,7 @@ class PositioningSource : public QObject
     void deviceLastErrorChanged();
     void deviceSocketStateChanged();
     void deviceSocketStateStringChanged();
+    void deviceBatteryLevelChanged();
     void positionInformationChanged();
     void elevationCorrectionModeChanged();
     void antennaHeightChanged();

--- a/src/core/positioning/positioningsource.h
+++ b/src/core/positioning/positioningsource.h
@@ -164,7 +164,7 @@ class PositioningSource : public QObject
     /**
      * Returns the device current battery level as a 0.0 to 1.0 double range.
      */
-    double deviceBatteryLevel() const { return mReceiver ? mReceiver->barreryLevel() : std::numeric_limits<double>::quiet_NaN(); }
+    double deviceBatteryLevel() const { return mReceiver ? mReceiver->batteryLevel() : std::numeric_limits<double>::quiet_NaN(); }
 
     /**
      * Returns a GnssPositionInformation position information object.

--- a/src/qml/BluetoothDeviceChooser.qml
+++ b/src/qml/BluetoothDeviceChooser.qml
@@ -136,7 +136,7 @@ Item {
 
       onCurrentIndexChanged: {
         let idx = bluetoothDeviceModel.index(currentIndex, 0);
-        deviceName = bluetoothDeviceModel.data(idx, BluetoothDeviceModel.DeviceNameRole);
+        deviceName = bluetoothDeviceModel.data(idx, BluetoothDeviceModel.DeviceNameRole).trim();
         deviceAddress = bluetoothDeviceModel.data(idx, BluetoothDeviceModel.DeviceAddressRole);
         deviceClassicSupport = bluetoothDeviceModel.data(idx, BluetoothDeviceModel.DeviceClassicSupportRole);
         deviceLowEnergySupport = bluetoothDeviceModel.data(idx, BluetoothDeviceModel.DeviceLowEnergySupportRole);

--- a/src/qml/InformationDrawer.qml
+++ b/src/qml/InformationDrawer.qml
@@ -122,6 +122,30 @@ Item {
             }
           }
         }
+
+        Rectangle {
+          id: batteryIndicator
+          Layout.alignment: Qt.AlignVCenter
+          Layout.preferredWidth: 18
+          Layout.preferredHeight: 12
+          Layout.bottomMargin: 1
+          visible: !isNaN(positionSource.deviceBatteryLevel)
+
+          color: "transparent"
+          border.width: 2
+          border.color: Theme.mainTextColor
+          radius: 2
+
+          Rectangle {
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.topMargin: 3
+            anchors.leftMargin: 3
+            height: parent.height - 6
+            width: (parent.width - 6) * positionSource.deviceBatteryLevel
+            color: positionSource.deviceBatteryLevel > 0.20 ? Theme.goodColor : positionSource.deviceBatteryLevel > 0.05 ? Theme.warningColor : Theme.errorColor
+          }
+        }
       }
 
       PositioningInformationView {

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -1303,11 +1303,11 @@ Page {
                   switch (positionSource.deviceSocketState) {
                   case QAbstractSocket.ConnectedState:
                   case QAbstractSocket.BoundState:
-                    return qsTr('Connected to %1').arg(positioningSettings.positioningDeviceName);
+                    return qsTr('Connected to %1').arg(positioningSettings.positioningDeviceName.trim());
                   case QAbstractSocket.UnconnectedState:
-                    return qsTr('Connect to %1').arg(positioningSettings.positioningDeviceName);
+                    return qsTr('Connect to %1').arg(positioningSettings.positioningDeviceName.trim());
                   default:
-                    return qsTr('Connecting to %1').arg(positioningSettings.positioningDeviceName);
+                    return qsTr('Connecting to %1').arg(positioningSettings.positioningDeviceName.trim());
                   }
                 }
                 enabled: positionSource.deviceSocketState === QAbstractSocket.UnconnectedState


### PR DESCRIPTION
The PR adds a useful battery level indicator for (some) external GNSS devices. The easiest ones to add are BLE devices, since there is a standard way to report that.

Some GNSS vendors also include battery level reporting in their NMEA string (i.e. outside of a BLE connection), we can leverage that in the future too.

(There's a bit of debugging I will remove when this is tested)