### PR TITLE
Improve filtering of empty public projects, use a more meaningful update date in the cloud project details view

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudproject.h
+++ b/src/core/qfieldcloud/qfieldcloudproject.h
@@ -48,6 +48,7 @@ class QFieldCloudProject : public QObject
     Q_PROPERTY( QDateTime createdAt READ createdAt NOTIFY createdAtChanged )
     Q_PROPERTY( QDateTime updatedAt READ updatedAt NOTIFY updatedAtChanged )
     Q_PROPERTY( qint64 remoteSizeBytes READ remoteSizeBytes NOTIFY remoteSizeBytesChanged )
+    Q_PROPERTY( QDateTime dataLastUpdatedAt READ dataLastUpdatedAt NOTIFY dataLastUpdatedAtChanged )
 
     Q_PROPERTY( ProjectStatus status READ status NOTIFY statusChanged )
     Q_PROPERTY( PackagingStatus packagingStatus READ packagingStatus NOTIFY packagingStatusChanged )

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1347,11 +1347,17 @@ bool QFieldCloudProjectsFilterModel::filterAcceptsRow( int source_row, const QMo
   }
 
   const bool isPublic = project->localPath().isEmpty() && project->userRoleOrigin() == QStringLiteral( "public" );
-  if ( mIncludePublic )
+  if ( mIncludePublic && isPublic )
   {
-    if ( project->remoteSizeBytes() == 0 && isPublic && project->updatedAt().toSecsSinceEpoch() - project->createdAt().toSecsSinceEpoch() < 300 )
+    if ( project->remoteSizeBytes() == 0 )
     {
-      // This is most likely an empty project, skip
+      // Empty project, skip
+      return false;
+    }
+
+    if ( project->remoteSizeBytes() < 30000 && project->dataLastUpdatedAt().isNull() )
+    {
+      // Most likely a created project with a single OSM layer that never was customized, skip
       return false;
     }
   }

--- a/src/qml/QFieldCloudProjectDetails.qml
+++ b/src/qml/QFieldCloudProjectDetails.qml
@@ -227,6 +227,7 @@ ColumnLayout {
           Text {
             id: projectDetailsUpdateDateLabel
             Layout.fillWidth: true
+            visible: cloudProject != undefined && !isNaN(cloudProject.dataLastUpdatedAt.getTime())
             font: Theme.strongFont
             color: Theme.mainTextColor
 
@@ -240,7 +241,7 @@ ColumnLayout {
             color: Theme.secondaryTextColor
             wrapMode: Text.WordWrap
 
-            text: cloudProject != undefined ? Qt.formatDateTime(new Date(cloudProject.updatedAt), "dddd, MMMM dd, yyyy - hh:mm") : ""
+            text: cloudProject != undefined ? Qt.formatDateTime(new Date(cloudProject.dataLastUpdatedAt), "dddd, MMMM dd, yyyy - hh:mm") : ""
           }
         }
 


### PR DESCRIPTION
Thanks to the work of @gounux , we can now safely filter zero byte projects out. I've also realized that the updated_at datetime is not that useful and that data_last_updated_at gives us a much better way to try and filter out the single OSM layer created project.

These two improvements make for a much nicer list of public projects.