### PR TITLE
 Add show password button to the NTRIP configuration popup's password field

### DIFF
--- a/src/qml/PositioningNtripSettings.qml
+++ b/src/qml/PositioningNtripSettings.qml
@@ -85,14 +85,14 @@ QfPopup {
             Layout.preferredWidth: 100
           }
 
-          TextField {
+          QfTextField {
             id: ntripHostTextField
             Layout.fillWidth: true
             font: Theme.defaultFont
             inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
           }
 
-          TextField {
+          QfTextField {
             id: ntripPortTextField
             Layout.preferredWidth: 100
             font: Theme.defaultFont
@@ -144,7 +144,7 @@ QfPopup {
           Layout.fillWidth: true
         }
 
-        TextField {
+        QfTextField {
           id: ntripUsernameTextField
           Layout.fillWidth: true
           font: Theme.defaultFont
@@ -159,7 +159,7 @@ QfPopup {
           Layout.fillWidth: true
         }
 
-        TextField {
+        QfTextField {
           id: ntripPasswordTextField
           Layout.fillWidth: true
           font: Theme.defaultFont

--- a/src/qml/imports/Theme/QfTextField.qml
+++ b/src/qml/imports/Theme/QfTextField.qml
@@ -24,7 +24,7 @@ TextField {
     anchors.rightMargin: 10
     anchors.verticalCenter: parent.verticalCenter
     font: parent.font
-    color: Theme.mainTextDisabledColor
+    color: enabled ? Theme.secondaryTextColor : Theme.mainTextDisabledColor
   }
 
   QfToolButton {
@@ -33,7 +33,7 @@ TextField {
     z: 1
     visible: (!!textField.echoMode && textField.echoMode !== TextInput.Normal) || originalEchoMode !== TextInput.Normal
     iconSource: textField.echoMode === TextInput.Normal ? Theme.getThemeVectorIcon('ic_hide_green_48dp') : Theme.getThemeVectorIcon('ic_show_green_48dp')
-    iconColor: Theme.mainColor
+    iconColor: textField.enabled ? Theme.mainTextColor : Theme.mainTextDisabledColor
     anchors.right: textField.right
     anchors.verticalCenter: textField.verticalCenter
     opacity: textField.text.length > 0 ? 1 : 0.25


### PR DESCRIPTION
While debugging an NTRIP issue, I realized we were missing a show password button for the NTRIP configuration popup's password field. This PR addresses that.