### PR TITLE
Insure *GGA sentences are sent as GPGGA sentences to NTRIP servers

### DIFF
--- a/src/core/positioning/ntripclient.cpp
+++ b/src/core/positioning/ntripclient.cpp
@@ -194,13 +194,41 @@ void NtripClient::nmeaSentenceReceived( const QString &sentence )
 
   const thread_local QRegularExpression rxSentence( u"^\\$([A-Z]{2})([A-Z]{3})"_s );
   const QRegularExpressionMatch sentenceMatch = rxSentence.match( sentence );
+  const QString talkerId = sentenceMatch.captured( 1 );
   const QString sentenceId = sentenceMatch.captured( 2 );
   if ( sentenceId != QStringLiteral( "GGA" ) )
   {
     return;
   }
 
-  sendNmeaSentence( sentence );
+  QString sentenceToSend = sentence;
+  if ( talkerId != QStringLiteral( "GP" ) )
+  {
+    // Some NTRIP servers will only consume GPGGA sentences, we must adjust accordingly
+    const int asteriskIndex = sentence.lastIndexOf( '*' );
+    if ( asteriskIndex > 0 )
+    {
+      QString payload = sentence.mid( 1, asteriskIndex - 1 );
+      payload.replace( 0, 2, QStringLiteral( "GP" ) );
+
+      // Calculate new checkum
+      quint8 checksum = 0;
+      const QByteArray payloadBytes = payload.toLatin1();
+      for ( char c : payloadBytes )
+      {
+        checksum ^= c;
+      }
+
+      const QString trailing = sentence.mid( asteriskIndex + 3 );
+      sentenceToSend = QStringLiteral( "$%1*%2%3" )
+                         .arg( payload )
+                         .arg( checksum, 2, 16, QLatin1Char( '0' ) )
+                         .toUpper()
+                         .arg( trailing );
+    }
+  }
+
+  sendNmeaSentence( sentenceToSend );
   mLastNtripGgaSent = epoch;
 }
 

--- a/src/core/positioning/ntripclient.cpp
+++ b/src/core/positioning/ntripclient.cpp
@@ -212,12 +212,8 @@ void NtripClient::nmeaSentenceReceived( const QString &sentence )
       payload.replace( 0, 2, QStringLiteral( "GP" ) );
 
       // Calculate new checkum
-      quint8 checksum = 0;
       const QByteArray payloadBytes = payload.toLatin1();
-      for ( char c : payloadBytes )
-      {
-        checksum ^= c;
-      }
+      const quint8 checksum = std::accumulate( payloadBytes.begin(), payloadBytes.end(), 0, std::bit_xor<quint8>() );
 
       const QString trailing = sentence.mid( asteriskIndex + 3 );
       sentenceToSend = QStringLiteral( "$%1*%2%3" )

--- a/src/core/positioning/ntripclient.cpp
+++ b/src/core/positioning/ntripclient.cpp
@@ -377,10 +377,28 @@ void NtripSocket::onReadyRead()
     mHeaderBuffer.append( data );
 
     qsizetype headerEnd = mHeaderBuffer.indexOf( "\r\n\r\n" );
-    if ( headerEnd != -1 )
+    int separatorSize = 4;
+    if ( headerEnd == -1 )
+    {
+      // Check for ICY 200 header
+      headerEnd = mHeaderBuffer.indexOf( "\r\n" );
+      if ( headerEnd >= 0 )
+      {
+        if ( mHeaderBuffer.startsWith( "ICY 200 OK" ) )
+        {
+          separatorSize = 2;
+        }
+        else
+        {
+          headerEnd = -1;
+        }
+      }
+    }
+
+    if ( headerEnd >= 0 )
     {
       const QByteArray headerBlock = mHeaderBuffer.left( headerEnd );
-      const QByteArray body = mHeaderBuffer.mid( headerEnd + 4 );
+      const QByteArray body = mHeaderBuffer.mid( headerEnd + separatorSize );
       mHeaderBuffer.clear();
 
       // Check for SOURCETABLE response (mountpoint not found)

--- a/src/qml/PositioningNtripSettings.qml
+++ b/src/qml/PositioningNtripSettings.qml
@@ -364,6 +364,7 @@ QfPopup {
         if (idx > -1) {
           ntripMountPointComboBox.currentIndex = idx;
         } else {
+          ntripMountPointComboBox.currentIndex = -1;
           ntripMountPointComboBox.editText = previousMountPoint;
         }
       } else {


### PR DESCRIPTION
TIL: some NTRIP servers are old enough to expect G>>P<<GGA sentences and will fail when receiving other GGA sentences (such as G>>N<<GGA). We can work around this by ensuring that all of our sentences are sent as GPGGA. This PR does exactly that.

This should fix https://github.com/opengisch/QField/issues/7521#issuecomment-4673010042 -- I've been able to run tests locally with a fake NMEA log sent to the server. 