### PR TITLE
Add cloud project cloning

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1254,19 +1254,25 @@ void QFieldCloudProjectsModel::cloneProject( const QString &projectId, const QSt
   mIsCloning = true;
   emit isCloningChanged();
 
-  QString finalizedName = name;
-  finalizedName.replace( QRegularExpression( "[^A-Za-z0-9_]" ), QStringLiteral( "_" ) );
-
-  QStringList projectNames;
-  for ( const QFieldCloudProject *project : mProjects )
-  {
-    projectNames << project->name().toLower();
-  }
+  static const QRegularExpression sInvalidChars( "[^A-Za-z0-9_]" );
+  QString baseName = name;
+  baseName.replace( sInvalidChars, QStringLiteral( "_" ) );
+  QString finalizedName = baseName;
 
   int uniqueSuffix = 1;
-  while ( projectNames.contains( finalizedName.toLower() ) )
+  bool nameExists = true;
+  while ( nameExists )
   {
-    finalizedName = QStringLiteral( "%1_%2" ).arg( name, QString::number( uniqueSuffix++ ) );
+    nameExists = false;
+    for ( const QFieldCloudProject *project : mProjects )
+    {
+      if ( project->name().compare( finalizedName, Qt::CaseInsensitive ) == 0 )
+      {
+        nameExists = true;
+        finalizedName = QStringLiteral( "%1_%2" ).arg( baseName, QString::number( uniqueSuffix++ ) );
+        break;
+      }
+    }
   }
 
   QVariantMap params;

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1243,6 +1243,76 @@ void QFieldCloudProjectsModel::projectCreationReceived()
   emit isCreatingChanged();
 }
 
