### PR TITLE
Display range editor widget suffix when configured to a non-empty value

### DIFF
--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -42,11 +42,11 @@ EditorWidgetBase {
         } else if (isNull) {
           return qsTr("NULL");
         }
-        return value;
+        return rangeItem.suffix ? value + " " + rangeItem.suffix : value;
       }
     }
 
-    TextField {
+    QfTextField {
       id: textField
       leftPadding: isEnabled || (!isEditable && isEditing) ? 10 : 0
       width: parent.width - decreaseButton.width - increaseButton.width - parent.spacing * 2
@@ -54,6 +54,7 @@ EditorWidgetBase {
 
       font: Theme.defaultFont
       color: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
+      suffixText: rangeItem.suffix
 
       text: isNull ? '' : value
 


### PR DESCRIPTION
### 🚀 Description
Ensure the range's suffix is shown aand switch to `QfTextField`.

### ✨ How to test
- In QGIS, create a numeric field with a Range widget and set a suffix (e.g. `km`) in Advanced Options
- Open the project in QField
- Verify the suffix appears next to the value in both view and edit mode

### Demo

**In QGIS**    
   

<img width="1261" height="535" alt="image" src="https://github.com/user-attachments/assets/3b389e46-9a67-4d56-815d-981d763e92dc" />

**In Readonly mode**
   

<img width="803" height="544" alt="image" src="https://github.com/user-attachments/assets/5c886dc5-6349-4210-b2b8-01fafe9fc73c" />

**In Edit mode**
   

<img width="803" height="544" alt="image" src="https://github.com/user-attachments/assets/8028f534-8708-4346-8e8e-c7a8ed911575" />

---


Uses the existing suffixText support in `QfTextField` added in #7504

Fixes #6200