### PR TITLE
Do a better job at deciding whether to fetch cloud project details

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -249,8 +249,8 @@ void QFieldCloudProjectsModel::appendProject( const QString &projectId, bool for
 
   if ( !forceRefresh )
   {
-    const QModelIndex index = findProjectIndex( projectId );
-    if ( index.isValid() )
+    const QFieldCloudProject *project = findProject( projectId );
+    if ( project && ( project->checkout() & QFieldCloudProject::RemoteCheckout ) )
     {
       emit projectAppended( projectId );
       return;

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4838,7 +4838,7 @@ ApplicationWindow {
         if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
           projectInfo.cloudUserInformation = cloudConnection.userInformation;
           // Refresh cloud project details
-          cloudProjectsModel.appendProject(cloudProjectId, true);
+          cloudProjectsModel.appendProject(cloudProjectId);
         } else {
           projectInfo.restoreCloudUserInformation();
         }
@@ -5114,7 +5114,7 @@ ApplicationWindow {
         if (cloudProjectId) {
           projectInfo.cloudUserInformation = userInformation;
           // Refresh cloud project details
-          cloudProjectsModel.appendProject(cloudProjectId, true);
+          cloudProjectsModel.appendProject(cloudProjectId);
         }
         // Reload recent projects to insure only current user projects are visible
         recentProjectListModel.reloadModel();


### PR DESCRIPTION
While the optional force refresh argument will come in handy, we should always seek remote details when the cloud project checkout state is local only.