### PR TITLE
When opening a cloud project, insure its details are always refreshed

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -240,18 +240,21 @@ QFieldCloudProject *QFieldCloudProjectsModel::findProject( const QString &projec
   return nullptr;
 }
 
-void QFieldCloudProjectsModel::appendProject( const QString &projectId )
+void QFieldCloudProjectsModel::appendProject( const QString &projectId, bool forceRefresh )
 {
   if ( !mCloudConnection )
   {
     return;
   }
 
-  const QModelIndex index = findProjectIndex( projectId );
-  if ( index.isValid() )
+  if ( !forceRefresh )
   {
-    emit projectAppended( projectId );
-    return;
+    const QModelIndex index = findProjectIndex( projectId );
+    if ( index.isValid() )
+    {
+      emit projectAppended( projectId );
+      return;
+    }
   }
 
   QString projectOwner;

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -187,7 +187,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     Q_INVOKABLE QFieldCloudProject *findProject( const QString &projectId ) const;
 
     //! Fetches a cloud project for a given \a projectId and appends it to the model.
-    Q_INVOKABLE void appendProject( const QString &projectId );
+    Q_INVOKABLE void appendProject( const QString &projectId, bool forceRefresh = false );
 
     //! Fetches all cloud projects tied to a given \a search term and/or \a owner name.
     Q_INVOKABLE void appendProjects( const QString &owner, const QString &search, int projectFetchOffset = 0 );

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -945,12 +945,14 @@ Page {
     target: cloudProjectsModel
 
     function onProjectAppended(projectId, hasError, errorString) {
-      requestedProjectDetails = "";
-      if (hasError) {
-        displayToast(qsTr("QFieldCloud project details fetching failed"));
-      } else {
-        projectDetails.cloudProject = cloudProjectsModel.findProject(projectId);
-        projectsSwipeView.currentIndex = 1;
+      if (requestedProjectDetails != "") {
+        requestedProjectDetails = "";
+        if (hasError) {
+          displayToast(qsTr("QFieldCloud project details fetching failed"));
+        } else {
+          projectDetails.cloudProject = cloudProjectsModel.findProject(projectId);
+          projectsSwipeView.currentIndex = 1;
+        }
       }
     }
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4837,6 +4837,8 @@ ApplicationWindow {
         }
         if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
           projectInfo.cloudUserInformation = cloudConnection.userInformation;
+          // Refresh cloud project details
+          cloudProjectsModel.appendProject(cloudProjectId, true);
         } else {
           projectInfo.restoreCloudUserInformation();
         }
@@ -5111,6 +5113,8 @@ ApplicationWindow {
         var cloudProjectId = QFieldCloudUtils.getProjectId(qgisProject.fileName);
         if (cloudProjectId) {
           projectInfo.cloudUserInformation = userInformation;
+          // Refresh cloud project details
+          cloudProjectsModel.appendProject(cloudProjectId, true);
         }
         // Reload recent projects to insure only current user projects are visible
         recentProjectListModel.reloadModel();


### PR DESCRIPTION
If you're opening a cloud project in QField into a long-standing session, the cloud project details might have changed. If you are opening a _public_ project, details are _never_ refreshed. Let's fix that.