### PR TITLE
WelcomeScreen: replace dual-repeater grid with named extensible action items

### DIFF
--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -487,6 +487,7 @@ Page {
             Layout.preferredWidth: Math.min(welcomeActionsListView.contentWidth, welcomeActions.width)
             Layout.preferredHeight: Math.max(welcomeActionCloud.height, welcomeActionLocalProjects.height, welcomeActionNewProject.height)
             Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
+            clip: true
 
             contentItem: ListView {
               id: welcomeActionsListView

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -22,41 +22,6 @@ Page {
   signal showSettings
   signal showProjectCreationScreen
 
-  component WelcomeActionItem: ColumnLayout {
-    property url iconSource
-    property color iconColor
-    property string label
-    signal clicked
-
-    Layout.fillWidth: true
-    Layout.alignment: Qt.AlignTop
-    spacing: 4
-
-    QfToolButton {
-      Layout.alignment: Qt.AlignHCenter
-      Layout.preferredWidth: Math.min(mainWindow.height / 4, welcomeActions.width / 3 / 1.5)
-      Layout.preferredHeight: Layout.preferredWidth
-      icon.width: width / 2.2
-      icon.height: height / 2.2
-      bgcolor: Theme.controlBackgroundAlternateColor
-      round: false
-      roundborder: true
-      iconSource: parent.iconSource
-      iconColor: parent.iconColor
-      smooth: true
-      onClicked: parent.clicked()
-    }
-
-    Text {
-      Layout.preferredWidth: welcomeActions.width / 3
-      text: parent.label
-      horizontalAlignment: Text.AlignHCenter
-      wrapMode: Text.WordWrap
-      color: Theme.mainTextColor
-      font: Theme.tipFont
-    }
-  }
-
   visible: false
   focus: visible
 
@@ -516,21 +481,37 @@ Page {
           width: parent.width - 12
           spacing: 12
 
-          RowLayout {
+          Container {
+            id: welcomeActionsContainer
             objectName: "welcomeActionsContainer"
             Layout.fillWidth: true
-            spacing: 0
 
-            WelcomeActionItem {
+            readonly property real buttonSize: Math.min(mainWindow.height / 4, width / 3 / 1.5)
+            Layout.preferredHeight: buttonSize + 4 + Theme.tipFont.pixelSize * 3
+
+            contentItem: ListView {
+              model: parent.contentModel
+              width: parent.width
+              height: parent.height
+              orientation: ListView.Horizontal
+              spacing: 0
+              ScrollBar.horizontal: QfScrollBar {
+                policy: contentWidth > width ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
+              }
+            }
+
+            QfWelcomeAction {
               objectName: "welcomeActionCloud"
+              width: welcomeActionsContainer.width / 3
               iconSource: Theme.getThemeVectorIcon("ic_cloud_active_24dp")
               iconColor: Theme.cloudColor
               label: qsTr("QFieldCloud\nprojects")
               onClicked: showQFieldCloudScreen()
             }
 
-            WelcomeActionItem {
+            QfWelcomeAction {
               objectName: "welcomeActionLocalProjects"
+              width: welcomeActionsContainer.width / 3
               iconSource: Theme.getThemeVectorIcon("ic_folder_open_black_24dp")
               iconColor: Theme.mainColor
               label: qsTr("Local projects and\n datasets")
@@ -540,8 +521,9 @@ Page {
               }
             }
 
-            WelcomeActionItem {
+            QfWelcomeAction {
               objectName: "welcomeActionNewProject"
+              width: welcomeActionsContainer.width / 3
               iconSource: Theme.getThemeVectorIcon("ic_add_white_24dp")
               iconColor: Theme.mainColor
               label: qsTr("Create new\nproject")

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -22,6 +22,41 @@ Page {
   signal showSettings
   signal showProjectCreationScreen
 
+  component WelcomeActionItem: ColumnLayout {
+    property url iconSource
+    property color iconColor
+    property string label
+    signal clicked
+
+    Layout.fillWidth: true
+    Layout.alignment: Qt.AlignTop
+    spacing: 4
+
+    QfToolButton {
+      Layout.alignment: Qt.AlignHCenter
+      Layout.preferredWidth: Math.min(mainWindow.height / 4, welcomeActions.width / 3 / 1.5)
+      Layout.preferredHeight: Layout.preferredWidth
+      icon.width: width / 2.2
+      icon.height: height / 2.2
+      bgcolor: Theme.controlBackgroundAlternateColor
+      round: false
+      roundborder: true
+      iconSource: parent.iconSource
+      iconColor: parent.iconColor
+      smooth: true
+      onClicked: parent.clicked()
+    }
+
+    Text {
+      Layout.preferredWidth: welcomeActions.width / 3
+      text: parent.label
+      horizontalAlignment: Text.AlignHCenter
+      wrapMode: Text.WordWrap
+      color: Theme.mainTextColor
+      font: Theme.tipFont
+    }
+  }
+
   visible: false
   focus: visible
 
@@ -481,65 +516,36 @@ Page {
           width: parent.width - 12
           spacing: 12
 
-          GridLayout {
+          RowLayout {
+            objectName: "welcomeActionsContainer"
             Layout.fillWidth: true
-            columns: 3
-            rows: 2
+            spacing: 0
 
-            Repeater {
-              id: actionsRepeater
-              model: [
-                {
-                  "icon": Theme.getThemeVectorIcon("ic_cloud_active_24dp"),
-                  "iconColor": Theme.cloudColor,
-                  "action": function () {
-                    showQFieldCloudScreen();
-                  }
-                },
-                {
-                  "icon": Theme.getThemeVectorIcon("ic_folder_open_black_24dp"),
-                  "iconColor": Theme.mainColor,
-                  "action": function () {
-                    platformUtilities.requestStoragePermission();
-                    showLocalDataPicker();
-                  }
-                },
-                {
-                  "icon": Theme.getThemeVectorIcon("ic_add_white_24dp"),
-                  "iconColor": Theme.mainColor,
-                  "action": function () {
-                    showProjectCreationScreen();
-                  }
-                }
-              ]
+            WelcomeActionItem {
+              objectName: "welcomeActionCloud"
+              iconSource: Theme.getThemeVectorIcon("ic_cloud_active_24dp")
+              iconColor: Theme.cloudColor
+              label: qsTr("QFieldCloud\nprojects")
+              onClicked: showQFieldCloudScreen()
+            }
 
-              delegate: QfToolButton {
-                Layout.alignment: Qt.AlignHCenter
-                Layout.preferredWidth: Math.min(mainWindow.height / 4, welcomeActions.width / actionsRepeater.count / 1.5)
-                Layout.preferredHeight: Layout.preferredWidth
-                icon.width: width / 2.2
-                icon.height: height / 2.2
-                bgcolor: Theme.controlBackgroundAlternateColor
-                round: false
-                roundborder: true
-                iconSource: modelData.icon
-                iconColor: modelData.iconColor
-                smooth: true
-                onClicked: modelData.action()
+            WelcomeActionItem {
+              objectName: "welcomeActionLocalProjects"
+              iconSource: Theme.getThemeVectorIcon("ic_folder_open_black_24dp")
+              iconColor: Theme.mainColor
+              label: qsTr("Local projects and\n datasets")
+              onClicked: {
+                platformUtilities.requestStoragePermission();
+                showLocalDataPicker();
               }
             }
 
-            Repeater {
-              model: [qsTr("QFieldCloud\nprojects"), qsTr("Local projects and\n datasets"), qsTr("Create new\nproject")]
-
-              delegate: Text {
-                Layout.preferredWidth: welcomeActions.width / 3
-                text: modelData
-                horizontalAlignment: Text.AlignHCenter
-                wrapMode: Text.WordWrap
-                color: Theme.mainTextColor
-                font: Theme.tipFont
-              }
+            WelcomeActionItem {
+              objectName: "welcomeActionNewProject"
+              iconSource: Theme.getThemeVectorIcon("ic_add_white_24dp")
+              iconColor: Theme.mainColor
+              label: qsTr("Create new\nproject")
+              onClicked: showProjectCreationScreen()
             }
           }
 

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -484,12 +484,12 @@ Page {
           Container {
             id: welcomeActionsContainer
             objectName: "welcomeActionsContainer"
-            Layout.fillWidth: true
-
-            readonly property real buttonSize: Math.min(mainWindow.height / 4, width / 3 / 1.5)
-            Layout.preferredHeight: buttonSize + 4 + Theme.tipFont.pixelSize * 3
+            Layout.preferredWidth: Math.min(welcomeActionsListView.contentWidth, welcomeActions.width)
+            Layout.preferredHeight: Math.max(welcomeActionCloud.height, welcomeActionLocalProjects.height, welcomeActionNewProject.height)
+            Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
 
             contentItem: ListView {
+              id: welcomeActionsListView
               model: parent.contentModel
               width: parent.width
               height: parent.height
@@ -501,8 +501,9 @@ Page {
             }
 
             QfWelcomeAction {
+              id: welcomeActionCloud
               objectName: "welcomeActionCloud"
-              width: welcomeActionsContainer.width / 3
+              width: welcomeActions.width / 3
               iconSource: Theme.getThemeVectorIcon("ic_cloud_active_24dp")
               iconColor: Theme.cloudColor
               label: qsTr("QFieldCloud\nprojects")
@@ -510,8 +511,9 @@ Page {
             }
 
             QfWelcomeAction {
+              id: welcomeActionLocalProjects
               objectName: "welcomeActionLocalProjects"
-              width: welcomeActionsContainer.width / 3
+              width: welcomeActions.width / 3
               iconSource: Theme.getThemeVectorIcon("ic_folder_open_black_24dp")
               iconColor: Theme.mainColor
               label: qsTr("Local projects and\n datasets")
@@ -522,8 +524,9 @@ Page {
             }
 
             QfWelcomeAction {
+              id: welcomeActionNewProject
               objectName: "welcomeActionNewProject"
-              width: welcomeActionsContainer.width / 3
+              width: welcomeActions.width / 3
               iconSource: Theme.getThemeVectorIcon("ic_add_white_24dp")
               iconColor: Theme.mainColor
               label: qsTr("Create new\nproject")

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -489,6 +489,8 @@ Page {
             Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
             clip: true
 
+            readonly property real itemWidth: count > 3 ? welcomeActions.width / 3.3 : welcomeActions.width / 3
+
             contentItem: ListView {
               id: welcomeActionsListView
               model: parent.contentModel
@@ -504,7 +506,7 @@ Page {
             QfWelcomeAction {
               id: welcomeActionCloud
               objectName: "welcomeActionCloud"
-              width: welcomeActions.width / 3
+              width: welcomeActionsContainer.itemWidth
               iconSource: Theme.getThemeVectorIcon("ic_cloud_active_24dp")
               iconColor: Theme.cloudColor
               label: qsTr("QFieldCloud\nprojects")
@@ -514,7 +516,7 @@ Page {
             QfWelcomeAction {
               id: welcomeActionLocalProjects
               objectName: "welcomeActionLocalProjects"
-              width: welcomeActions.width / 3
+              width: welcomeActionsContainer.itemWidth
               iconSource: Theme.getThemeVectorIcon("ic_folder_open_black_24dp")
               iconColor: Theme.mainColor
               label: qsTr("Local projects and\n datasets")
@@ -527,7 +529,7 @@ Page {
             QfWelcomeAction {
               id: welcomeActionNewProject
               objectName: "welcomeActionNewProject"
-              width: welcomeActions.width / 3
+              width: welcomeActionsContainer.itemWidth
               iconSource: Theme.getThemeVectorIcon("ic_add_white_24dp")
               iconColor: Theme.mainColor
               label: qsTr("Create new\nproject")

--- a/src/qml/imports/Theme/QfWelcomeAction.qml
+++ b/src/qml/imports/Theme/QfWelcomeAction.qml
@@ -17,6 +17,7 @@ ColumnLayout {
   spacing: 4
 
   QfToolButton {
+    id: actionButton
     Layout.alignment: Qt.AlignHCenter
     Layout.minimumWidth: 48
     Layout.minimumHeight: 48
@@ -35,6 +36,7 @@ ColumnLayout {
 
   Text {
     Layout.fillWidth: true
+    visible: root.width / 1.5 > actionButton.Layout.minimumWidth
     text: root.label
     horizontalAlignment: Text.AlignHCenter
     wrapMode: Text.WordWrap

--- a/src/qml/imports/Theme/QfWelcomeAction.qml
+++ b/src/qml/imports/Theme/QfWelcomeAction.qml
@@ -18,6 +18,8 @@ ColumnLayout {
 
   QfToolButton {
     Layout.alignment: Qt.AlignHCenter
+    Layout.minimumWidth: 48
+    Layout.minimumHeight: 48
     Layout.preferredWidth: Math.min(Screen.height / 4, root.width / 1.5)
     Layout.preferredHeight: Layout.preferredWidth
     icon.width: width / 2.2

--- a/src/qml/imports/Theme/QfWelcomeAction.qml
+++ b/src/qml/imports/Theme/QfWelcomeAction.qml
@@ -1,0 +1,42 @@
+import QtQuick
+import QtQuick.Layouts
+import org.qfield
+import Theme
+
+/**
+ * \ingroup qml
+ */
+ColumnLayout {
+  id: root
+
+  property url iconSource
+  property color iconColor
+  property string label
+  signal clicked
+
+  spacing: 4
+
+  QfToolButton {
+    Layout.alignment: Qt.AlignHCenter
+    Layout.preferredWidth: Math.min(Screen.height / 4, root.width / 1.5)
+    Layout.preferredHeight: Layout.preferredWidth
+    icon.width: width / 2.2
+    icon.height: height / 2.2
+    bgcolor: Theme.controlBackgroundAlternateColor
+    round: false
+    roundborder: true
+    iconSource: root.iconSource
+    iconColor: root.iconColor
+    smooth: true
+    onClicked: root.clicked()
+  }
+
+  Text {
+    Layout.fillWidth: true
+    text: root.label
+    horizontalAlignment: Text.AlignHCenter
+    wrapMode: Text.WordWrap
+    color: Theme.mainTextColor
+    font: Theme.tipFont
+  }
+}

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -28,3 +28,4 @@ QfToolButton 1.0 QfToolButton.qml
 QfToolButtonDrawer 1.0 QfToolButtonDrawer.qml
 QfToolButtonPie 1.0 QfToolButtonPie.qml
 QfVisibilityFadingRow 1.0 QfVisibilityFadingRow.qml
+QfWelcomeAction 1.0 QfWelcomeAction.qml

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -126,6 +126,7 @@
         <file>imports/Theme/qmldir</file>
         <file>imports/Theme/QfSwipeAnimator.qml</file>
         <file>imports/Theme/QfVisibilityFadingRow.qml</file>
+        <file>imports/Theme/QfWelcomeAction.qml</file>
         <file>imports/Theme/QfProgressRing.qml</file>
         <file>imports/Theme/QfProjectThumbnail.qml</file>
         <file>imports/Theme/QfScrollBar.qml</file>


### PR DESCRIPTION
### 🚀 Description

Refactors the welcome screen action area to make it plugin-friendly. Each action (Cloud, Local Projects, New Project) is now a self-contained, named item that plugins can target directly..

### ✨ Key Changes

- Replaced dual-Repeater `GridLayout` (separate models for buttons and labels) with a `RowLayout` of independent, self-contained items — each item owns its button and label together.
- Exposed `objectNames` on each action item (`welcomeActionCloud`, `welcomeActionLocalProjects`, `welcomeActionNewProject`).