+void QFieldCloudProjectsModel::cloneProject( const QString &projectId, const QString &name )
+{
+  if ( projectId.isEmpty() || name.isEmpty() )
+  {
+    emit projectCloned( QString(), true, tr( "Project cloning requires a source project and a name" ) );
+    return;
+  }
+
+  mIsCloning = true;
+  emit isCloningChanged();
+
+  QString finalizedName = name;
+  finalizedName.replace( QRegularExpression( "[^A-Za-z0-9_]" ), QStringLiteral( "_" ) );
+
+  QStringList projectNames;
+  for ( const QFieldCloudProject *project : mProjects )
+  {
+    projectNames << project->name().toLower();
+  }
+
+  int uniqueSuffix = 1;
+  while ( projectNames.contains( finalizedName.toLower() ) )
+  {
+    finalizedName = QStringLiteral( "%1_%2" ).arg( name, QString::number( uniqueSuffix++ ) );
+  }
+
+  QVariantMap params;
+  params.insert( QStringLiteral( "name" ), finalizedName );
+  params.insert( QStringLiteral( "owner" ), mUsername );
+  params.insert( QStringLiteral( "description" ), QString() );
+  params.insert( QStringLiteral( "private" ), true );
+
+  params.insert( QStringLiteral( "clone_from_project" ), projectId );
+  QNetworkRequest request;
+  const NetworkReply *reply = mCloudConnection->post( request, QStringLiteral( "/api/v1/projects/" ), params );
+  connect( reply, &NetworkReply::finished, this, &QFieldCloudProjectsModel::projectCloneReceived );
+}
+
+void QFieldCloudProjectsModel::projectCloneReceived()
+{
+  NetworkReply *reply = qobject_cast<NetworkReply *>( sender() );
+  QNetworkReply *rawReply = reply->currentRawReply();
+  Q_ASSERT( rawReply );
+
+  if ( rawReply->error() != QNetworkReply::NoError )
+  {
+    emit projectCloned( QString(), true, mCloudConnection->errorString( rawReply ) );
+    mIsCloning = false;
+    emit isCloningChanged();
+    return;
+  }
+
+  QByteArray response = rawReply->readAll();
+  QJsonDocument doc = QJsonDocument::fromJson( response );
+  QVariantHash projectDetails = doc.object().toVariantHash();
+  QFieldCloudProject *cloudProject = QFieldCloudProject::fromDetails( projectDetails, mCloudConnection, mGpkgFlusher );
+  if ( cloudProject )
+  {
+    insertProjects( QList<QFieldCloudProject *>() << cloudProject );
+    emit projectCloned( cloudProject->id() );
+  }
+  else
+  {
+    emit projectCloned( QString(), true, tr( "Cloud project could not be cloned." ) );
+  }
+
+  mIsCloning = false;
+  emit isCloningChanged();
+}
+
 // --
 
 QFieldCloudProjectsFilterModel::QFieldCloudProjectsFilterModel( QObject *parent )

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1152,12 +1152,11 @@ void QFieldCloudProjectsModel::createProject( const QString &name, const QString
 {
   if ( name.isEmpty() )
   {
-    emit projectCreated( QString(), !fromProjectId.isEmpty(), true, tr( "Project creation requires a name" ) );
+    emit projectCreated( QString(), fromProjectId, true, tr( "Project creation requires a name" ) );
     return;
   }
 
   mIsCreating = true;
-  mPendingCreationIsClone = !fromProjectId.isEmpty();
   emit isCreatingChanged();
 
   QString sanitizedName = name;
@@ -1177,7 +1176,7 @@ void QFieldCloudProjectsModel::createProject( const QString &name, const QString
 
     if ( rawReply->error() != QNetworkReply::NoError )
     {
-      emit projectCreated( QString(), mPendingCreationIsClone, true, mCloudConnection->errorString( rawReply ) );
+      emit projectCreated( QString(), fromProjectId, true, mCloudConnection->errorString( rawReply ) );
       return;
     }
 
@@ -1212,6 +1211,7 @@ void QFieldCloudProjectsModel::createProject( const QString &name, const QString
     }
 
     QNetworkRequest request;
+    request.setAttribute( static_cast<QNetworkRequest::Attribute>( ProjectsRequestAttribute::FromProjectId ), fromProjectId );
     const NetworkReply *creationReply = mCloudConnection->post( request, url, params );
     connect( creationReply, &NetworkReply::finished, this, &QFieldCloudProjectsModel::projectCreationReceived );
   } );
@@ -1223,9 +1223,11 @@ void QFieldCloudProjectsModel::projectCreationReceived()
   QNetworkReply *rawReply = reply->currentRawReply();
   Q_ASSERT( rawReply );
 
+  const QString fromProjectId = rawReply->request().attribute( static_cast<QNetworkRequest::Attribute>( ProjectsRequestAttribute::FromProjectId ) ).toString();
+
   if ( rawReply->error() != QNetworkReply::NoError )
   {
-    emit projectCreated( QString(), mPendingCreationIsClone, true, mCloudConnection->errorString( rawReply ) );
+    emit projectCreated( QString(), fromProjectId, true, mCloudConnection->errorString( rawReply ) );
 
     mIsCreating = false;
     emit isCreatingChanged();
@@ -1239,11 +1241,11 @@ void QFieldCloudProjectsModel::projectCreationReceived()
   if ( cloudProject )
   {
     insertProjects( QList<QFieldCloudProject *>() << cloudProject );
-    emit projectCreated( cloudProject->id(), mPendingCreationIsClone );
+    emit projectCreated( cloudProject->id(), fromProjectId );
   }
   else
   {
-    emit projectCreated( QString(), mPendingCreationIsClone, true, tr( "Cloud project could not be created." ) );
+    emit projectCreated( QString(), fromProjectId, true, tr( "Cloud project could not be created." ) );
   }
 
   mIsCreating = false;

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1148,7 +1148,7 @@ void QFieldCloudProjectsModel::updateLocalizedDataPaths( const QString &projectP
   QgsApplication::instance()->localizedDataPathRegistry()->setPaths( localizedDataPaths );
 }
 
-void QFieldCloudProjectsModel::createProject( QString name )
+void QFieldCloudProjectsModel::createProject( const QString name, const QString fromProjectId )
 {
   if ( name.isEmpty() )
   {
@@ -1159,7 +1159,8 @@ void QFieldCloudProjectsModel::createProject( QString name )
   mIsCreating = true;
   emit isCreatingChanged();
 
-  name.replace( QRegularExpression( "[^A-Za-z0-9_]" ), QStringLiteral( "_" ) );
+  QString sanitizedName = name;
+  sanitizedName.replace( QRegularExpression( "[^A-Za-z0-9_]" ), QStringLiteral( "_" ) );
 
   QString url = QStringLiteral( "/api/v1/projects/?owner=%1" ).arg( mUsername );
   QNetworkRequest request( url );
@@ -1168,7 +1169,7 @@ void QFieldCloudProjectsModel::createProject( QString name )
   mCloudConnection->setAuthenticationDetails( request );
 
   const NetworkReply *listingreply = mCloudConnection->get( request, url );
-  connect( listingreply, &NetworkReply::finished, this, [this, name]() {
+  connect( listingreply, &NetworkReply::finished, this, [this, sanitizedName, fromProjectId]() {
     NetworkReply *reply = qobject_cast<NetworkReply *>( sender() );
     QNetworkReply *rawReply = reply->currentRawReply();
     Q_ASSERT( rawReply );
@@ -1190,10 +1191,10 @@ void QFieldCloudProjectsModel::createProject( QString name )
     }
 
     int uniqueSuffix = 1;
-    QString finalizedName = name;
+    QString finalizedName = sanitizedName;
     while ( projectNames.contains( finalizedName.toLower() ) )
     {
-      finalizedName = QStringLiteral( "%1_%2" ).arg( name, QString::number( uniqueSuffix++ ) );
+      finalizedName = QStringLiteral( "%1_%2" ).arg( sanitizedName, QString::number( uniqueSuffix++ ) );
     }
 
     QString url = QStringLiteral( "/api/v1/projects/" );
@@ -1203,6 +1204,11 @@ void QFieldCloudProjectsModel::createProject( QString name )
     params.insert( QStringLiteral( "owner" ), mUsername );
     params.insert( QStringLiteral( "description" ), QString() );
     params.insert( QStringLiteral( "private" ), true );
+
+    if ( !fromProjectId.isEmpty() )
+    {
+      params.insert( QStringLiteral( "clone_from_project" ), fromProjectId );
+    }
 
     QNetworkRequest request;
     const NetworkReply *creationReply = mCloudConnection->post( request, url, params );
@@ -1241,74 +1247,6 @@ void QFieldCloudProjectsModel::projectCreationReceived()
 
   mIsCreating = false;
   emit isCreatingChanged();
-}
-
-void QFieldCloudProjectsModel::cloneProject( const QString &projectId, const QString &name )
-{
-  if ( projectId.isEmpty() || name.isEmpty() )
-  {
-    emit projectCloned( QString(), true, tr( "Project cloning requires a source project and a name" ) );
-    return;
-  }
-
-  mIsCloning = true;
-  emit isCloningChanged();
-
-  static const QRegularExpression sInvalidChars( "[^A-Za-z0-9_]" );
-  QString baseName = name;
-  baseName.replace( sInvalidChars, QStringLiteral( "_" ) );
-  QString finalizedName = baseName;
-
-  int uniqueSuffix = 1;
-  while ( std::any_of( mProjects.cbegin(), mProjects.cend(), [&finalizedName]( const QFieldCloudProject *project ) {
-    return project->name().compare( finalizedName, Qt::CaseInsensitive ) == 0;
-  } ) )
-  {
-    finalizedName = QStringLiteral( "%1_%2" ).arg( baseName, QString::number( uniqueSuffix++ ) );
-  }
-
-  QVariantMap params;
-  params.insert( QStringLiteral( "name" ), finalizedName );
-  params.insert( QStringLiteral( "owner" ), mUsername );
-  params.insert( QStringLiteral( "description" ), QString() );
-  params.insert( QStringLiteral( "private" ), true );
-
-  params.insert( QStringLiteral( "clone_from_project" ), projectId );
-  QNetworkRequest request;
-  const NetworkReply *reply = mCloudConnection->post( request, QStringLiteral( "/api/v1/projects/" ), params );
-  connect( reply, &NetworkReply::finished, this, &QFieldCloudProjectsModel::projectCloneReceived );
-}
-
-void QFieldCloudProjectsModel::projectCloneReceived()
-{
-  NetworkReply *reply = qobject_cast<NetworkReply *>( sender() );
-  QNetworkReply *rawReply = reply->currentRawReply();
-  Q_ASSERT( rawReply );
-
-  if ( rawReply->error() != QNetworkReply::NoError )
-  {
-    emit projectCloned( QString(), true, mCloudConnection->errorString( rawReply ) );
-    mIsCloning = false;
-    emit isCloningChanged();
-    return;
-  }
-
-  QByteArray response = rawReply->readAll();
-  QJsonDocument doc = QJsonDocument::fromJson( response );
-  QVariantHash projectDetails = doc.object().toVariantHash();
-  QFieldCloudProject *const cloudProject = QFieldCloudProject::fromDetails( projectDetails, mCloudConnection, mGpkgFlusher );
-  if ( cloudProject )
-  {
-    insertProjects( QList<QFieldCloudProject *>() << cloudProject );
-    emit projectCloned( cloudProject->id() );
-  }
-  else
-  {
-    emit projectCloned( QString(), true, tr( "Cloud project could not be cloned." ) );
-  }
-
-  mIsCloning = false;
-  emit isCloningChanged();
 }
 
 // --

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1148,7 +1148,7 @@ void QFieldCloudProjectsModel::updateLocalizedDataPaths( const QString &projectP
   QgsApplication::instance()->localizedDataPathRegistry()->setPaths( localizedDataPaths );
 }
 
-void QFieldCloudProjectsModel::createProject( const QString name, const QString fromProjectId )
+void QFieldCloudProjectsModel::createProject( const QString &name, const QString &fromProjectId )
 {
   if ( name.isEmpty() )
   {

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1241,7 +1241,7 @@ void QFieldCloudProjectsModel::projectCreationReceived()
   if ( cloudProject )
   {
     insertProjects( QList<QFieldCloudProject *>() << cloudProject );
-    emit projectCreated( cloudProject->id(), fromProjectId );
+    emit projectCreated( cloudProject->id(), fromProjectId, false, QString() );
   }
   else
   {

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1260,19 +1260,11 @@ void QFieldCloudProjectsModel::cloneProject( const QString &projectId, const QSt
   QString finalizedName = baseName;
 
   int uniqueSuffix = 1;
-  bool nameExists = true;
-  while ( nameExists )
+  while ( std::any_of( mProjects.cbegin(), mProjects.cend(), [&finalizedName]( const QFieldCloudProject *project ) {
+    return project->name().compare( finalizedName, Qt::CaseInsensitive ) == 0;
+  } ) )
   {
-    nameExists = false;
-    for ( const QFieldCloudProject *project : mProjects )
-    {
-      if ( project->name().compare( finalizedName, Qt::CaseInsensitive ) == 0 )
-      {
-        nameExists = true;
-        finalizedName = QStringLiteral( "%1_%2" ).arg( baseName, QString::number( uniqueSuffix++ ) );
-        break;
-      }
-    }
+    finalizedName = QStringLiteral( "%1_%2" ).arg( baseName, QString::number( uniqueSuffix++ ) );
   }
 
   QVariantMap params;
@@ -1304,7 +1296,7 @@ void QFieldCloudProjectsModel::projectCloneReceived()
   QByteArray response = rawReply->readAll();
   QJsonDocument doc = QJsonDocument::fromJson( response );
   QVariantHash projectDetails = doc.object().toVariantHash();
-  QFieldCloudProject *cloudProject = QFieldCloudProject::fromDetails( projectDetails, mCloudConnection, mGpkgFlusher );
+  QFieldCloudProject *const cloudProject = QFieldCloudProject::fromDetails( projectDetails, mCloudConnection, mGpkgFlusher );
   if ( cloudProject )
   {
     insertProjects( QList<QFieldCloudProject *>() << cloudProject );

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -1152,11 +1152,12 @@ void QFieldCloudProjectsModel::createProject( const QString name, const QString 
 {
   if ( name.isEmpty() )
   {
-    emit projectCreated( QString(), true, tr( "Project creation requires a name" ) );
+    emit projectCreated( QString(), !fromProjectId.isEmpty(), true, tr( "Project creation requires a name" ) );
     return;
   }
 
   mIsCreating = true;
+  mPendingCreationIsClone = !fromProjectId.isEmpty();
   emit isCreatingChanged();
 
   QString sanitizedName = name;
@@ -1176,7 +1177,7 @@ void QFieldCloudProjectsModel::createProject( const QString name, const QString 
 
     if ( rawReply->error() != QNetworkReply::NoError )
     {
-      emit projectCreated( QString(), true, mCloudConnection->errorString( rawReply ) );
+      emit projectCreated( QString(), mPendingCreationIsClone, true, mCloudConnection->errorString( rawReply ) );
       return;
     }
 
@@ -1224,7 +1225,7 @@ void QFieldCloudProjectsModel::projectCreationReceived()
 
   if ( rawReply->error() != QNetworkReply::NoError )
   {
-    emit projectCreated( QString(), true, mCloudConnection->errorString( rawReply ) );
+    emit projectCreated( QString(), mPendingCreationIsClone, true, mCloudConnection->errorString( rawReply ) );
 
     mIsCreating = false;
     emit isCreatingChanged();
@@ -1238,11 +1239,11 @@ void QFieldCloudProjectsModel::projectCreationReceived()
   if ( cloudProject )
   {
     insertProjects( QList<QFieldCloudProject *>() << cloudProject );
-    emit projectCreated( cloudProject->id() );
+    emit projectCreated( cloudProject->id(), mPendingCreationIsClone );
   }
   else
   {
-    emit projectCreated( QString(), true, tr( "Cloud project could not be created." ) );
+    emit projectCreated( QString(), mPendingCreationIsClone, true, tr( "Cloud project could not be created." ) );
   }
 
   mIsCreating = false;

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -216,7 +216,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void gpkgFlusherChanged();
     void warning( const QString &message );
 
-    void projectCreated( const QString &projectId, const QString &fromProjectId = QString(), const bool hasError = false, const QString &errorString = QString() );
+    void projectCreated( const QString &projectId, const QString &fromProjectId, const bool hasError, const QString &errorString );
     void projectAppended( const QString &projectId, const bool hasError = false, const QString &errorString = QString() );
     void projectsAppended( const QString &owner, const QString &search, const bool hasError = false, const QString &errorString = QString() );
     void projectDownloaded( const QString &projectId, const QString &projectName, const QString &projectOwner, const bool hasError = false, const QString &errorString = QString() );

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -52,6 +52,9 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Returns TRUE whether the model is creating a project
     Q_PROPERTY( bool isCreating READ isCreating NOTIFY isCreatingChanged )
 
+    //! Returns TRUE whether the model is cloning a project
+    Q_PROPERTY( bool isCloning READ isCloning NOTIFY isCloningChanged )
+
     //! Currently busy project ids.
     Q_PROPERTY( QSet<QString> busyProjectIds READ busyProjectIds NOTIFY busyProjectIdsChanged )
 
@@ -124,6 +127,9 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
     //! Returns TRUE whether the model is being refreshed
     bool isCreating() const { return mIsCreating; }
+
+    //! Returns TRUE whether the model is cloning a project
+    bool isCloning() const { return mIsCloning; }
 
     //! Returns the cloud project id of the currently opened project.
     QString currentProjectId() const;
@@ -204,6 +210,9 @@ class QFieldCloudProjectsModel : public QAbstractListModel
      */
     Q_INVOKABLE void createProject( const QString name );
 
+    //! Clones a cloud project with given \a projectId using \a name as the cloned project name.
+    Q_INVOKABLE void cloneProject( const QString &projectId, const QString &name );
+
   signals:
     void cloudConnectionChanged();
     void layerObserverChanged();
@@ -216,6 +225,8 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void warning( const QString &message );
 
     void projectCreated( const QString &projectId, const bool hasError = false, const QString &errorString = QString() );
+    void projectCloned( const QString &projectId, const bool hasError = false, const QString &errorString = QString() );
+    void isCloningChanged();
     void projectAppended( const QString &projectId, const bool hasError = false, const QString &errorString = QString() );
     void projectsAppended( const QString &owner, const QString &search, const bool hasError = false, const QString &errorString = QString() );
     void projectDownloaded( const QString &projectId, const QString &projectName, const QString &projectOwner, const bool hasError = false, const QString &errorString = QString() );
@@ -233,6 +244,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void projectListReceived();
     void projectReceived();
     void projectCreationReceived();
+    void projectCloneReceived();
 
   private:
     void setupProjectConnections( QFieldCloudProject *project );
@@ -250,6 +262,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
     bool mIsRefreshing = false;
     bool mIsCreating = false;
+    bool mIsCloning = false;
 
     QString mCurrentProjectId;
     QPointer<QFieldCloudProject> mCurrentProject;

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -52,9 +52,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     //! Returns TRUE whether the model is creating a project
     Q_PROPERTY( bool isCreating READ isCreating NOTIFY isCreatingChanged )
 
-    //! Returns TRUE whether the model is cloning a project
-    Q_PROPERTY( bool isCloning READ isCloning NOTIFY isCloningChanged )
-
     //! Currently busy project ids.
     Q_PROPERTY( QSet<QString> busyProjectIds READ busyProjectIds NOTIFY busyProjectIdsChanged )
 
@@ -127,9 +124,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
     //! Returns TRUE whether the model is being refreshed
     bool isCreating() const { return mIsCreating; }
-
-    //! Returns TRUE whether the model is cloning a project
-    bool isCloning() const { return mIsCloning; }
 
     //! Returns the cloud project id of the currently opened project.
     QString currentProjectId() const;
@@ -208,10 +202,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
      * The converted project will then be removed from the local storage in favor of a newly packaged
      * cloud project downloaded from the server.
      */
-    Q_INVOKABLE void createProject( const QString name );
-
-    //! Clones a cloud project with given \a projectId using \a name as the cloned project name.
-    Q_INVOKABLE void cloneProject( const QString &projectId, const QString &name );
+    Q_INVOKABLE void createProject( const QString name, const QString fromProjectId = QString() );
 
   signals:
     void cloudConnectionChanged();
@@ -225,8 +216,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void warning( const QString &message );
 
     void projectCreated( const QString &projectId, const bool hasError = false, const QString &errorString = QString() );
-    void projectCloned( const QString &projectId, const bool hasError = false, const QString &errorString = QString() );
-    void isCloningChanged();
     void projectAppended( const QString &projectId, const bool hasError = false, const QString &errorString = QString() );
     void projectsAppended( const QString &owner, const QString &search, const bool hasError = false, const QString &errorString = QString() );
     void projectDownloaded( const QString &projectId, const QString &projectName, const QString &projectOwner, const bool hasError = false, const QString &errorString = QString() );
@@ -244,7 +233,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void projectListReceived();
     void projectReceived();
     void projectCreationReceived();
-    void projectCloneReceived();
 
   private:
     void setupProjectConnections( QFieldCloudProject *project );
@@ -262,7 +250,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
     bool mIsRefreshing = false;
     bool mIsCreating = false;
-    bool mIsCloning = false;
 
     QString mCurrentProjectId;
     QPointer<QFieldCloudProject> mCurrentProject;

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -215,7 +215,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void gpkgFlusherChanged();
     void warning( const QString &message );
 
-    void projectCreated( const QString &projectId, const bool hasError = false, const QString &errorString = QString() );
+    void projectCreated( const QString &projectId, const bool isClone = false, const bool hasError = false, const QString &errorString = QString() );
     void projectAppended( const QString &projectId, const bool hasError = false, const QString &errorString = QString() );
     void projectsAppended( const QString &owner, const QString &search, const bool hasError = false, const QString &errorString = QString() );
     void projectDownloaded( const QString &projectId, const QString &projectName, const QString &projectOwner, const bool hasError = false, const QString &errorString = QString() );
@@ -250,6 +250,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
     bool mIsRefreshing = false;
     bool mIsCreating = false;
+    bool mPendingCreationIsClone = false;
 
     QString mCurrentProjectId;
     QPointer<QFieldCloudProject> mCurrentProject;

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -202,7 +202,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
      * The converted project will then be removed from the local storage in favor of a newly packaged
      * cloud project downloaded from the server.
      */
-    Q_INVOKABLE void createProject( const QString name, const QString fromProjectId = QString() );
+    Q_INVOKABLE void createProject( const QString &name, const QString &fromProjectId = QString() );
 
   signals:
     void cloudConnectionChanged();

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.h
@@ -101,6 +101,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
       ProjectId = QNetworkRequest::User + 4,
       ProjectOwnerName = QNetworkRequest::User + 5,
       ProjectSearchTerm = QNetworkRequest::User + 6,
+      FromProjectId = QNetworkRequest::User + 7,
     };
 
     Q_ENUM( ColumnRole )
@@ -215,7 +216,7 @@ class QFieldCloudProjectsModel : public QAbstractListModel
     void gpkgFlusherChanged();
     void warning( const QString &message );
 
-    void projectCreated( const QString &projectId, const bool isClone = false, const bool hasError = false, const QString &errorString = QString() );
+    void projectCreated( const QString &projectId, const QString &fromProjectId = QString(), const bool hasError = false, const QString &errorString = QString() );
     void projectAppended( const QString &projectId, const bool hasError = false, const QString &errorString = QString() );
     void projectsAppended( const QString &owner, const QString &search, const bool hasError = false, const QString &errorString = QString() );
     void projectDownloaded( const QString &projectId, const QString &projectName, const QString &projectOwner, const bool hasError = false, const QString &errorString = QString() );
@@ -250,7 +251,6 @@ class QFieldCloudProjectsModel : public QAbstractListModel
 
     bool mIsRefreshing = false;
     bool mIsCreating = false;
-    bool mPendingCreationIsClone = false;
 
     QString mCurrentProjectId;
     QPointer<QFieldCloudProject> mCurrentProject;

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -786,8 +786,8 @@ Popup {
       }
     }
 
-    function onProjectCreated(projectId, isClone, hasError, errorString) {
-      if (isClone) {
+    function onProjectCreated(projectId, fromProjectId, hasError, errorString) {
+      if (fromProjectId !== "") {
         return;
       }
       if (!qfieldCloudPopup.visible) {

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -786,7 +786,10 @@ Popup {
       }
     }
 
-    function onProjectCreated(projectId, hasError, errorString) {
+    function onProjectCreated(projectId, isClone, hasError, errorString) {
+      if (isClone) {
+        return;
+      }
       if (!qfieldCloudPopup.visible) {
         qfieldCloudPopup.visible = true;
       }

--- a/src/qml/QFieldCloudProjectDetails.qml
+++ b/src/qml/QFieldCloudProjectDetails.qml
@@ -327,6 +327,7 @@ ColumnLayout {
   QfButton {
     id: downloadProjectInDetailsLayout
     Layout.fillWidth: true
+    dropdown: !showProgress
     progressValue: cloudProject ? cloudProject.downloadProgress : 0
     showProgress: cloudProject != undefined && cloudProject.status === QFieldCloudProject.ProjectStatus.Downloading
     text: {
@@ -352,11 +353,16 @@ ColumnLayout {
         cloudProjectsModel.projectPackageAndDownload(cloudProject.id);
       }
     }
+
+    onDropdownClicked: {
+      projectDetailsMenu.popup(downloadProjectInDetailsLayout.width - projectDetailsMenu.width, downloadProjectInDetailsLayout.y);
+    }
   }
 
   QfButton {
     id: openProjectBtn
     Layout.fillWidth: true
+    dropdown: true
     text: qsTr("Open project")
     visible: cloudProject != undefined && cloudProject.localPath !== ""
     enabled: cloudProject != undefined && cloudProject.localPath !== "" && cloudProject.status === QFieldCloudProject.Idle
@@ -368,6 +374,26 @@ ColumnLayout {
       }
       projectsSwipeView.currentIndex = 0;
       cloudProject = undefined;
+    }
+
+    onDropdownClicked: {
+      projectDetailsMenu.popup(openProjectBtn.width - projectDetailsMenu.width, openProjectBtn.y);
+    }
+  }
+
+  QfMenu {
+    id: projectDetailsMenu
+
+    MenuItem {
+      font: Theme.defaultFont
+      width: parent.width
+      height: 48
+      leftPadding: Theme.menuItemLeftPadding
+      text: qsTr("Clone project")
+      onTriggered: {
+        cloneProjectName.text = cloudProject.name;
+        cloneProjectDialog.open();
+      }
     }
   }
 }

--- a/src/qml/QFieldCloudProjectDetails.qml
+++ b/src/qml/QFieldCloudProjectDetails.qml
@@ -391,6 +391,7 @@ ColumnLayout {
       leftPadding: Theme.menuItemLeftPadding
       text: qsTr("Clone project")
       onTriggered: {
+        cloneProjectDialog.sourceProjectId = cloudProject.id;
         cloneProjectName.text = cloudProject.name;
         cloneProjectDialog.open();
       }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -928,9 +928,10 @@ Page {
     id: cloneProjectDialog
     parent: mainWindow.contentItem
     title: qsTr("Project Cloning")
+    width: mainWindow.width - 40
 
     ColumnLayout {
-      width: parent.width
+      width: cloneProjectDialog.availableWidth
       spacing: 10
 
       Label {

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -1004,11 +1004,11 @@ Page {
       }
     }
 
-    function onProjectCreated(projectId, hasError, errorString) {
+    function onProjectCreated(projectId, isClone, hasError, errorString) {
       if (hasError) {
-        displayToast(qsTr("Project creation failed: %1").arg(errorString));
+        displayToast(isClone ? qsTr("Project cloning failed: %1").arg(errorString) : qsTr("Project creation failed: %1").arg(errorString));
       } else {
-        displayToast(qsTr("Project successfully created"));
+        displayToast(isClone ? qsTr("Project successfully cloned") : qsTr("Project successfully created"));
       }
     }
   }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -946,8 +946,9 @@ Page {
     }
 
     onAccepted: {
-      if (cloneProjectName.text !== "") {
-        cloudProjectsModel.cloneProject(projectActions.projectId, cloneProjectName.text);
+      const trimmedName = cloneProjectName.text.trim();
+      if (trimmedName !== "") {
+        cloudProjectsModel.cloneProject(projectActions.projectId, trimmedName);
       }
     }
   }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -849,6 +849,7 @@ Page {
 
       text: qsTr("Clone Project")
       onTriggered: {
+        cloneProjectDialog.sourceProjectId = projectActions.projectId;
         cloneProjectName.text = projectActions.projectName;
         cloneProjectDialog.open();
       }
@@ -929,6 +930,7 @@ Page {
     parent: mainWindow.contentItem
     title: qsTr("Project Cloning")
     width: mainWindow.width - 40
+    property string sourceProjectId: ""
 
     ColumnLayout {
       width: cloneProjectDialog.availableWidth
@@ -949,7 +951,7 @@ Page {
     onAccepted: {
       const trimmedName = cloneProjectName.text.trim();
       if (trimmedName !== "") {
-        cloudProjectsModel.cloneProject(projectActions.projectId, trimmedName);
+        cloudProjectsModel.cloneProject(sourceProjectId, trimmedName);
       }
     }
   }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -838,6 +838,22 @@ Page {
         border.color: "transparent"
       }
     }
+
+    MenuItem {
+      id: cloneProject
+
+      font: Theme.defaultFont
+      width: parent.width
+      height: visible ? 48 : 0
+      leftPadding: Theme.menuItemLeftPadding
+
+      text: qsTr("Clone Project")
+      onTriggered: {
+        cloneProjectName.text = projectActions.projectName;
+        cloneProjectDialog.open();
+      }
+    }
+
     MenuItem {
       id: removeProject
 
@@ -908,6 +924,34 @@ Page {
     }
   }
 
+  QfDialog {
+    id: cloneProjectDialog
+    parent: mainWindow.contentItem
+    title: qsTr("Project Cloning")
+
+    ColumnLayout {
+      width: parent.width
+      spacing: 10
+
+      Label {
+        Layout.fillWidth: true
+        wrapMode: Text.WordWrap
+        text: qsTr("What name do you want to give to your cloned project?")
+      }
+
+      QfTextField {
+        id: cloneProjectName
+        Layout.fillWidth: true
+      }
+    }
+
+    onAccepted: {
+      if (cloneProjectName.text !== "") {
+        cloudProjectsModel.cloneProject(projectActions.projectId, cloneProjectName.text);
+      }
+    }
+  }
+
   Connections {
     id: codeReaderConnection
     target: codeReader
@@ -953,6 +997,14 @@ Page {
           projectDetails.cloudProject = cloudProjectsModel.findProject(projectId);
           projectsSwipeView.currentIndex = 1;
         }
+      }
+    }
+
+    function onProjectCloned(projectId, hasError, errorString) {
+      if (hasError) {
+        displayToast(qsTr("Project cloning failed: %1").arg(errorString));
+      } else {
+        displayToast(qsTr("Project successfully cloned"));
       }
     }
   }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -1004,7 +1004,8 @@ Page {
       }
     }
 
-    function onProjectCreated(projectId, isClone, hasError, errorString) {
+    function onProjectCreated(projectId, fromProjectId, hasError, errorString) {
+      const isClone = fromProjectId !== "";
       if (hasError) {
         displayToast(isClone ? qsTr("Project cloning failed: %1").arg(errorString) : qsTr("Project creation failed: %1").arg(errorString));
       } else {

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -951,7 +951,7 @@ Page {
     onAccepted: {
       const trimmedName = cloneProjectName.text.trim();
       if (trimmedName !== "") {
-        cloudProjectsModel.cloneProject(sourceProjectId, trimmedName);
+        cloudProjectsModel.createProject(trimmedName, sourceProjectId);
       }
     }
   }
@@ -1004,11 +1004,11 @@ Page {
       }
     }
 
-    function onProjectCloned(projectId, hasError, errorString) {
+    function onProjectCreated(projectId, hasError, errorString) {
       if (hasError) {
-        displayToast(qsTr("Project cloning failed: %1").arg(errorString));
+        displayToast(qsTr("Project creation failed: %1").arg(errorString));
       } else {
-        displayToast(qsTr("Project successfully cloned"));
+        displayToast(qsTr("Project successfully created"));
       }
     }
   }

--- a/test/qml/tst_qfieldCloudScreenUI.qml
+++ b/test/qml/tst_qfieldCloudScreenUI.qml
@@ -59,6 +59,10 @@ TestCase {
     width: 400
     height: 600
 
+    function displayToast(message, type, actionText, actionCallback) {
+    // no-op for test environment
+    }
+
     QFieldControls.QFieldCloudScreen {
       id: qfieldCloudScreen
       width: mainWindow.width
@@ -109,6 +113,12 @@ TestCase {
     signalName: "currentProjectChanged"
   }
 
+  SignalSpy {
+    id: projectCreatedSpy
+    target: cloudProjectsModel
+    signalName: "projectCreated"
+  }
+
   function cleanup() {
     if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
       cloudConnection.logout();
@@ -123,6 +133,7 @@ TestCase {
     currentProjectIdSpy.clear();
     currentProjectSpy.clear();
     subscriptionSpy.clear();
+    projectCreatedSpy.clear();
   }
 
   // Returns all available server configurations (local if provided, remote if provided)
@@ -199,6 +210,18 @@ TestCase {
       wait(1000);
     }
     return projectInfo;
+  }
+
+  // Helper: Find a project id by name
+  function findProjectIdByName(projectName) {
+    for (let i = 0; i < cloudProjectsModel.rowCount(); i++) {
+      const index = cloudProjectsModel.index(i, 0);
+      const name = cloudProjectsModel.data(index, QFieldCloudProjectsModel.NameRole);
+      if (name === projectName) {
+        return cloudProjectsModel.data(index, QFieldCloudProjectsModel.IdRole);
+      }
+    }
+    return "";
   }
 
   /**
@@ -548,5 +571,100 @@ TestCase {
     verify(info.storageTotal > 0);
     verify(info.storageUsed >= 0);
     verify(info.status !== "");
+  }
+
+  /**
+   * Tests that createProject with an empty name fails fast and preserves fromProjectId.
+   *
+   * Scenario: Calling createProject with an empty name emits projectCreated synchronously
+   * with hasError true and the original fromProjectId, so callers can distinguish
+   * create vs clone failures from the signal alone.
+   */
+  function test_12_createProjectEmptyNameFailsWithFromProjectId_data() {
+    return serverConfigs();
+  }
+  function test_12_createProjectEmptyNameFailsWithFromProjectId(data) {
+    loginToServer(data);
+    projectCreatedSpy.clear();
+
+    const sourceId = "some-source-id";
+    cloudProjectsModel.createProject("", sourceId);
+    tryCompare(projectCreatedSpy, "count", 1, 5000);
+
+    // projectCreated(projectId, fromProjectId, hasError, errorString)
+    const args = projectCreatedSpy.signalArguments[0];
+    compare(args[0], "");
+    compare(args[1], sourceId);
+    compare(args[2], true);
+    verify(args[3] !== "");
+  }
+
+  /**
+   * Tests plain project creation emits an empty fromProjectId.
+   *
+   * Scenario: createProject without a source id results in projectCreated where
+   * fromProjectId is empty, which is how the UI distinguishes a regular creation
+   * from a clone operation.
+   */
+  function test_13_createProjectEmitsEmptyFromProjectId_data() {
+    return remoteConfigs();
+  }
+  function test_13_createProjectEmitsEmptyFromProjectId(data) {
+    loginAndRefresh(data);
+    projectCreatedSpy.clear();
+
+    const projectName = "TestCreate_" + Date.now();
+    cloudProjectsModel.createProject(projectName);
+
+    tryCompare(projectCreatedSpy, "count", 1, 60000);
+
+    const args = projectCreatedSpy.signalArguments[0];
+    verify(args[0] !== "");
+    compare(args[1], "");
+    compare(args[2], false);
+
+    const createdProject = cloudProjectsModel.findProject(args[0]);
+    verify(createdProject !== null);
+    verify(createdProject.name.indexOf("TestCreate_") === 0);
+  }
+
+  /**
+   * Tests cloning a cloud project end-to-end via createProject with a fromProjectId.
+   *
+   * Scenario: Clone QFieldCloudTesting; verify projectCreated carries the source
+   * project id back, a new project appears in the model, and the original is intact.
+   */
+  function test_14_cloneProjectViaCreateProject_data() {
+    return remoteConfigs();
+  }
+  function test_14_cloneProjectViaCreateProject(data) {
+    loginAndRefresh(data);
+    verify(cloudProjectsModel.rowCount() > 0);
+
+    const sourceProjectId = findProjectIdByName("QFieldCloudTesting");
+    verify(sourceProjectId !== "");
+
+    projectCreatedSpy.clear();
+    const cloneName = "TestClone_" + Date.now();
+    cloudProjectsModel.createProject(cloneName, sourceProjectId);
+
+    tryCompare(projectCreatedSpy, "count", 1, 60000);
+
+    const args = projectCreatedSpy.signalArguments[0];
+    const newProjectId = args[0];
+    const fromProjectId = args[1];
+    const hasError = args[2];
+
+    compare(hasError, false);
+    compare(fromProjectId, sourceProjectId);
+    verify(newProjectId !== "");
+
+    const clonedProject = cloudProjectsModel.findProject(newProjectId);
+    verify(clonedProject !== null);
+
+    // Source project must remain in the model after cloning
+    const sourceProject = cloudProjectsModel.findProject(sourceProjectId);
+    verify(sourceProject !== null);
+    compare(sourceProject.name, "QFieldCloudTesting");
   }
 }

--- a/test/test_qml.cpp
+++ b/test/test_qml.cpp
@@ -195,6 +195,7 @@ class Setup : public QObject
       iface->setParent( engine );
       AppInterface::setInstance( iface );
       engine->rootContext()->setContextProperty( QStringLiteral( "iface" ), iface );
+      engine->globalObject().setProperty( QStringLiteral( "displayToast" ), engine->evaluate( QStringLiteral( "(function() {})" ) ) );
     }
 };
 

--- a/test/test_qml.cpp
+++ b/test/test_qml.cpp
@@ -195,7 +195,6 @@ class Setup : public QObject
       iface->setParent( engine );
       AppInterface::setInstance( iface );
       engine->rootContext()->setContextProperty( QStringLiteral( "iface" ), iface );
-      engine->globalObject().setProperty( QStringLiteral( "displayToast" ), engine->evaluate( QStringLiteral( "(function() {})" ) ) );
     }
 };
 


### PR DESCRIPTION
Introduces the ability to clone a QFieldCloud project directly from within QField, laying the groundwork for the upcoming project templates feature in QFieldCloud.

Users can now clone any cloud project from two entry points:
- The 3-dot menu in the projects list
- The dropdown on the "Download project" and "Open project" buttons in the project details panel

When triggered, a dialog pre-filled with the source project's name is presented. The cloned project name is sanitized and guaranteed to be unique by appending a numerical suffix if needed. On success the cloned project appears immediately in the projects list and a toast notification is shown

https://github.com/user-attachments/assets/1f72df13-809a-4978-95a6-19fd443a79dc