### PR TITLE
Wrap long text in value relation combobox

### DIFF
--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -306,10 +306,9 @@ Item {
       }
 
       contentItem: Text {
-        leftPadding: comboBox.background.visible ? 8 : 0
-        rightPadding: comboBox.indicator.width + comboBox.spacing
-        topPadding: 8
-        bottomPadding: 8
+        leftPadding: comboBox.background.visible ? comboBox.Material.textFieldHorizontalPadding : 0
+        topPadding: comboBox.Material.textFieldVerticalPadding
+        bottomPadding: comboBox.Material.textFieldVerticalPadding
         text: comboBox.displayText
         font: Theme.defaultFont
         color: displayedTextColor
@@ -370,10 +369,9 @@ Item {
               id: delegateLabel
               text: model.display
               font: Theme.defaultFont
-              color: highlighted ? Theme.mainColor : Theme.mainTextColor
+              color: comboBox.currentIndex === index ? Theme.mainColor : Theme.mainTextColor
               wrapMode: Text.WordWrap
               verticalAlignment: Text.AlignVCenter
-              leftPadding: 8
             }
           }
 

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -296,6 +296,21 @@ Item {
       }
 
       font: Theme.defaultFont
+      delegate: ItemDelegate {
+        width: ListView.view.width
+        height: Math.max(delegateLabel.implicitHeight + 16, 48)
+        highlighted: comboBox.highlightedIndex === index
+
+        contentItem: Text {
+          id: delegateLabel
+          text: model[comboBox.textRole] ?? ""
+          font: Theme.defaultFont
+          color: comboBox.currentIndex === index ? Theme.mainColor : Theme.mainTextColor
+          wrapMode: Text.WordWrap
+          verticalAlignment: Text.AlignVCenter
+        }
+      }
+
       displayText: {
         if (!isEditing && value === "") {
           return qsTr("Empty");
@@ -357,21 +372,6 @@ Item {
                 text: section
                 visible: featureListModel.displayGroupName
               }
-            }
-          }
-
-          delegate: ItemDelegate {
-            width: ListView.view.width
-            height: Math.max(delegateLabel.implicitHeight + 16, 48)
-            highlighted: comboBox.highlightedIndex === index
-
-            contentItem: Text {
-              id: delegateLabel
-              text: model.display
-              font: Theme.defaultFont
-              color: comboBox.currentIndex === index ? Theme.mainColor : Theme.mainTextColor
-              wrapMode: Text.WordWrap
-              verticalAlignment: Text.AlignVCenter
             }
           }
 

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -296,7 +296,6 @@ Item {
       }
 
       font: Theme.defaultFont
-      text.color: displayedTextColor
       displayText: {
         if (!isEditing && value === "") {
           return qsTr("Empty");
@@ -304,6 +303,18 @@ Item {
           return qsTr("NULL");
         }
         return comboBox.currentIndex === -1 && value !== undefined ? '(' + value + ')' : comboBox.currentText;
+      }
+
+      contentItem: Text {
+        leftPadding: comboBox.background.visible ? 8 : 0
+        rightPadding: comboBox.indicator.width + comboBox.spacing
+        topPadding: 8
+        bottomPadding: 8
+        text: comboBox.displayText
+        font: Theme.defaultFont
+        color: displayedTextColor
+        verticalAlignment: Text.AlignVCenter
+        wrapMode: Text.WordWrap
       }
 
       popup: Popup {

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -350,6 +350,22 @@ Item {
             }
           }
 
+          delegate: ItemDelegate {
+            width: ListView.view.width
+            height: Math.max(delegateLabel.implicitHeight + 16, 48)
+            highlighted: comboBox.highlightedIndex === index
+
+            contentItem: Text {
+              id: delegateLabel
+              text: model.display
+              font: Theme.defaultFont
+              color: highlighted ? Theme.mainColor : Theme.mainTextColor
+              wrapMode: Text.WordWrap
+              verticalAlignment: Text.AlignVCenter
+              leftPadding: 8
+            }
+          }
+
           ScrollIndicator.vertical: ScrollIndicator {}
         }
       }


### PR DESCRIPTION
### 🚀 Description

Long display values in a ValueRelation field were being silently truncated with an ellipsis (…) in both the collapsed combobox and the dropdown list, with no way for the user to read the full text.

### ✨ Key Changes

- `Dropdown list` — added a custom delegate to the popup's `ListView` with `wrapMode: Text.WordWrap` and dynamic item height.


### Issue 


https://github.com/user-attachments/assets/d2bb4825-ceb2-4623-8049-a59f07389692



### New UI


https://github.com/user-attachments/assets/46d429c9-327d-4871-83ad-e5751f561b22

---

Related to https://github.com/opengisch/QField/issues/6678