### PR TITLE
Add plugin geometry injection API for the 3D map scene

### DIFF
--- a/src/core/3d/quick3dgeometryconfiguration.cpp
+++ b/src/core/3d/quick3dgeometryconfiguration.cpp
@@ -1,0 +1,63 @@
+/***************************************************************************
+  quick3dgeometryconfiguration.cpp - Quick3DGeometryConfiguration
+
+ ---------------------
+ begin                : 16.6.2026
+ copyright            : (C) 2026 by Mohsen Dehghanzadeh
+ email                : mohsen@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "quick3dgeometryconfiguration.h"
+
+Quick3DGeometryConfiguration::Quick3DGeometryConfiguration( QQuickItem *parent )
+  : QQuickItem( parent )
+{
+  setVisible( false );
+}
+
+void Quick3DGeometryConfiguration::setWkt( const QString &wkt )
+{
+  if ( mWkt == wkt )
+  {
+    return;
+  }
+  mWkt = wkt;
+  emit wktChanged();
+}
+
+void Quick3DGeometryConfiguration::setCrs( const QgsCoordinateReferenceSystem &crs )
+{
+  if ( mCrs == crs )
+  {
+    return;
+  }
+  mCrs = crs;
+  emit crsChanged();
+}
+
+void Quick3DGeometryConfiguration::setLineColor( const QColor &color )
+{
+  if ( mLineColor == color )
+  {
+    return;
+  }
+  mLineColor = color;
+  emit lineColorChanged();
+}
+
+void Quick3DGeometryConfiguration::setLineWidth( float width )
+{
+  if ( qFuzzyCompare( mLineWidth, width ) )
+  {
+    return;
+  }
+  mLineWidth = width;
+  emit lineWidthChanged();
+}

--- a/src/core/3d/quick3dgeometryconfiguration.h
+++ b/src/core/3d/quick3dgeometryconfiguration.h
@@ -30,7 +30,6 @@
 class Quick3DGeometryConfiguration : public QQuickItem
 {
     Q_OBJECT
-    QML_ELEMENT
 
     //! WKT representation of the geometry to render
     Q_PROPERTY( QString wkt READ wkt WRITE setWkt NOTIFY wktChanged )

--- a/src/core/3d/quick3dgeometryconfiguration.h
+++ b/src/core/3d/quick3dgeometryconfiguration.h
@@ -1,0 +1,72 @@
+/***************************************************************************
+  quick3dgeometryconfiguration.h - Quick3DGeometryConfiguration
+
+ ---------------------
+ begin                : 16.6.2026
+ copyright            : (C) 2026 by Mohsen Dehghanzadeh
+ email                : mohsen@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QUICK3DGEOMETRYCONFIGURATION_H
+#define QUICK3DGEOMETRYCONFIGURATION_H
+
+#include <QColor>
+#include <QQuickItem>
+#include <qgscoordinatereferencesystem.h>
+
+/**
+ * \brief Lightweight data item used by plugins to inject geometry into the 3D map scene.
+ *
+ * \note QML Type: Quick3DGeometryConfiguration
+ * \ingroup core
+ */
+class Quick3DGeometryConfiguration : public QQuickItem
+{
+    Q_OBJECT
+    QML_ELEMENT
+
+    //! WKT representation of the geometry to render
+    Q_PROPERTY( QString wkt READ wkt WRITE setWkt NOTIFY wktChanged )
+    //! Coordinate reference system the geometry is expressed in
+    Q_PROPERTY( QgsCoordinateReferenceSystem crs READ crs WRITE setCrs NOTIFY crsChanged )
+    //! Color of the rendered geometry
+    Q_PROPERTY( QColor lineColor READ lineColor WRITE setLineColor NOTIFY lineColorChanged )
+    //! Outline tube thickness in scene units
+    Q_PROPERTY( float lineWidth READ lineWidth WRITE setLineWidth NOTIFY lineWidthChanged )
+
+  public:
+    explicit Quick3DGeometryConfiguration( QQuickItem *parent = nullptr );
+
+    QString wkt() const { return mWkt; }
+    void setWkt( const QString &wkt );
+
+    QgsCoordinateReferenceSystem crs() const { return mCrs; }
+    void setCrs( const QgsCoordinateReferenceSystem &crs );
+
+    QColor lineColor() const { return mLineColor; }
+    void setLineColor( const QColor &color );
+
+    float lineWidth() const { return mLineWidth; }
+    void setLineWidth( float width );
+
+  signals:
+    void wktChanged();
+    void crsChanged();
+    void lineColorChanged();
+    void lineWidthChanged();
+
+  private:
+    QString mWkt;
+    QgsCoordinateReferenceSystem mCrs;
+    QColor mLineColor = QColor( 255, 102, 0 );
+    float mLineWidth = 4.0f;
+};
+
+#endif // QUICK3DGEOMETRYCONFIGURATION_H

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -9,6 +9,7 @@ set(QFIELD_CORE_SRCS
     3d/quick3dmaptexturedata.cpp
     3d/quick3drubberbandgeometry.cpp
     3d/quick3dgeometry.cpp
+    3d/quick3dgeometryconfiguration.cpp
     3d/quick3dgeometryutils.cpp
     3d/maptoview3d.cpp
     utils/coordinatereferencesystemutils.cpp
@@ -162,6 +163,7 @@ set(QFIELD_CORE_HDRS
     3d/quick3drubberbandgeometry.h
     3d/quick3dgeometryutils.h
     3d/quick3dgeometry.h
+    3d/quick3dgeometryconfiguration.h
     3d/maptoview3d.h
     utils/coordinatereferencesystemutils.h
     utils/expressioncontextutils.h

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -38,7 +38,6 @@
 #include <QSettings>
 #include <QTemporaryFile>
 #include <QTranslator>
-#include <QtQuick3D/QQuick3DObject>
 #include <qgsapplication.h>
 #include <qgsauthmanager.h>
 #include <qgsmessagelog.h>
@@ -120,18 +119,16 @@ void AppInterface::addItemToPluginsToolbar( QQuickItem *item ) const
   }
 }
 
