### PR TITLE
[Backport release-4_2] Fix parsing of HTTP status code when the server sends only a single line

### DIFF
--- a/src/core/positioning/ntripclient.cpp
+++ b/src/core/positioning/ntripclient.cpp
@@ -537,7 +537,8 @@ int NtripSocket::parseHttpStatusCode( const QByteArray &headerBlock )
 {
   // Match first line: "HTTP/1.0 200 OK", "ICY 200 OK", "SOURCETABLE 200 OK"
   const thread_local QRegularExpression re( QStringLiteral( "^(?:HTTP/\\d\\.\\d|ICY|SOURCETABLE)\\s+(\\d{3})" ) );
-  const QString firstLine = QString::fromLatin1( headerBlock.left( headerBlock.indexOf( "\r\n" ) ) );
+  const int firstNewLine = headerBlock.indexOf( "\r\n" );
+  const QString firstLine = QString::fromLatin1( firstNewLine > 0 ? headerBlock.left( firstNewLine ) : headerBlock );
   const QRegularExpressionMatch match = re.match( firstLine );
   return match.hasMatch() ? match.captured( 1 ).toInt() : -1;
 }


### PR DESCRIPTION
Backport #7523
 **Authored by:** @nirvn