### PR TITLE
Add crucial project title into the side dashboad above project legend

### DIFF
--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -75,10 +75,10 @@ QString FileUtils::nativeSeparatorsPath( const QString &filePath )
   return QDir::toNativeSeparators( filePath );
 }
 
-QString FileUtils::fileName( const QString &filePath )
+QString FileUtils::fileName( const QString &filePath, bool includeSuffix )
 {
   QFileInfo fileInfo( filePath );
-  return fileInfo.fileName();
+  return includeSuffix ? fileInfo.fileName() : fileInfo.completeBaseName();
 }
 
 QString FileUtils::fileSuffix( const QString &filePath )

--- a/src/core/utils/fileutils.h
+++ b/src/core/utils/fileutils.h
@@ -45,7 +45,7 @@ class QFIELD_CORE_EXPORT FileUtils : public QObject
     //! Returns TRUE if the provided mimetype is a supported image
     Q_INVOKABLE static bool isImageMimeTypeSupported( const QString &mimeType );
     //! Returns the filename of a \a filePath - if no file name exists it's empty
-    Q_INVOKABLE static QString fileName( const QString &filePath );
+    Q_INVOKABLE static QString fileName( const QString &filePath, bool includeSuffix = true );
     //! Returns true if the \a filePath exists (false if it's a directory)
     Q_INVOKABLE static bool fileExists( const QString &filePath );
     //! Returns the suffix (extension)

