### PR TITLE
Use dynamic storage thresholds from QFieldCloud subscription API

### DIFF
--- a/src/core/utils/qfieldcloudutils.h
+++ b/src/core/utils/qfieldcloudutils.h
@@ -83,6 +83,8 @@ struct CloudSubscriptionInformation
     Q_PROPERTY( QString plan MEMBER plan )
     Q_PROPERTY( double storageTotal MEMBER storageTotal )
     Q_PROPERTY( double storageUsed MEMBER storageUsed )
+    Q_PROPERTY( double storageThresholdWarning MEMBER storageThresholdWarning )
+    Q_PROPERTY( double storageThresholdCritical MEMBER storageThresholdCritical )
     Q_PROPERTY( QString status MEMBER status )
 
   public:
@@ -92,17 +94,21 @@ struct CloudSubscriptionInformation
       : plan( subscriptionInformation.value( QStringLiteral( "plan_display_name" ) ).toString() )
       , storageTotal( subscriptionInformation.value( QStringLiteral( "active_storage_total_bytes" ) ).toDouble() )
       , storageUsed( subscriptionInformation.value( QStringLiteral( "storage_used_bytes" ) ).toDouble() )
+      , storageThresholdWarning( subscriptionInformation.value( QStringLiteral( "plan_storage_threshold_warning_bytes" ) ).toDouble() )
+      , storageThresholdCritical( subscriptionInformation.value( QStringLiteral( "plan_storage_threshold_critical_bytes" ) ).toDouble() )
       , status( subscriptionInformation.value( QStringLiteral( "status" ) ).toString() )
     {}
 
     bool operator==( const CloudSubscriptionInformation &other ) const
     {
-      return plan == other.plan && storageTotal == other.storageTotal && storageUsed == other.storageUsed && status == other.status;
+      return plan == other.plan && storageTotal == other.storageTotal && storageUsed == other.storageUsed && storageThresholdWarning == other.storageThresholdWarning && storageThresholdCritical == other.storageThresholdCritical && status == other.status;
     }
 
     QString plan;
     double storageTotal = 0;
     double storageUsed = 0;
+    double storageThresholdWarning = 0;
+    double storageThresholdCritical = 0;
     QString status;
 };
 

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -749,7 +749,7 @@ Popup {
     function onSubscriptionInformationReceived(subscriptionInformation) {
       storageMeterBar.loading = false;
       if (subscriptionInformation.storageTotal > 0) {
-        showStorageBar(subscriptionInformation.storageUsed, subscriptionInformation.storageTotal, subscriptionInformation.plan);
+        showStorageBar(subscriptionInformation.storageUsed, subscriptionInformation.storageTotal, subscriptionInformation.plan, subscriptionInformation.storageThresholdWarning, subscriptionInformation.storageThresholdCritical);
       }
     }
   }
@@ -959,12 +959,17 @@ Popup {
     }
   }
 
-  function showStorageBar(usedBytes, totalBytes, plan) {
+  function showStorageBar(usedBytes, totalBytes, plan, thresholdWarningBytes, thresholdCriticalBytes) {
     const owner = cloudProjectsModel.currentProject ? cloudProjectsModel.currentProject.owner : cloudConnection.username;
     lastSubscriptionUser = owner;
-    storageMeterBar.value = usedBytes / totalBytes;
+    const usageRatio = usedBytes / totalBytes;
+    const warnRatio = thresholdWarningBytes > 0 ? 1.0 - (thresholdWarningBytes / totalBytes) : 0.8;
+    const critRatio = thresholdCriticalBytes > 0 ? 1.0 - (thresholdCriticalBytes / totalBytes) : 0.95;
+    storageMeterBar.value = usageRatio;
     storageMeterBar.usageText = qsTr("Used %1 of %2").arg(FileUtils.representFileSize(usedBytes, true)).arg(FileUtils.representFileSize(totalBytes, true));
     storageMeterBar.relatedUrl = QFieldCloudUtils.subscriptionManagementUrl(cloudConnection.url, plan, cloudProjectsModel.currentProject ? cloudProjectsModel.currentProject.owner : "", cloudConnection.username);
+    storageMeterBar.warningThreshold = warnRatio;
+    storageMeterBar.criticalThreshold = critRatio;
     storageMeterBar.visible = true;
   }
 }

--- a/src/qml/QFieldCloudProjectDetails.qml
+++ b/src/qml/QFieldCloudProjectDetails.qml
@@ -46,6 +46,8 @@ ColumnLayout {
         detailsStorageMeter.value = subscriptionInformation.storageUsed / subscriptionInformation.storageTotal;
         detailsStorageMeter.usageText = qsTr("Using %1 of %2").arg(FileUtils.representFileSize(subscriptionInformation.storageUsed, true)).arg(FileUtils.representFileSize(subscriptionInformation.storageTotal, true));
         detailsStorageMeter.relatedUrl = QFieldCloudUtils.subscriptionManagementUrl(cloudConnection.url, subscriptionInformation.plan, projectDetails.cloudProject.owner, cloudConnection.username);
+        detailsStorageMeter.warningThreshold = subscriptionInformation.storageThresholdWarning > 0 ? 1.0 - (subscriptionInformation.storageThresholdWarning / subscriptionInformation.storageTotal) : 0.8;
+        detailsStorageMeter.criticalThreshold = subscriptionInformation.storageThresholdCritical > 0 ? 1.0 - (subscriptionInformation.storageThresholdCritical / subscriptionInformation.storageTotal) : 0.95;
         detailsStorageMeter.visible = true;
       }
     }


### PR DESCRIPTION
### 🚀 Description
Previously, `QfMeterBar` used hardcoded thresholds (0.8 warning, 0.95 critical) to determine storage bar colors. The QFieldCloud subscription API  returns `plan_storage_threshold_warning_bytes` and `plan_storage_threshold_critical_bytes` per plan.

This PR wires those server-provided thresholds through the full stack so each plan's actual limits drive the visual feedback shown to the user.

### ✨ Key Changes
- `CloudSubscriptionInformation`: added `storageThresholdWarning` and `storageThresholdCritical` fields.
