### PR TITLE
[Backport release-4_2] Only rely on satellite positioning to avoid spikes when tracking positions

### DIFF
--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -25,7 +25,7 @@ InternalGnssReceiver::InternalGnssReceiver( QObject *parent )
 {
   if ( mGeoPositionSource )
   {
-    mGeoPositionSource->setPreferredPositioningMethods( QGeoPositionInfoSource::AllPositioningMethods );
+    mGeoPositionSource->setPreferredPositioningMethods( QGeoPositionInfoSource::SatellitePositioningMethods );
     mGeoPositionSource->setUpdateInterval( 1000 );
 
     connect( mGeoPositionSource.get(), &QGeoPositionInfoSource::positionUpdated, this, &InternalGnssReceiver::handlePositionUpdated );


### PR DESCRIPTION
Backport #7535
 **Authored by:** @nirvn