-void AppInterface::addItemToMapCanvas3D( QQuick3DObject *node ) const
+void AppInterface::addItemToMapCanvas3D( QQuickItem *item ) const
 {
   QObject *root = rootObject();
   if ( !root )
-  {
     return;
-  }
 
-  QQuick3DObject *scene = root->findChild<QQuick3DObject *>( QStringLiteral( "mapCanvas3DPluginScene" ) );
-  if ( scene )
+  QQuickItem *container = root->findChild<QQuickItem *>( QStringLiteral( "mapCanvas3DPluginContainer" ) );
+  if ( container )
   {
-    node->setParentItem( scene );
+    item->setParentItem( container );
   }
 }
 

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -38,6 +38,7 @@
 #include <QSettings>
 #include <QTemporaryFile>
 #include <QTranslator>
+#include <QtQuick3D/QQuick3DObject>
 #include <qgsapplication.h>
 #include <qgsauthmanager.h>
 #include <qgsmessagelog.h>
@@ -116,6 +117,21 @@ void AppInterface::addItemToPluginsToolbar( QQuickItem *item ) const
   if ( toolbar )
   {
     item->setParentItem( toolbar );
+  }
+}
+
+void AppInterface::addItemToMapCanvas3D( QQuick3DObject *node ) const
+{
+  QObject *root = rootObject();
+  if ( !root )
+  {
+    return;
+  }
+
+  QQuick3DObject *scene = root->findChild<QQuick3DObject *>( QStringLiteral( "mapCanvas3DPluginScene" ) );
+  if ( scene )
+  {
+    node->setParentItem( scene );
   }
 }
 

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -27,6 +27,7 @@ class QgisMobileapp;
 class QgsRectangle;
 class QgsFeature;
 class QQuickItem;
+class QQuick3DObject;
 class QQmlEngine;
 class QFieldXmlHttpRequest;
 
@@ -182,6 +183,11 @@ class AppInterface : public QObject
      * Adds an \a item in the plugins toolbar container
      */
     Q_INVOKABLE void addItemToPluginsToolbar( QQuickItem *item ) const;
