### PR TITLE
Fix crash handling property collections when building an attribute form

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -627,14 +627,15 @@ void AttributeFormModelBase::buildForm( QgsAttributeEditorContainer *container, 
           item->setData( QString(), AttributeFormModel::ConstraintDescription );
         }
 
-        QgsProperty property = mLayer->editFormConfig().dataDefinedFieldProperties( field.name() ).property( QgsEditFormConfig::DataDefinedProperty::Alias );
-        if ( property.isActive() )
+        if ( mLayer->editFormConfig().dataDefinedFieldProperties( field.name() ).isActive( QgsEditFormConfig::DataDefinedProperty::Alias ) )
         {
+          QgsProperty property = mLayer->editFormConfig().dataDefinedFieldProperties( field.name() ).property( QgsEditFormConfig::DataDefinedProperty::Alias );
           mAliasExpressions.insert( item, property.asExpression() );
         }
-        property = mLayer->editFormConfig().dataDefinedFieldProperties( field.name() ).property( QgsEditFormConfig::DataDefinedProperty::Editable );
-        if ( property.isActive() )
+
+        if ( mLayer->editFormConfig().dataDefinedFieldProperties( field.name() ).isActive( QgsEditFormConfig::DataDefinedProperty::Editable ) )
         {
+          QgsProperty property = mLayer->editFormConfig().dataDefinedFieldProperties( field.name() ).property( QgsEditFormConfig::DataDefinedProperty::Editable );
           mReadOnlyExpressions.insert( item, property.asExpression() );
         }
 

--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -957,9 +957,9 @@ bool FeatureModel::updateAttributesFromFeature( const QgsFeature &feature )
           continue;
         }
 
-        QgsProperty property = mLayer->editFormConfig().dataDefinedFieldProperties( field.name() ).property( QgsEditFormConfig::DataDefinedProperty::Editable );
-        if ( property.isActive() )
+        if ( mLayer->editFormConfig().dataDefinedFieldProperties( field.name() ).isActive( QgsEditFormConfig::DataDefinedProperty::Editable ) )
         {
+          QgsProperty property = mLayer->editFormConfig().dataDefinedFieldProperties( field.name() ).property( QgsEditFormConfig::DataDefinedProperty::Editable );
           QgsExpression expression( property.asExpression() );
           QgsExpressionContext expressionContext = createExpressionContext();
           expressionContext.setFeature( mFeature );


### PR DESCRIPTION
Stumbled on this when working on FieldTM plugin's reader mode. 