### PR TITLE
Bring the relation editor widget list view back to fix height issues

### DIFF
--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -10,7 +10,7 @@ EditorWidgetBase {
 
   property var relationEditorModel: undefined
 
-  property alias gridView: gridView
+  property alias listView: listView
   property alias footer: footer
   property alias headerEntry: headerEntry
 
@@ -19,7 +19,7 @@ EditorWidgetBase {
   property int maximumVisibleItems: 4
   property bool showAllItems: false
   property bool showSortButton: true
-  property alias itemCount: gridView.count
+  property alias itemCount: listView.count
 
   // Generic container slots for subclass specific content
   property alias headerActions: headerActionsContainer.data
@@ -37,7 +37,7 @@ EditorWidgetBase {
   }
 
   height: {
-    const cappedHeight = !showAllItems && maximumVisibleItems > 0 ? Math.min(maximumVisibleItems * gridView.cellHeight, gridView.contentHeight) : gridView.contentHeight;
+    const cappedHeight = !showAllItems && maximumVisibleItems > 0 ? Math.min(maximumVisibleItems * relationEditorBase.itemHeight, listView.contentHeight) : listView.contentHeight;
     return cappedHeight + headerEntry.height + (footer.visible ? footer.height : 0) + 10;
   }
   enabled: true
@@ -156,19 +156,17 @@ EditorWidgetBase {
       }
     }
 
-    GridView {
-      id: gridView
+    ListView {
+      id: listView
+      visible: count > 0
       anchors.top: headerEntry.bottom
       anchors.left: parent.left
       anchors.right: parent.right
-      height: footer.visible ? parent.height - headerEntry.height - footer.height : parent.height - headerEntry.height
-
-      // Default to single-column list layout, subclasses can override
-      cellWidth: width
-      cellHeight: itemHeight
+      height: footer.visible ? parent.height - headerEntry.height - footer.height : parent.height - headerEntry.height - 10
       focus: true
       clip: true
       boundsBehavior: Flickable.StopAtBounds
+      highlightRangeMode: ListView.ApplyRange
       ScrollBar.vertical: QfScrollBar {}
     }
 

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -22,13 +22,13 @@ RelationEditorBase {
     property int featureFocus: -1
     onModelUpdated: {
       if (featureFocus > -1) {
-        gridView.currentIndex = referencingFeatureListModel.getFeatureIdRow(featureFocus);
+        listView.currentIndex = referencingFeatureListModel.getFeatureIdRow(featureFocus);
         featureFocus = -1;
       }
     }
   }
 
-  property bool isGridView: true
+  property bool isCardView: true
   property string imagePrefix: {
     if (qgisProject == undefined)
       return "";
@@ -181,7 +181,7 @@ RelationEditorBase {
     property string currentProcess: ""
     property var availableBars: ({})
 
-    barCount: isGridView ? 40 : 20
+    barCount: isCardView ? 40 : 20
 
     onBarCountChanged: {
       availableBars = {};
@@ -224,41 +224,38 @@ RelationEditorBase {
     }
   }
 
-  readonly property int visibleCards: Math.max(2, Math.floor(gridView.width / 180))
-  readonly property int cardSize: Math.floor(gridView.width / (visibleCards + 0.5))
+  readonly property int visibleCards: Math.max(2, Math.floor(listView.width / 180))
+  readonly property int cardSize: Math.floor(listView.width / (visibleCards + 0.5))
+  readonly property int cardMargin: 8
   readonly property int listItemHeight: 72
   readonly property int toggleHeight: 40
-  readonly property int gridMargin: 8
 
   bottomMargin: 10 + (itemCount > 0 ? toggleHeight : 0)
 
   height: {
     const toggleSpace = itemCount > 0 ? toggleHeight : 0;
-    if (isGridView) {
+    if (isCardView) {
       if (itemCount === 0) {
         return headerEntry.height + 10 + toggleSpace;
       }
-      return cardSize + gridMargin * 2 + headerEntry.height + 10 + toggleSpace;
+      return cardSize + cardMargin * 2 + headerEntry.height + toggleSpace;
     }
-    const cappedHeight = !showAllItems && maximumVisibleItems > 0 ? Math.min(maximumVisibleItems * gridView.cellHeight, gridView.contentHeight) : gridView.contentHeight;
+    const cappedHeight = !isCardView && !showAllItems && maximumVisibleItems > 0 ? Math.min(maximumVisibleItems * relationEditor.itemHeight, listView.contentHeight) : listView.contentHeight;
     return cappedHeight + headerEntry.height + 10 + toggleSpace;
   }
 
-  gridView.flow: isGridView ? GridView.FlowTopToBottom : GridView.FlowLeftToRight
-  gridView.flickableDirection: isGridView ? Flickable.HorizontalFlick : Flickable.VerticalFlick
-  gridView.topMargin: isGridView ? gridMargin : 0
-  gridView.bottomMargin: isGridView ? gridMargin : 0
-  gridView.ScrollBar.vertical.policy: isGridView ? ScrollBar.AlwaysOff : ScrollBar.AsNeeded
+  listView.orientation: isCardView ? Qt.Horizontal : Qt.Vertical
+  listView.flickableDirection: isCardView ? Flickable.HorizontalFlick : Flickable.VerticalFlick
+  listView.topMargin: isCardView ? cardMargin : 0
+  listView.bottomMargin: isCardView ? cardMargin : 0
+  listView.ScrollBar.vertical.policy: isCardView ? ScrollBar.AlwaysOff : ScrollBar.AsNeeded
 
-  gridView.cellWidth: isGridView ? cardSize : gridView.width
-  gridView.cellHeight: isGridView ? cardSize : listItemHeight
-
-  gridView.model: DelegateModel {
+  listView.model: DelegateModel {
     model: referencingFeatureListModel
-    delegate: isGridView ? gridDelegate : listDelegate
+    delegate: isCardView ? cardDelegate : listDelegate
   }
 
-  onIsGridViewChanged: stopAllMedia()
+  onIsCardViewChanged: stopAllMedia()
 
   ExpressionEvaluator {
     id: attachmentNamingEvaluator
@@ -361,7 +358,7 @@ RelationEditorBase {
     padding: 0
     width: slotSize * 2 + 4
     height: toggleHeight
-    checked: !isGridView
+    checked: !isCardView
     indicator: Rectangle {
       implicitHeight: viewSwitch.slotSize
       implicitWidth: viewSwitch.slotSize * 2
@@ -430,7 +427,7 @@ RelationEditorBase {
     }
 
     onClicked: {
-      isGridView = !checked;
+      isCardView = !checked;
     }
   }
 
@@ -585,8 +582,8 @@ RelationEditorBase {
     id: listDelegate
 
     Item {
-      width: gridView.cellWidth
-      height: gridView.cellHeight
+      width: listView.width
+      height: relationEditor.listItemHeight
 
       property string attachmentFullPath: ""
       Component.onCompleted: {
@@ -876,11 +873,11 @@ RelationEditorBase {
   }
 
   Component {
-    id: gridDelegate
+    id: cardDelegate
 
     Item {
-      width: gridView.cellWidth
-      height: gridView.cellHeight
+      width: relationEditor.cardSize
+      height: relationEditor.cardSize
 
       property string attachmentFullPath: ""
       Component.onCompleted: {
@@ -1100,33 +1097,33 @@ RelationEditorBase {
           clip: true
 
           Row {
-            id: gridWaveformBars
+            id: cardWaveformBars
             anchors.centerIn: parent
             width: parent.width
             height: parent.height * 0.7
             spacing: 2
 
-            property int barCount: gridWaveformRepeater.count
-            property real barWidth: (gridWaveformBars.width - (spacing * barCount)) / barCount
+            property int barCount: cardWaveformRepeater.count
+            property real barWidth: (cardWaveformBars.width - (spacing * barCount)) / barCount
 
             Repeater {
-              id: gridWaveformRepeater
+              id: cardWaveformRepeater
 
               model: attachmentFullPath in audioAnalyzer.availableBars ? audioAnalyzer.availableBars[attachmentFullPath] : [0]
 
               Rectangle {
-                width: gridWaveformBars.barWidth
-                height: gridWaveformBars.height * modelData
+                width: cardWaveformBars.barWidth
+                height: cardWaveformBars.height * modelData
                 radius: 1.5
                 anchors.verticalCenter: parent.verticalCenter
                 color: {
-                  if (audioPlayerLoader.active && (index / gridWaveformBars.barCount) < audioPlayerLoader.progress) {
+                  if (audioPlayerLoader.active && (index / cardWaveformBars.barCount) < audioPlayerLoader.progress) {
                     return Theme.mainColor;
                   }
                   return Theme.mainTextDisabledColor;
                 }
                 opacity: {
-                  if (audioPlayerLoader.active && (index / gridWaveformBars.barCount) < audioPlayerLoader.progress) {
+                  if (audioPlayerLoader.active && (index / cardWaveformBars.barCount) < audioPlayerLoader.progress) {
                     return 0.9;
                   }
                   return 0.35;
@@ -1137,7 +1134,7 @@ RelationEditorBase {
 
           Rectangle {
             visible: audioPlayerLoader.active && audioPlayerLoader.progress > 0
-            x: gridWaveformBars.x + gridWaveformBars.width * audioPlayerLoader.progress
+            x: cardWaveformBars.x + cardWaveformBars.width * audioPlayerLoader.progress
             y: 0
             width: 2
             height: parent.height
@@ -1185,14 +1182,14 @@ RelationEditorBase {
 
           Rectangle {
             anchors.centerIn: parent
-            width: Math.min(gridSuffixText.contentWidth + 8, parent.width)
-            height: gridSuffixText.contentHeight + 4
+            width: Math.min(cardSuffixText.contentWidth + 8, parent.width)
+            height: cardSuffixText.contentHeight + 4
             radius: 2
             color: Theme.controlBorderColor
-            visible: gridSuffixText.text !== ""
+            visible: cardSuffixText.text !== ""
 
             Text {
-              id: gridSuffixText
+              id: cardSuffixText
               anchors.centerIn: parent
               text: FileUtils.fileSuffix(attachmentFullPath).toUpperCase()
               font.pointSize: Theme.tinyFont.pointSize

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -33,7 +33,7 @@ RelationEditorBase {
     }
   }
 
-  gridView.model: DelegateModel {
+  listView.model: DelegateModel {
     model: orderedRelationModel
     delegate: dragDelegate
   }
@@ -66,9 +66,9 @@ RelationEditorBase {
         if (held === true) {
           held = false;
           orderedRelationModel.moveItems(indexFrom, indexTo);
-        } else if (gridView.currentIndex !== dragArea.DelegateModel.itemsIndex) {
-          gridView.currentIndex = dragArea.DelegateModel.itemsIndex;
-          orderedRelationModel.triggerViewCurrentFeatureChange(gridView.currentIndex);
+        } else if (listView.currentIndex !== dragArea.DelegateModel.itemsIndex) {
+          listView.currentIndex = dragArea.DelegateModel.itemsIndex;
+          orderedRelationModel.triggerViewCurrentFeatureChange(listView.currentIndex);
         }
       }
 
@@ -182,7 +182,7 @@ RelationEditorBase {
             visible: isEnabled
             width: visible ? 48 : 0
             height: 48
-            opacity: (index === gridView.count - 1) ? 0.3 : 1
+            opacity: (index === listView.count - 1) ? 0.3 : 1
 
             round: false
             iconSource: Theme.getThemeVectorIcon('ic_chevron_down')
@@ -190,7 +190,7 @@ RelationEditorBase {
             bgcolor: 'transparent'
 
             onClicked: {
-              if (index === gridView.count - 1) {
+              if (index === listView.count - 1) {
                 return;
               }
               orderedRelationModel.moveItems(index, index + 1);
@@ -249,7 +249,7 @@ RelationEditorBase {
             dragArea.indexFrom = drag.source.DelegateModel.itemsIndex;
           }
           dragArea.indexTo = dragArea.DelegateModel.itemsIndex;
-          gridView.model.items.move(drag.source.DelegateModel.itemsIndex, dragArea.DelegateModel.itemsIndex);
+          listView.model.items.move(drag.source.DelegateModel.itemsIndex, dragArea.DelegateModel.itemsIndex);
         }
       }
     }

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -24,7 +24,7 @@ RelationEditorBase {
     property int featureFocus: -1
     onModelUpdated: {
       if (featureFocus > -1) {
-        gridView.currentIndex = referencingFeatureListModel.getFeatureIdRow(featureFocus);
+        listView.currentIndex = referencingFeatureListModel.getFeatureIdRow(featureFocus);
         featureFocus = -1;
       }
     }
@@ -34,7 +34,7 @@ RelationEditorBase {
     referencingFeatureListModel.sortOrder = referencingFeatureListModel.sortOrder === Qt.AscendingOrder ? Qt.DescendingOrder : Qt.AscendingOrder;
   }
 
-  gridView.model: DelegateModel {
+  listView.model: DelegateModel {
     model: referencingFeatureListModel
     delegate: referencingFeatureDelegate
   }

--- a/test/qml/tst_relations.qml
+++ b/test/qml/tst_relations.qml
@@ -92,20 +92,20 @@ TestCase {
     verify(relation_editor.item.relationEditorModel !== null);
     compare(relation_editor.item.relationEditorModel.feature.id, 1);
     compare(relation_editor.item.relationEditorModel.rowCount(), 2);
-    let delegate1TextString = relation_editor.item.gridView.itemAtIndex(0).children[2].children[0].text;
-    let delegate2TextString = relation_editor.item.gridView.itemAtIndex(1).children[2].children[0].text;
+    let delegate1TextString = relation_editor.item.listView.itemAtIndex(0).children[2].children[0].text;
+    let delegate2TextString = relation_editor.item.listView.itemAtIndex(1).children[2].children[0].text;
     compare(delegate1TextString, "Village Alpha");
     compare(delegate2TextString, "Village Beta");
 
     // 9) Sort action
     relation_editor.item.toggleSortAction();
-    delegate1TextString = relation_editor.item.gridView.itemAtIndex(0).children[2].children[0].text;
-    delegate2TextString = relation_editor.item.gridView.itemAtIndex(1).children[2].children[0].text;
+    delegate1TextString = relation_editor.item.listView.itemAtIndex(0).children[2].children[0].text;
+    delegate2TextString = relation_editor.item.listView.itemAtIndex(1).children[2].children[0].text;
     compare(delegate1TextString, "Village Beta");
     compare(delegate2TextString, "Village Alpha");
     relation_editor.item.toggleSortAction();
-    delegate1TextString = relation_editor.item.gridView.itemAtIndex(0).children[2].children[0].text;
-    delegate2TextString = relation_editor.item.gridView.itemAtIndex(1).children[2].children[0].text;
+    delegate1TextString = relation_editor.item.listView.itemAtIndex(0).children[2].children[0].text;
+    delegate2TextString = relation_editor.item.listView.itemAtIndex(1).children[2].children[0].text;
     compare(delegate1TextString, "Village Alpha");
     compare(delegate2TextString, "Village Beta");
 
@@ -121,7 +121,7 @@ TestCase {
     relation_editor.item.relationEditorModel.reload();
     wait(200);
     compare(relation_editor.item.relationEditorModel.rowCount(), 3);
-    const delegate3TextString = relation_editor.item.gridView.itemAtIndex(2).children[2].children[0].text;
+    const delegate3TextString = relation_editor.item.listView.itemAtIndex(2).children[2].children[0].text;
     compare(delegate3TextString, "Village Gamma");
 
     // 11) Delete a feature
@@ -129,8 +129,8 @@ TestCase {
     relation_editor.item.deleteDialog.accepted();
     wait(200);
     compare(relation_editor.item.relationEditorModel.rowCount(), 2);
-    delegate1TextString = relation_editor.item.gridView.itemAtIndex(0).children[2].children[0].text;
-    delegate2TextString = relation_editor.item.gridView.itemAtIndex(1).children[2].children[0].text;
+    delegate1TextString = relation_editor.item.listView.itemAtIndex(0).children[2].children[0].text;
+    delegate2TextString = relation_editor.item.listView.itemAtIndex(1).children[2].children[0].text;
     compare(delegate1TextString, "Village Alpha");
     compare(delegate2TextString, "Village Beta");
   }


### PR DESCRIPTION
While we initially were considering a multi-row grid, we settled on a scrolling one line, a much better outcome :) However, we stuck to the newly-introduced GridView. That in turn created a big regression with the traditional relation editor whereas children with a long feature display name now have text overlapping beyond the confine of their static height. 

<img width="701" height="364" alt="image" src="https://github.com/user-attachments/assets/900947d1-b25f-47f3-b232-6d130e7bc3c4" />

:scream: 

A ListView gives us variable height, and now that we have a single scrolling row for our card view, we can actually revert to that. This PR does exactly that.

I wish I had seen this problem 6 hours ago prior to releasing 4.2.2 though. Oh well, 4.2.3 will come out soon :)