+
+    /**
+     * Adds a 3D \a node to the plugin scene container.
+     */
+    Q_INVOKABLE void addItemToMapCanvas3D( QQuick3DObject *node ) const;
 
     /**
      * Adds an \a item in the map canvas menu's action toolbar container

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -27,7 +27,6 @@ class QgisMobileapp;
 class QgsRectangle;
 class QgsFeature;
 class QQuickItem;
-class QQuick3DObject;
 class QQmlEngine;
 class QFieldXmlHttpRequest;
 
@@ -185,9 +184,9 @@ class AppInterface : public QObject
     Q_INVOKABLE void addItemToPluginsToolbar( QQuickItem *item ) const;
 
     /**
-     * Adds a 3D \a node to the plugin scene container.
+     * Adds a geometry \a configuration to the persistent plugin 3D container.
      */
-    Q_INVOKABLE void addItemToMapCanvas3D( QQuick3DObject *node ) const;
+    Q_INVOKABLE void addItemToMapCanvas3D( QQuickItem *item ) const;
 
     /**
      * Adds an \a item in the map canvas menu's action toolbar container

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -131,6 +131,7 @@
 #include "qgsquickmapsettings.h"
 #include "qgsquickmaptransform.h"
 #include "quick3dgeometry.h"
+#include "quick3dgeometryconfiguration.h"
 #include "quick3dmaptexturedata.h"
 #include "quick3drubberbandgeometry.h"
 #include "quick3dterraingeometry.h"
@@ -475,6 +476,7 @@ void QgisMobileapp::initDeclarative( QQmlEngine *engine )
   qmlRegisterType<Quick3DTerrainProvider>( "org.qfield", 1, 0, "Quick3DTerrainProvider" );
   qmlRegisterType<Quick3DMapTextureData>( "org.qfield", 1, 0, "Quick3DMapTextureData" );
   qmlRegisterType<Quick3DGeometry>( "org.qfield", 1, 0, "Quick3DGeometry" );
+  qmlRegisterType<Quick3DGeometryConfiguration>( "org.qfield", 1, 0, "Quick3DGeometryConfiguration" );
   qmlRegisterType<MapToView3D>( "org.qfield", 1, 0, "MapToView3D" );
 
   // Register QField QML types

--- a/src/qml/3d/MapCanvas3D.qml
+++ b/src/qml/3d/MapCanvas3D.qml
@@ -260,22 +260,20 @@ Item {
     }
 
     Repeater3D {
-      model: mapArea.pluginContainer ? mapArea.pluginContainer.children.length : 0
+      model: mapArea.pluginContainer ? mapArea.pluginContainer.children : null
 
       Node {
-        required property int index
-
-        property Quick3DGeometryConfiguration config: mapArea.pluginContainer ? mapArea.pluginContainer.children[index] : null
+        required property Quick3DGeometryConfiguration modelData
 
         Model {
           geometry: Quick3DGeometry {
-            qgsGeometry: GeometryUtils.createGeometryFromWkt(config ? config.wkt : '')
-            crs: config ? config.crs : qgisProject.crs
+            qgsGeometry: GeometryUtils.createGeometryFromWkt(modelData.wkt)
+            crs: modelData.crs
             terrainProvider: mapTerrainProvider
-            lineWidth: config ? config.lineWidth : 4.0
+            lineWidth: modelData.lineWidth
             heightOffset: 20.0
             altitudeClamping: Quick3DGeometry.ClampToGround
-            color: config ? config.lineColor : '#FF6600'
+            color: modelData.lineColor
           }
           materials: PrincipledMaterial {
             vertexColorsEnabled: true

--- a/src/qml/3d/MapCanvas3D.qml
+++ b/src/qml/3d/MapCanvas3D.qml
@@ -30,6 +30,8 @@ Item {
 
   property TrackingModel trackingModel: null
 
+  property alias terrainProvider: mapTerrainProvider
+
   signal cameraInteractionDetected
   signal featureIdentifyRequested(point screenPoint)
 
@@ -255,6 +257,32 @@ Item {
         visible: modelData.tracker ? modelData.tracker.visible : false
       }
     }
+
+    Repeater3D {
+      id: pluginGeometries3D
+      model: pluginGeometryModel
+
+      Node {
+        required property string wkt
+        required property var crs
+        required property string lineColor
+
+        Model {
+          geometry: Quick3DGeometry {
+            qgsGeometry: GeometryUtils.createGeometryFromWkt(wkt)
+            crs: crs
+            terrainProvider: mapTerrainProvider
+            lineWidth: 4.0
+            heightOffset: 20.0
+            altitudeClamping: Quick3DGeometry.ClampToGround
+            color: lineColor
+          }
+          materials: PrincipledMaterial {
+            vertexColorsEnabled: true
+          }
+        }
+      }
+    }
   }
 
   TouchCameraController {
@@ -370,5 +398,21 @@ Item {
 
   function zoomOut() {
     cameraController.distance = cameraController.clampDistance(cameraController.distance * 1.25);
+  }
+
+  function addPluginGeometry(wkt, crs, lineColor) {
+    pluginGeometryModel.append({
+      wkt: wkt,
+      crs: crs,
+      lineColor: lineColor || '#FF6600'
+    });
+  }
+
+  function clearPluginGeometries() {
+    pluginGeometryModel.clear();
+  }
+
+  ListModel {
+    id: pluginGeometryModel
   }
 }

--- a/src/qml/3d/MapCanvas3D.qml
+++ b/src/qml/3d/MapCanvas3D.qml
@@ -258,30 +258,8 @@ Item {
       }
     }
 
-    Repeater3D {
-      id: pluginGeometries3D
-      model: pluginGeometryModel
-
-      Node {
-        required property string wkt
-        required property var crs
-        required property string lineColor
-
-        Model {
-          geometry: Quick3DGeometry {
-            qgsGeometry: GeometryUtils.createGeometryFromWkt(wkt)
-            crs: crs
-            terrainProvider: mapTerrainProvider
-            lineWidth: 4.0
-            heightOffset: 20.0
-            altitudeClamping: Quick3DGeometry.ClampToGround
-            color: lineColor
-          }
-          materials: PrincipledMaterial {
-            vertexColorsEnabled: true
-          }
-        }
-      }
+    Node {
+      objectName: 'mapCanvas3DPluginOverlay'
     }
   }
 
@@ -398,21 +376,5 @@ Item {
 
   function zoomOut() {
     cameraController.distance = cameraController.clampDistance(cameraController.distance * 1.25);
-  }
-
-  function addPluginGeometry(wkt, crs, lineColor) {
-    pluginGeometryModel.append({
-      wkt: wkt,
-      crs: crs,
-      lineColor: lineColor || '#FF6600'
-    });
-  }
-
-  function clearPluginGeometries() {
-    pluginGeometryModel.clear();
-  }
-
-  ListModel {
-    id: pluginGeometryModel
   }
 }

--- a/src/qml/3d/MapCanvas3D.qml
+++ b/src/qml/3d/MapCanvas3D.qml
@@ -31,6 +31,7 @@ Item {
   property TrackingModel trackingModel: null
 
   property alias terrainProvider: mapTerrainProvider
+  property Node pluginScene: null
 
   signal cameraInteractionDetected
   signal featureIdentifyRequested(point screenPoint)
@@ -76,6 +77,7 @@ Item {
   View3D {
     id: view3d
     anchors.fill: parent
+    importScene: mapArea.pluginScene
 
     environment: SceneEnvironment {
       clearColor: mapArea.mapSettings ? mapArea.mapSettings.backgroundColor : "#FFFFFF"
@@ -256,10 +258,6 @@ Item {
         color: modelData.tracker ? modelData.tracker.color : "#FFFF3232"
         visible: modelData.tracker ? modelData.tracker.visible : false
       }
-    }
-
-    Node {
-      objectName: 'mapCanvas3DPluginOverlay'
     }
   }
 

--- a/src/qml/3d/MapCanvas3D.qml
+++ b/src/qml/3d/MapCanvas3D.qml
@@ -31,7 +31,7 @@ Item {
   property TrackingModel trackingModel: null
 
   property alias terrainProvider: mapTerrainProvider
-  property Node pluginScene: null
+  property Item pluginContainer: null
 
   signal cameraInteractionDetected
   signal featureIdentifyRequested(point screenPoint)
@@ -77,7 +77,6 @@ Item {
   View3D {
     id: view3d
     anchors.fill: parent
-    importScene: mapArea.pluginScene
 
     environment: SceneEnvironment {
       clearColor: mapArea.mapSettings ? mapArea.mapSettings.backgroundColor : "#FFFFFF"
@@ -257,6 +256,31 @@ Item {
         terrainProvider: mapTerrainProvider
         color: modelData.tracker ? modelData.tracker.color : "#FFFF3232"
         visible: modelData.tracker ? modelData.tracker.visible : false
+      }
+    }
+
+    Repeater3D {
+      model: mapArea.pluginContainer ? mapArea.pluginContainer.children.length : 0
+
+      Node {
+        required property int index
+
+        property Quick3DGeometryConfiguration config: mapArea.pluginContainer ? mapArea.pluginContainer.children[index] : null
+
+        Model {
+          geometry: Quick3DGeometry {
+            qgsGeometry: GeometryUtils.createGeometryFromWkt(config ? config.wkt : '')
+            crs: config ? config.crs : qgisProject.crs
+            terrainProvider: mapTerrainProvider
+            lineWidth: config ? config.lineWidth : 4.0
+            heightOffset: 20.0
+            altitudeClamping: Quick3DGeometry.ClampToGround
+            color: config ? config.lineColor : '#FF6600'
+          }
+          materials: PrincipledMaterial {
+            vertexColorsEnabled: true
+          }
+        }
       }
     }
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -16,7 +16,6 @@
  ***************************************************************************/
 import QtCore
 import QtQuick
