### PR TITLE
Only rely on satellite positioning to avoid spikes when tracking positions

### DIFF
--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -25,7 +25,7 @@ InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
 {
   if ( mGeoPositionSource )
   {
-    mGeoPositionSource->setPreferredPositioningMethods( QGeoPositionInfoSource::AllPositioningMethods );
+    mGeoPositionSource->setPreferredPositioningMethods( QGeoPositionInfoSource::SatellitePositioningMethods );
     mGeoPositionSource->setUpdateInterval( 1000 );
 
     connect( mGeoPositionSource.get(), &QGeoPositionInfoSource::positionUpdated, this, &InternalGnssReceiver::handlePositionUpdated );


### PR DESCRIPTION
Relying on non-satellite positioning sources might well cause this issue that has been haunting our users: https://community.qfield.org/t/track-jumps-to-certain-points-an-back/1642/8