--- a/src/core/utils/projectutils.cpp
+++ b/src/core/utils/projectutils.cpp
@@ -95,7 +95,7 @@ QString ProjectUtils::title( QgsProject *project )
 QString ProjectUtils::createProject( const QVariantMap &options, const GnssPositionInformation &positionInformation )
 {
   QString projectTitle = options.value( QStringLiteral( "title" ), tr( "Created Project" ) ).toString();
-  QString projectFilename = projectTitle;
+  QString projectFilename = projectTitle.normalized( QString::NormalizationForm_KD );
   projectFilename.replace( QRegularExpression( "[^A-Za-z0-9_]" ), QStringLiteral( "_" ) );
 
   QDir createdProjectsDir( QStringLiteral( "%1/Created Projects/" ).arg( PlatformUtilities::instance()->applicationDirectory() ) );

--- a/src/core/utils/projectutils.cpp
+++ b/src/core/utils/projectutils.cpp
@@ -113,6 +113,7 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
   QgsProject *createdProject = new QgsProject();
 
   // Basic project settings
+  createdProject->setTitle( projectTitle );
   createdProject->setCrs( QgsCoordinateReferenceSystem( "EPSG:3857" ) );
   createdProject->displaySettings()->setCoordinateType( Qgis::CoordinateDisplayType::CustomCrs );
   createdProject->displaySettings()->setCoordinateCustomCrs( QgsCoordinateReferenceSystem( "EPSG:4326" ) );

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -282,6 +282,69 @@ Drawer {
     }
 
     GroupBox {
+      id: projectInformationContainer
+      Layout.fillWidth: true
+      title: qsTr("Title")
+      leftPadding: 5
+      rightPadding: 5
+      topPadding: label.height + 5
+      bottomPadding: 5
+
+      background: Rectangle {
+        color: "transparent"
+      }
+
+      label: Label {
+        x: mapThemeContainer.leftPadding
+        height: 25
+        width: parent.availableWidth
+        leftPadding: mainWindow.sceneLeftMargin
+        text: parent.title
+        color: Theme.mainTextColor
+        font: Theme.strongTipFont
+        elide: Text.ElideRight
+        verticalAlignment: Text.AlignVCenter
+        clip: true
+      }
+
+      RowLayout {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.leftMargin: mainWindow.sceneLeftMargin + 5
+        anchors.rightMargin: 5
+
+        QfSwipeAnimator {
+          Layout.fillWidth: true
+          Layout.preferredHeight: projectTitle.contentHeight
+          Layout.alignment: Qt.AlignVCenter
+          contentImplicitWidth: projectTitle.contentWidth
+          shouldAutoFlick: dashBoard.opened && projectTitle.contentWidth > width
+          duration: shouldAutoFlick ? Math.abs(projectTitle.contentWidth - width) * 100 + 10 : 10000
+
+          Text {
+            id: projectTitle
+            text: qgisProject ? qgisProject.title !== "" ? qgisProject.title : FileUtils.fileName(qgisProject.fileName, false) : ""
+            font: Theme.defaultFont
+            color: Theme.mainTextColor
+          }
+        }
+
+        QfToolButton {
+          id: temporalButton
+          Layout.alignment: Qt.AlignVCenter
+          width: 36
+          height: 36
+          padding: 0
+          visible: flatLayerTree.isTemporal
+          iconSource: Theme.getThemeVectorIcon('ic_temporal_black_24dp')
+          iconColor: mapSettings.isTemporal ? Theme.mainColor : Theme.mainTextColor
+          bgcolor: "transparent"
+          onClicked: temporalProperties.open()
+        }
+      }
+    }
+
+    GroupBox {
       id: mapThemeContainer
       Layout.fillWidth: true
       title: qsTr("Map Theme")
@@ -366,16 +429,6 @@ Drawer {
             font.pointSize: Theme.tipFont.pointSize
             highlighted: mapThemeComboBox.highlightedIndex == index
           }
-        }
-
-        QfToolButton {
-          id: temporalButton
-          Layout.alignment: Qt.AlignVCenter
-          visible: flatLayerTree.isTemporal
-          iconSource: Theme.getThemeVectorIcon('ic_temporal_black_24dp')
-          iconColor: mapSettings.isTemporal ? Theme.mainColor : Theme.mainTextColor
-          bgcolor: "transparent"
-          onClicked: temporalProperties.open()
         }
       }
     }

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -315,15 +315,26 @@ Drawer {
 
         QfSwipeAnimator {
           Layout.fillWidth: true
-          Layout.preferredHeight: projectTitle.contentHeight
+          Layout.preferredHeight: projectTitleText.contentHeight
           Layout.alignment: Qt.AlignVCenter
-          contentImplicitWidth: projectTitle.contentWidth
-          shouldAutoFlick: dashBoard.opened && projectTitle.contentWidth > width
-          duration: shouldAutoFlick ? Math.abs(projectTitle.contentWidth - width) * 100 + 10 : 10000
+          contentImplicitWidth: projectTitleText.contentWidth
+          shouldAutoFlick: dashBoard.opened && projectTitleText.contentWidth > width
+          duration: shouldAutoFlick ? Math.abs(projectTitleText.contentWidth - width) * 100 + 10 : 10000
 
           Text {
-            id: projectTitle
-            text: qgisProject ? qgisProject.title !== "" ? qgisProject.title : FileUtils.fileName(qgisProject.fileName, false) : ""
+            id: projectTitleText
+            text: {
+              if (qgisProject) {
+                if (qgisProject.title !== "") {
+                  return qgisProject.title;
+                } else if (cloudProjectsModel.currentProject) {
+                  return cloudProjectsModel.currentProject.name;
+                } else {
+                  return FileUtils.fileName(qgisProject.fileName, false);
+                }
+              }
+              return "";
+            }
             font: Theme.defaultFont
             color: Theme.mainTextColor
           }

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -281,77 +281,52 @@ Drawer {
       }
     }
 
-    GroupBox {
-      id: projectInformationContainer
+    RowLayout {
+      id: projectInformationLayout
       Layout.fillWidth: true
-      title: qsTr("Title")
-      leftPadding: 5
-      rightPadding: 5
-      topPadding: label.height + 5
-      bottomPadding: 5
+      Layout.leftMargin: mainWindow.sceneLeftMargin + 10
+      Layout.rightMargin: 10
+      Layout.bottomMargin: 5
 
-      background: Rectangle {
-        color: "transparent"
-      }
+      QfSwipeAnimator {
+        Layout.fillWidth: true
+        Layout.preferredHeight: projectTitleText.contentHeight
+        Layout.alignment: Qt.AlignVCenter
+        contentImplicitWidth: projectTitleText.contentWidth
+        shouldAutoFlick: dashBoard.opened && projectTitleText.contentWidth > width
+        duration: shouldAutoFlick ? Math.abs(projectTitleText.contentWidth - width) * 100 + 10 : 10000
+        interactive: false
 
-      label: Label {
-        x: mapThemeContainer.leftPadding
-        height: 25
-        width: parent.availableWidth
-        leftPadding: mainWindow.sceneLeftMargin
-        text: parent.title
-        color: Theme.mainTextColor
-        font: Theme.strongTipFont
-        elide: Text.ElideRight
-        verticalAlignment: Text.AlignVCenter
-        clip: true
-      }
-
-      RowLayout {
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.leftMargin: mainWindow.sceneLeftMargin + 5
-        anchors.rightMargin: 5
-
-        QfSwipeAnimator {
-          Layout.fillWidth: true
-          Layout.preferredHeight: projectTitleText.contentHeight
-          Layout.alignment: Qt.AlignVCenter
-          contentImplicitWidth: projectTitleText.contentWidth
-          shouldAutoFlick: dashBoard.opened && projectTitleText.contentWidth > width
-          duration: shouldAutoFlick ? Math.abs(projectTitleText.contentWidth - width) * 100 + 10 : 10000
-
-          Text {
-            id: projectTitleText
-            text: {
-              if (qgisProject) {
-                if (qgisProject.title !== "") {
-                  return qgisProject.title;
-                } else if (cloudProjectsModel.currentProject) {
-                  return cloudProjectsModel.currentProject.name;
-                } else {
-                  return FileUtils.fileName(qgisProject.fileName, false);
-                }
+        Text {
+          id: projectTitleText
+          text: {
+            if (qgisProject) {
+              if (qgisProject.title !== "") {
+                return qgisProject.title;
+              } else if (cloudProjectsModel.currentProject) {
+                return cloudProjectsModel.currentProject.name;
+              } else {
+                return FileUtils.fileName(qgisProject.fileName, false);
               }
-              return "";
             }
-            font: Theme.defaultFont
-            color: Theme.mainTextColor
+            return "";
           }
+          font: Theme.strongFont
+          color: Theme.mainTextColor
         }
+      }
 
-        QfToolButton {
-          id: temporalButton
-          Layout.alignment: Qt.AlignVCenter
-          width: 36
-          height: 36
-          padding: 0
-          visible: flatLayerTree.isTemporal
-          iconSource: Theme.getThemeVectorIcon('ic_temporal_black_24dp')
-          iconColor: mapSettings.isTemporal ? Theme.mainColor : Theme.mainTextColor
-          bgcolor: "transparent"
-          onClicked: temporalProperties.open()
-        }
+      QfToolButton {
+        id: temporalButton
+        Layout.alignment: Qt.AlignVCenter
+        width: 36
+        height: 36
+        padding: 0
+        visible: flatLayerTree.isTemporal
+        iconSource: Theme.getThemeVectorIcon('ic_temporal_black_24dp')
+        iconColor: mapSettings.isTemporal ? Theme.mainColor : Theme.mainTextColor
+        bgcolor: "transparent"
+        onClicked: temporalProperties.open()
       }
     }
 

--- a/src/qml/imports/Theme/QfSwipeAnimator.qml
+++ b/src/qml/imports/Theme/QfSwipeAnimator.qml
@@ -17,6 +17,14 @@ Flickable {
     loops: 10
     running: flick.shouldAutoFlick
 
+    onStopped: {
+      flick.contentX = 0;
+    }
+
+    PauseAnimation {
+      duration: 2000
+    }
+
     NumberAnimation {
       target: flick
       property: "contentX"
@@ -25,7 +33,7 @@ Flickable {
     }
 
     PauseAnimation {
-      duration: 1000
+      duration: 2000
     }
 
     NumberAnimation {
@@ -33,10 +41,6 @@ Flickable {
       property: "contentX"
       to: 0
       duration: flick.duration
-    }
-
-    PauseAnimation {
-      duration: 1000
     }
   }
 


### PR DESCRIPTION
A nice UX improvement that's been requested for a while, including by our very own @suricactus :

<img width="504" height="589" alt="image" src="https://github.com/user-attachments/assets/41bbb714-0bdc-4758-ae5c-b49232ca2f13" />

The logic goes like this:
- if the project has a proper title metadata, we use it (that's neat as it is something that's translatable)
- if the project has no proper title and it's a cloud project, we use the cloud project name value
- if we have no proper title and it's not a cloud project, we use the project filename

