### PR TITLE
Consider 'root' project author as empty

### DIFF
--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -338,7 +338,7 @@ Drawer {
 
         property string projectAuthor: {
           if (qgisProject) {
-            if (qgisProject.metadata.author !== "" && qgisProject.metadata.author !== "Not available") {
+            if (qgisProject.metadata.author !== "" && qgisProject.metadata.author !== "Not available" && qgisProject.metadata.author !== "root") {
               return qgisProject.metadata.author;
             } else if (cloudProjectsModel.currentProject) {
               return cloudProjectsModel.currentProject.owner;


### PR DESCRIPTION
Prior to QGIS 4, project metadata's author values were never kept when saving. Instead, they were overwritten using the current logged in username. This means that all project authors are set to 'root' when packaged on QFieldCloud. Not ideal :)

This PR considers a 'root' author as an empty value, which in turn means that we will use the nice cloud project owner name as fallback.

