### PR TITLE
Fix flaky QML tests (?!)

### DIFF
--- a/test/qml/tst_positioning.qml
+++ b/test/qml/tst_positioning.qml
@@ -71,7 +71,7 @@ TestCase {
     }
 
     featureModel.resetAttributes();
-    compare(featureModel.feature.attribute("source"), "manual");
+    tryVerify(() => featureModel.feature.attribute("source") === "manual", 2000);
     verify(featureModel.feature.attribute("Quality") !== undefined);
     verify(featureModel.feature.attribute("Fix status") !== undefined);
     verify(featureModel.feature.attribute("Horizontal accuracy") !== undefined);
@@ -82,7 +82,7 @@ TestCase {
     verify(featureModel.appExpressionContextScopesGenerator.positionInformation.latitude !== undefined);
     featureModel.appExpressionContextScopesGenerator.positionLocked = true;
     featureModel.resetAttributes();
-    compare(featureModel.feature.attribute("source"), "nmea");
+    tryVerify(() => featureModel.feature.attribute("source") === "nmea", 2000);
     verify(featureModel.feature.attribute("Quality") !== undefined);
     verify(featureModel.feature.attribute("Fix status") !== undefined);
     verify(featureModel.feature.attribute("Horizontal accuracy") !== undefined);

--- a/test/qml/tst_qfieldCloudScreenUI.qml
+++ b/test/qml/tst_qfieldCloudScreenUI.qml
@@ -404,18 +404,16 @@ TestCase {
     compare(project1.localPath, "");
     compare(project2.localPath, "");
     table.positionViewAtIndex(project1Info.rowIndex, ListView.Center);
-    wait(300);
+    tryVerify(() => table.itemAtIndex(project1Info.rowIndex) !== null, 5000);
     const delegate1 = table.itemAtIndex(project1Info.rowIndex);
-    verify(delegate1 !== null);
     const downloadButton1 = delegate1.children[1].children[2].children[0];
     verify(downloadButton1 !== null);
     downloadButton1.clicked();
     wait(500);
 
     table.positionViewAtIndex(project2Info.rowIndex, ListView.Center);
-    wait(300);
+    tryVerify(() => table.itemAtIndex(project2Info.rowIndex) !== null, 5000);
     const delegate2 = table.itemAtIndex(project2Info.rowIndex);
-    verify(delegate2 !== null);
     const downloadButton2 = delegate2.children[1].children[2].children[0];
     verify(downloadButton2 !== null);
     downloadButton2.clicked();
@@ -464,9 +462,8 @@ TestCase {
       // only attempt cancel if still downloading.
       if (project.status === QFieldCloudProject.Downloading) {
         table.positionViewAtIndex(projectInfo.rowIndex, ListView.Center);
-        wait(200);
+        tryVerify(() => table.itemAtIndex(projectInfo.rowIndex) !== null, 5000);
         delegate = table.itemAtIndex(projectInfo.rowIndex);
-        verify(delegate !== null);
         downloadButton = delegate.children[1].children[2].children[0];
         verify(downloadButton !== null);
         downloadButton.clicked();


### PR DESCRIPTION
There are some failures on linux ci cd some times! testing to fix them!

**Error1:** 
```
FAIL!  : test_qml::QFieldCloudScreenUI::test_08_concurrentDownloads(remote) 'verify()' returned FALSE. ()
   Loc: [/home/runner/work/QField/QField/test/qml/tst_qfieldCloudScreenUI.qml(409)]
```

**Error2:** 
```
FAIL!  : test_qml::Positioning::test_00_featureModelPositioning() Compared values are not the same
   Actual   (): undefined
   Expected (): manual
```