-import QtQuick3D
 import QtQuick.Controls
 import QtQuick.Controls.impl
 import QtQuick.Controls.Material
@@ -725,9 +724,10 @@ ApplicationWindow {
       color: mapCanvas.mapSettings.backgroundColor
     }
 
-    Node {
-      id: mapCanvas3DPluginScene
-      objectName: 'mapCanvas3DPluginScene'
+    Item {
+      id: mapCanvas3DPluginContainer
+      objectName: 'mapCanvas3DPluginContainer'
+      visible: false
     }
 
     Loader {
@@ -757,7 +757,7 @@ ApplicationWindow {
 
       onLoaded: {
         item.objectName = 'mapCanvas3D';
-        item.pluginScene = mapCanvas3DPluginScene;
+        item.pluginContainer = mapCanvas3DPluginContainer;
         item.mapSettings = mapCanvas.mapSettings;
         item.trackingModel = trackingModel;
         item.eyeDomeLightingMode = settings.valueBool('3d/eyeDomeLightingMode', false);

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -750,6 +750,7 @@ ApplicationWindow {
       }
 
       onLoaded: {
+        item.objectName = 'mapCanvas3D';
         item.mapSettings = mapCanvas.mapSettings;
         item.trackingModel = trackingModel;
         item.eyeDomeLightingMode = settings.valueBool('3d/eyeDomeLightingMode', false);

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -16,6 +16,7 @@
  ***************************************************************************/
 import QtCore
 import QtQuick
+import QtQuick3D
 import QtQuick.Controls
 import QtQuick.Controls.impl
 import QtQuick.Controls.Material
@@ -724,6 +725,11 @@ ApplicationWindow {
       color: mapCanvas.mapSettings.backgroundColor
     }
 
+    Node {
+      id: mapCanvas3DPluginScene
+      objectName: 'mapCanvas3DPluginScene'
+    }
+
     Loader {
       id: mapCanvas3DLoader
       anchors.fill: parent
@@ -751,6 +757,7 @@ ApplicationWindow {
 
       onLoaded: {
         item.objectName = 'mapCanvas3D';
+        item.pluginScene = mapCanvas3DPluginScene;
         item.mapSettings = mapCanvas.mapSettings;
         item.trackingModel = trackingModel;
         item.eyeDomeLightingMode = settings.valueBool('3d/eyeDomeLightingMode', false);


### PR DESCRIPTION
### 🚀 Description
Plugins currently have no way to draw custom geometry inside the 3D map view. This PR adds a minimal, stable API surface that lets any QField plugin inject and remove geometries from the 3D scene at runtime.


### Demo
https://github.com/user-attachments/assets/97cfb16f-2379-4f92-b218-4c217096c6e6



### Plugin
**Final plugin** [qfield-3d-inject.zip](https://github.com/user-attachments/files/29166522/qfield-3d-inject.zip)

