### PR TITLE
[Backport release-4_2] Fix reconnect to BLE GNSS device when returning from locked screen

### DIFF
--- a/src/core/positioning/bluetoothlowenergyreceiver.cpp
+++ b/src/core/positioning/bluetoothlowenergyreceiver.cpp
@@ -77,7 +77,7 @@ void BluetoothLowEnergyReceiver::handleConnectDevice()
 
   if ( mController && mController->state() != QLowEnergyController::UnconnectedState )
   {
-    disconnectDevice();
+    doDisconnectDevice();
   }
   else
   {
@@ -87,17 +87,8 @@ void BluetoothLowEnergyReceiver::handleConnectDevice()
 
 void BluetoothLowEnergyReceiver::handleDisconnectDevice()
 {
-  if ( mController && mController->state() != QLowEnergyController::UnconnectedState )
-  {
-    qInfo() << "BluetoothLowEnergyReceiver: Disconnecting from device:" << mAddress;
-
-    clearService();
-
-    mConnectOnDisconnect = false;
-    mDisconnecting = true;
-    mLastGnssPositionValid = false;
-    mController->disconnectFromDevice();
-  }
+  mConnectOnDisconnect = false;
+  doDisconnectDevice();
 }
 
 void BluetoothLowEnergyReceiver::doConnectDevice()
@@ -123,6 +114,20 @@ void BluetoothLowEnergyReceiver::doConnectDevice()
   mController->connectToDevice();
 }
 
+void BluetoothLowEnergyReceiver::doDisconnectDevice()
+{
+  if ( mController && mController->state() != QLowEnergyController::UnconnectedState )
+  {
+    qInfo() << "BluetoothLowEnergyReceiver: Disconnecting from device:" << mAddress;
+
+    clearService();
+
+    mDisconnecting = true;
+    mLastGnssPositionValid = false;
+    mController->disconnectFromDevice();
+  }
+}
+
 void BluetoothLowEnergyReceiver::deviceConnected()
 {
   qInfo() << "BluetoothLowEnergyReceiver: Connected, discovering services";
@@ -135,6 +140,11 @@ void BluetoothLowEnergyReceiver::deviceDisconnected()
   setSocketState( QAbstractSocket::UnconnectedState );
 
   clearService();
+
+  if ( mConnectOnDisconnect )
+  {
+    doConnectDevice();
+  }
 }
 
 void BluetoothLowEnergyReceiver::controllerErrorOccurred( QLowEnergyController::Error error )

--- a/src/core/positioning/bluetoothlowenergyreceiver.h
+++ b/src/core/positioning/bluetoothlowenergyreceiver.h
@@ -65,11 +65,12 @@ class BluetoothLowEnergyReceiver : public NmeaGnssReceiver
     void serviceErrorOccurred( QLowEnergyService::ServiceError error );
     void characteristicChanged( const QLowEnergyCharacteristic &characteristic, const QByteArray &value );
 
-    //! Used to wait for previous connection to finish disconnecting
-    void doConnectDevice();
-
   private:
     void clearService();
+
+    //! Used to wait for previous connection to finish disconnecting
+    void doConnectDevice();
+    void doDisconnectDevice();
 
     QString mAddress;
 

--- a/src/core/positioning/bluetoothreceiver.cpp
+++ b/src/core/positioning/bluetoothreceiver.cpp
@@ -70,14 +70,8 @@ AbstractGnssReceiver::Capabilities BluetoothReceiver::capabilities() const
 
 void BluetoothReceiver::handleDisconnectDevice()
 {
-  if ( mSocket->state() != QBluetoothSocket::SocketState::UnconnectedState )
-  {
-    qInfo() << "BluetoothReceiver: Disconnecting from device: " << mAddress;
-    mConnectOnDisconnect = false;
-    mDisconnecting = true;
-    mLastGnssPositionValid = false;
-    mSocket->disconnectFromService();
-  }
+  mConnectOnDisconnect = false;
+  doDisconnectDevice();
 }
 
 void BluetoothReceiver::handleConnectDevice()
@@ -92,7 +86,7 @@ void BluetoothReceiver::handleConnectDevice()
   mConnectOnDisconnect = true;
   if ( mSocket->state() == QBluetoothSocket::SocketState::ConnectedState )
   {
-    disconnectDevice();
+    doDisconnectDevice();
   }
   else
   {
@@ -194,6 +188,17 @@ void BluetoothReceiver::doConnectDevice()
   }
 
   repairDevice( QBluetoothAddress( mAddress ) );
+}
+
+void BluetoothReceiver::doDisconnectDevice()
+{
+  if ( mSocket->state() != QBluetoothSocket::SocketState::UnconnectedState )
+  {
+    qInfo() << "BluetoothReceiver: Disconnecting from device: " << mAddress;
+    mDisconnecting = true;
+    mLastGnssPositionValid = false;
+    mSocket->disconnectFromService();
+  }
 }
 
 QString BluetoothReceiver::socketStateString()

--- a/src/core/positioning/bluetoothreceiver.h
+++ b/src/core/positioning/bluetoothreceiver.h
@@ -59,8 +59,8 @@ class BluetoothReceiver : public NmeaGnssReceiver
 
     void repairDevice( const QBluetoothAddress &address );
 
-    //! Used to wait for previous connection to finish disconnecting
     void doConnectDevice();
+    void doDisconnectDevice();
 
     QString mAddress;
 


### PR DESCRIPTION
Backport #7529
 **Authored by:** @nirvn