### PR TITLE
Added tests for reshape, erase and variable width buffer

### DIFF
--- a/test/test_geometryutils.cpp
+++ b/test/test_geometryutils.cpp
@@ -21,6 +21,7 @@
 #include "utils/geometryutils.h"
 
 #include <qgis.h>
+#include <qgsproject.h>
 #include <qgsvectorlayer.h>
 
 
@@ -75,5 +76,113 @@ TEST_CASE( "GeometryUtils" )
     mLayer->select( 1 );
 
     REQUIRE( GeometryUtils::splitFeatureFromRubberband( mLayer.get(), 1, model.get() ) == GeometryUtils::GeometryOperationResult::Success );
+  }
+
+  SECTION( "ReshapeFromRubberband" )
+  {
+    // reshapeFromRubberband reads the topological editing and avoid intersections
+    // state off the global project; pin them so the assertions stay deterministic
+    QgsProject::instance()->setTopologicalEditing( false );
+    QgsProject::instance()->setAvoidIntersectionsMode( Qgis::AvoidIntersectionsMode::AllowIntersections );
+
+    // an unknown feature has no base geometry to reshape
+    REQUIRE( GeometryUtils::reshapeFromRubberband( mLayer.get(), 100, model.get() ) == GeometryUtils::GeometryOperationResult::InvalidBaseGeometry );
+
+    const double originalArea = mLayer->getFeature( 1 ).geometry().area();
+    model->addVertexFromPoint( QgsPoint( 8.75, 8.25 ) );
+    model->addVertexFromPoint( QgsPoint( 9.5, 9.5 ) );
+    model->addVertexFromPoint( QgsPoint( 8.25, 8.75 ) );
+
+    // reshapeFromRubberband persists the result through layer->changeGeometry, which
+    // requires an open edit session just like the digitizing tool provides at runtime
+    REQUIRE( mLayer->startEditing() );
+    REQUIRE( GeometryUtils::reshapeFromRubberband( mLayer.get(), 1, model.get() ) == GeometryUtils::GeometryOperationResult::Success );
+    REQUIRE( mLayer->commitChanges() );
+
+    const QgsGeometry reshapedGeometry = mLayer->getFeature( 1 ).geometry();
+    REQUIRE( !reshapedGeometry.isNull() );
+    REQUIRE( reshapedGeometry.isGeosValid() );
+    REQUIRE( reshapedGeometry.area() > originalArea );
+  }
+
+  SECTION( "EraseFromRubberband" )
+  {
+    QgsProject::instance()->setTopologicalEditing( false );
+
+    // the rubberband used for erasing carries the buffer width as the M value of its
+    // vertices, the geometry type matches the line drawn by the Erase tool
+    std::unique_ptr<RubberbandModel> eraseModel = std::make_unique<RubberbandModel>();
+    eraseModel->setGeometryType( Qgis::GeometryType::Line );
+
+    // a dedicated square gives room for the M based buffer (width 5 * measureValue) to
+    // either nibble a corner or cut clean through, both deterministically
+    std::unique_ptr<QgsVectorLayer> squareLayer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Polygon?crs=epsg:3946" ), QStringLiteral( "square" ), QStringLiteral( "memory" ) );
+    QgsFeature square( squareLayer->fields(), 1 );
+    square.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "Polygon ((0 0, 10 0, 10 10, 0 10, 0 0))" ) ) );
+    REQUIRE( squareLayer->startEditing() );
+    REQUIRE( squareLayer->addFeature( square ) );
+    REQUIRE( squareLayer->commitChanges() );
+
+    // an unknown feature has no base geometry to erase
+    REQUIRE( GeometryUtils::eraseFromRubberband( squareLayer.get(), 100, eraseModel.get() ) == GeometryUtils::GeometryOperationResult::InvalidBaseGeometry );
+
+    SECTION( "Nibble a corner" )
+    {
+      const double originalArea = squareLayer->getFeature( 1 ).geometry().area();
+
+      // measureValue must be set before the vertices are added so each added vertex
+      // carries it as its M value; width 5 * 0.1 = 0.5 only clips the corner
+      eraseModel->setMeasureValue( 0.1 );
+      eraseModel->addVertexFromPoint( QgsPoint( -1, 1 ) );
+      eraseModel->addVertexFromPoint( QgsPoint( 1, -1 ) );
+
+      // eraseFromRubberband persists the result through layer->changeGeometry, which
+      // requires an open edit session just like the digitizing tool provides at runtime
+      REQUIRE( squareLayer->startEditing() );
+      REQUIRE( GeometryUtils::eraseFromRubberband( squareLayer.get(), 1, eraseModel.get() ) == GeometryUtils::GeometryOperationResult::Success );
+      REQUIRE( squareLayer->commitChanges() );
+
+      const QgsGeometry erasedGeometry = squareLayer->getFeature( 1 ).geometry();
+      REQUIRE( !erasedGeometry.isNull() );
+      REQUIRE( erasedGeometry.isGeosValid() );
+      REQUIRE( erasedGeometry.area() < originalArea );
+    }
+
+    SECTION( "Cut into multiple parts" )
+    {
+      // width 5 * 0.5 = 2.5 erases a band straight across the square, leaving two
+      // disjoint pieces, the multipart result cannot fit the single type layer
+      eraseModel->setMeasureValue( 0.5 );
+      eraseModel->addVertexFromPoint( QgsPoint( 5, -1 ) );
+      eraseModel->addVertexFromPoint( QgsPoint( 5, 11 ) );
+
+      REQUIRE( GeometryUtils::eraseFromRubberband( squareLayer.get(), 1, eraseModel.get() ) == GeometryUtils::GeometryOperationResult::AddPartNotMultiGeometry );
+    }
+  }
+
+  SECTION( "VariableWidthBufferByMFromRubberband" )
+  {
+    const QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromEpsgId( 3946 );
+
+    std::unique_ptr<RubberbandModel> bufferModel = std::make_unique<RubberbandModel>();
+    bufferModel->setGeometryType( Qgis::GeometryType::Line );
+
+    // without a measure value the vertices have no M, the buffer width collapses to zero
+    // and an empty geometry comes back
+    bufferModel->addVertexFromPoint( QgsPoint( 0, 0 ) );
+    bufferModel->addVertexFromPoint( QgsPoint( 10, 0 ) );
+    REQUIRE( GeometryUtils::variableWidthBufferByMFromRubberband( bufferModel.get(), crs ).isEmpty() );
+
+    // a positive measure value yields a buffer polygon with an area
+    std::unique_ptr<RubberbandModel> widthModel = std::make_unique<RubberbandModel>();
+    widthModel->setGeometryType( Qgis::GeometryType::Line );
+    widthModel->setMeasureValue( 1.0 );
+    widthModel->addVertexFromPoint( QgsPoint( 0, 0 ) );
+    widthModel->addVertexFromPoint( QgsPoint( 10, 0 ) );
+
+    const QgsGeometry buffer = GeometryUtils::variableWidthBufferByMFromRubberband( widthModel.get(), crs );
+    REQUIRE( !buffer.isEmpty() );
+    REQUIRE( buffer.isGeosValid() );
+    REQUIRE( buffer.area() > 0.0 );
   }
 }


### PR DESCRIPTION
this pr adds test coverage for three GeometryUtils functions that had none: reshapeFromRubberband, eraseFromRubberband and variableWidthBufferByMFromRubberband. These back the reshape and erase geometry editor tools, so they were a gap worth closing for the stability work while I was reading through the codebase

The idea was to feed a rubberband model the same point data the digitizing tools would produce, run the operation, and check the result. Where the output goes through geos I assert on the result code and structural facts (area changed, geometry still valid).

>What I assert is only the result code (Success, AddPartNotMultiGeometry etc) and structural facts (area went up, area went down, geometry is valid).
What I deliberately avoided was writing something like REQUIRE( geometry.asWkt() =="Polygon(88, 9.5 9.5, ...)" ), pinning the exact coordinate string geos produces. Reason is geos might order vertices or round coordinates slightly differently across versions, or not, but I still think it is better than asserting an exact geometry string. Let me know what you think on this @nirvn 