### PR TITLE
When copying WGS84 coordinates to the clipboard, generate the most universal form to ease pasting into other apps / websites

### DIFF
--- a/src/core/utils/stringutils.cpp
+++ b/src/core/utils/stringutils.cpp
@@ -88,6 +88,12 @@ double StringUtils::calcFuzzyScore( const QString &string, const QString &search
 
 QString StringUtils::pointInformation( const QgsPoint &point, const QgsCoordinateReferenceSystem &crs )
 {
+  if ( crs.authid() == QStringLiteral( "EPSG:4326" ) )
+  {
+    // For WGS84 coordinates, use the most universally accepted form (i.e. lat, lon)
+    return QStringLiteral( "%1, %2" ).arg( QString::number( point.y(), 'f', 5 ), QString::number( point.x(), 'f', 5 ) );
+  }
+
   QString firstSuffix;
   QString secondSuffix;
   const bool currentCrsIsXY = QgsCoordinateReferenceSystemUtils::defaultCoordinateOrderForCrs( crs ) == Qgis::CoordinateOrder::XY;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1484,9 +1484,23 @@ ApplicationWindow {
         bgcolor: Theme.toolButtonBackgroundColor
         visible: actionsPieMenu.openingAngle >= actionsPieMenu.segmentAngle * 4
         onClicked: {
-          var point = GeometryUtils.reprojectPoint(positionSource.sourcePosition, CoordinateReferenceSystemUtils.wgs84Crs(), projectInfo.coordinateDisplayCrs);
-          var coordinates = StringUtils.pointInformation(point, projectInfo.coordinateDisplayCrs);
-          coordinates += ' (' + qsTr('Accuracy') + ' ' + (positionSource.positionInformation && positionSource.positionInformation.haccValid ? positionSource.positionInformation.hacc.toLocaleString(Qt.locale(), 'f', 3) + " m" : qsTr("N/A")) + ')';
+          if (!positionSource.positionInformation) {
+            return;
+          }
+
+          const point = GeometryUtils.reprojectPoint(positionSource.sourcePosition, CoordinateReferenceSystemUtils.wgs84Crs(), projectInfo.coordinateDisplayCrs);
+          let coordinates = StringUtils.pointInformation(point, projectInfo.coordinateDisplayCrs);
+
+          let appendAccuracy = projectInfo.coordinateDisplayCrs.authid !== "EPSG:4326";
+          if (projectInfo.coordinateDisplayCrs.authid === "EPSG:4326") {
+            if (!positionSource.positionInformation.haccValid || positionSource.positionInformation.hacc > 10) {
+              appendAccuracy = true;
+            }
+          }
+          if (appendAccuracy) {
+            coordinates += ' (' + qsTr('Accuracy') + ' ' + (positionSource.positionInformation.haccValid ? positionSource.positionInformation.hacc.toLocaleString(Qt.locale(), 'f', 3) + " " + qsTr("meters") : qsTr("N/A")) + ')';
+          }
+
           platformUtilities.copyTextToClipboard(coordinates);
           displayToast(qsTr('Current location copied to clipboard'));
           actionsPieMenu.close();


### PR DESCRIPTION
QField appends CRS details to a copied coordinate when long tapping on the map canvas. Being in a part of the world where multiple CRSes are used on a daily basis, I've seen too many people burned by misinterpreting coordinates as being in CRS A when they were in CRS B.

That being said, when dealing with WGS84 coordinates, the intent is often to hop onto a different app or website to paste them there. In this scenario, the extra info we append gets in the way.

This PR tries to have your cake and eat it too by copying WGS84 coordinates _without adding any extra details_, just a pair of lat, lon. That maximizes the compatibility for this projection, and IMHO this is acceptable as the vast majority of people looking at a pair of doubles without any extra info will deduce it is WGS84.