### PR TITLE
Get rid of risky QList<QList<QPointF>> properies usage in the grid model object in favor of safer (and faster) QString ones

### DIFF
--- a/src/core/gridmodel.cpp
+++ b/src/core/gridmodel.cpp
@@ -138,11 +138,13 @@ void GridModel::setPrepareLines( bool prepare )
     if ( !mMajorLines.isEmpty() )
     {
       mMajorLines.clear();
+      mMajorLinesPath.clear();
       emit majorLinesChanged();
     }
     if ( !mMinorLines.isEmpty() )
     {
       mMinorLines.clear();
+      mMajorLinesPath.clear();
       emit minorLinesChanged();
     }
   }
@@ -165,6 +167,7 @@ void GridModel::setPrepareMarkers( bool prepare )
     if ( !mMarkers.isEmpty() )
     {
       mMarkers.clear();
+      mMarkersPath.clear();
       emit markersChanged();
     }
   }
@@ -290,16 +293,19 @@ void GridModel::clear()
   if ( !mMajorLines.isEmpty() )
   {
     mMajorLines.clear();
+    mMajorLinesPath.clear();
     emit majorLinesChanged();
   }
   if ( !mMinorLines.isEmpty() )
   {
     mMinorLines.clear();
+    mMajorLinesPath.clear();
     emit minorLinesChanged();
   }
   if ( !mMarkers.isEmpty() )
   {
     mMarkers.clear();
+    mMarkersPath.clear();
     emit markersChanged();
   }
   if ( !mAnnotations.isEmpty() )
@@ -493,13 +499,35 @@ void GridModel::update()
 
   if ( mPrepareMarkers )
   {
+    mMarkersPath.clear();
+    for ( const QPointF &marker : std::as_const( mMarkers ) )
+    {
+      mMarkersPath += QStringLiteral( "M %1 %2 L %3 %4 M %5 %6 L %7 %8 " ).arg( marker.x() ).arg( marker.y() - 5 ).arg( marker.x() ).arg( marker.y() + 5 ).arg( marker.x() - 5 ).arg( marker.y() ).arg( marker.x() + 5 ).arg( marker.y() );
+    }
     emit markersChanged();
   }
   if ( mPrepareLines )
   {
+    mMajorLinesPath.clear();
+    for ( const QList<QPointF> &majorLine : std::as_const( mMajorLines ) )
+    {
+      if ( majorLine.size() >= 2 )
+      {
+        mMajorLinesPath += QStringLiteral( "M %1 %2 L %3 %4 " ).arg( majorLine[0].x() ).arg( majorLine[0].y() ).arg( majorLine[1].x() ).arg( majorLine[1].y() );
+      }
+    }
     emit majorLinesChanged();
+
     if ( !mMinorLines.isEmpty() || hadMinorLines )
     {
+      mMinorLinesPath.clear();
+      for ( const QList<QPointF> &minorLine : std::as_const( mMinorLines ) )
+      {
+        if ( minorLine.size() >= 2 )
+        {
+          mMinorLinesPath += QStringLiteral( "M %1 %2 L %3 %4 " ).arg( minorLine[0].x() ).arg( minorLine[0].y() ).arg( minorLine[1].x() ).arg( minorLine[1].y() );
+        }
+      }
       emit minorLinesChanged();
     }
   }

--- a/src/core/gridmodel.h
+++ b/src/core/gridmodel.h
@@ -74,9 +74,9 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     Q_PROPERTY( bool prepareMarkers READ prepareMarkers WRITE setPrepareMarkers NOTIFY prepareMarkersChanged )
     Q_PROPERTY( bool prepareAnnotations READ prepareAnnotations WRITE setPrepareAnnotations NOTIFY prepareAnnotationsChanged )
 
-    Q_PROPERTY( QList<QList<QPointF>> majorLines READ majorLines NOTIFY majorLinesChanged )
-    Q_PROPERTY( QList<QList<QPointF>> minorLines READ minorLines NOTIFY minorLinesChanged )
-    Q_PROPERTY( QList<QPointF> markers READ markers NOTIFY markersChanged )
+    Q_PROPERTY( QString majorLinesPath READ majorLinesPath NOTIFY majorLinesChanged )
+    Q_PROPERTY( QString minorLinesPath READ minorLinesPath NOTIFY minorLinesChanged )
+    Q_PROPERTY( QString markersPath READ markersPath NOTIFY markersChanged )
     Q_PROPERTY( QList<GridAnnotation> annotations READ annotations NOTIFY annotationsChanged )
 
     Q_PROPERTY( bool autoColor READ autoColor WRITE setAutoColor NOTIFY autoColorChanged )
@@ -148,10 +148,10 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     void setPrepareLines( bool prepare );
 
     //! Returns the grid major lines
-    QList<QList<QPointF>> majorLines() const { return mMajorLines; }
+    QString majorLinesPath() const { return mMajorLinesPath; }
 
     //! Returns the grid minor lines
-    QList<QList<QPointF>> minorLines() const { return mMinorLines; }
+    QString minorLinesPath() const { return mMinorLinesPath; }
 
     //! Returns whether grid markers will be prepared
     bool prepareMarkers() const { return mPrepareMarkers; }
@@ -160,7 +160,7 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     void setPrepareMarkers( bool prepare );
 
     //! Returns the grid markers
-    QList<QPointF> markers() const { return mMarkers; }
+    QString markersPath() const { return mMarkersPath; }
 
     //! Returns whether grid annotations will be prepared
     bool prepareAnnotations() const { return mPrepareAnnotations; }
@@ -312,8 +312,13 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     bool mPrepareLines = false;
     QList<QList<QPointF>> mMajorLines;
     QList<QList<QPointF>> mMinorLines;
+    QString mMajorLinesPath;
+    QString mMinorLinesPath;
+
     bool mPrepareMarkers = false;
     QList<QPointF> mMarkers;
+    QString mMarkersPath;
+
     bool mPrepareAnnotations = false;
     QList<GridAnnotation> mAnnotations;
 

--- a/src/qml/GridRenderer.qml
+++ b/src/qml/GridRenderer.qml
@@ -34,35 +34,11 @@ Item {
 
   GridModel {
     id: gridModel
-
-    onMajorLinesChanged: {
-      let svgPath = "";
-      for (const line of majorLines) {
-        svgPath += "M " + (line[0].x) + " " + (line[0].y) + " L " + (line[1].x) + " " + (line[1].y) + " ";
-      }
-      majorLineSvgPath.path = svgPath;
-    }
-
-    onMinorLinesChanged: {
-      let svgPath = "";
-      for (const line of minorLines) {
-        svgPath += "M " + (line[0].x) + " " + (line[0].y) + " L " + (line[1].x) + " " + (line[1].y) + " ";
-      }
-      minorLineSvgPath.path = svgPath;
-    }
-
-    onMarkersChanged: {
-      let svgPath = "";
-      for (const marker of markers) {
-        svgPath += "M " + (marker.x) + " " + (marker.y - 5) + " L " + (marker.x) + " " + (marker.y + 5) + " " + "M " + (marker.x - 5) + " " + (marker.y) + " L " + (marker.x + 5) + " " + (marker.y) + " ";
-      }
-      markerSvgPath.path = svgPath;
-    }
   }
 
   Shape {
     id: minorLinesContainer
-    visible: gridModel.prepareLines && gridModel.minorLines.length > 0
+    visible: gridModel.prepareLines && gridModel.minorLinesPath != ""
     anchors.fill: parent
 
     ShapePath {
@@ -76,14 +52,14 @@ Item {
 
       PathSvg {
         id: minorLineSvgPath
-        path: ""
+        path: gridModel.minorLinesPath
       }
     }
   }
 
   Shape {
     id: majorLinesContainer
-    visible: gridModel.prepareLines && gridModel.majorLines.length > 0
+    visible: gridModel.prepareLines && gridModel.majorLinesPath != ""
     anchors.fill: parent
 
     ShapePath {
@@ -97,14 +73,14 @@ Item {
 
       PathSvg {
         id: majorLineSvgPath
-        path: ""
+        path: gridModel.majorLinesPath
       }
     }
   }
 
   Shape {
     id: markersContainer
-    visible: gridModel.prepareMarkers && gridModel.markers.length > 0
+    visible: gridModel.prepareMarkers && gridModel.markersPath != ""
     anchors.fill: parent
 
     ShapePath {
@@ -118,7 +94,7 @@ Item {
 
       PathSvg {
         id: markerSvgPath
-        path: ""
+        path: gridModel.markersPath
       }
     }
   }

--- a/src/qml/Rubberband.qml
+++ b/src/qml/Rubberband.qml
@@ -11,48 +11,53 @@ RubberbandShape {
 
   property bool showVertices: false
 
-  Shape {
-    anchors.fill: parent
-    ShapePath {
-      strokeColor: rubberbandShape.outlineColor
-      strokeWidth: rubberbandShape.lineWidth / rubberbandShape.scale + 2
-      strokeStyle: ShapePath.SolidLine
-      fillColor: "transparent"
-      joinStyle: ShapePath.RoundJoin
-      capStyle: ShapePath.RoundCap
-
-      PathPolyline {
-        path: rubberbandShape.polylines[0]
-      }
-    }
-    ShapePath {
-      strokeColor: rubberbandShape.color
-      strokeWidth: rubberbandShape.lineWidth / rubberbandShape.scale
-      strokeStyle: ShapePath.SolidLine
-      fillColor: rubberbandShape.polylinesType === Qgis.GeometryType.Polygon ? Qt.hsla(strokeColor.hslHue, strokeColor.hslSaturation, strokeColor.hslLightness, 0.25) : "transparent"
-      joinStyle: ShapePath.RoundJoin
-      capStyle: ShapePath.RoundCap
-
-      PathPolyline {
-        path: rubberbandShape.polylines[0]
-      }
-    }
-  }
-
   Repeater {
-    id: rubberbandVertices
-    model: showVertices && rubberbandShape.model.vertexCount > 1 ? rubberbandShape.polylines[0] : []
+    id: rubberbandPaths
+    model: rubberbandShape.polylines
 
-    Rectangle {
-      width: rubberbandShape.lineWidth / rubberbandShape.scale * 2
-      height: width
+    Shape {
+      anchors.fill: parent
+      ShapePath {
+        strokeColor: rubberbandShape.outlineColor
+        strokeWidth: rubberbandShape.lineWidth / rubberbandShape.scale + 2
+        strokeStyle: ShapePath.SolidLine
+        fillColor: "transparent"
+        joinStyle: ShapePath.RoundJoin
+        capStyle: ShapePath.RoundCap
 
-      x: modelData.x - width / 2
-      y: modelData.y - width / 2
+        PathPolyline {
+          path: modelData
+        }
+      }
+      ShapePath {
+        strokeColor: rubberbandShape.color
+        strokeWidth: rubberbandShape.lineWidth / rubberbandShape.scale
+        strokeStyle: ShapePath.SolidLine
+        fillColor: rubberbandShape.polylinesType === Qgis.GeometryType.Polygon ? Qt.hsla(strokeColor.hslHue, strokeColor.hslSaturation, strokeColor.hslLightness, 0.25) : "transparent"
+        joinStyle: ShapePath.RoundJoin
+        capStyle: ShapePath.RoundCap
 
-      color: rubberbandShape.color
-      border.width: 1
-      border.color: rubberbandShape.outlineColor
+        PathPolyline {
+          path: modelData
+        }
+      }
+
+      Repeater {
+        id: rubberbandVertices
+        model: showVertices && rubberbandShape.model.vertexCount > 1 ? modelData : []
+
+        Rectangle {
+          width: rubberbandShape.lineWidth / rubberbandShape.scale * 2
+          height: width
+
+          x: modelData.x - width / 2
+          y: modelData.y - width / 2
+
+          color: rubberbandShape.color
+          border.width: 1
+          border.color: rubberbandShape.outlineColor
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
OK, this is an attempt at fixing our worse crasher on Android against which we have virtually _zero_ useful information. 

This is what we get from the play store crash report:

```
 *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 16757 >>> ch.opengis.qfield <<<

#00 pc 0x00000000003259c0 /data/app/~~S9NoRUd-p7e3zZ8w5wBD5w==/ch.opengis.qfield-Av2aUp1ZNSqKfLozdBFVQA==/lib/arm64/libQt6Qml_arm64-v8a.so (QV4::Object::insertMember(QV4::StringOrSymbol*, QV4::Property const*, QV4::PropertyAttributes)+208) (BuildId: 889808dc3f74e5a60c59232ed4229eb4876ef52f)

#01 pc 0x0000000000325b78 /data/app/~~S9NoRUd-p7e3zZ8w5wBD5w==/ch.opengis.qfield-Av2aUp1ZNSqKfLozdBFVQA==/lib/arm64/libQt6Qml_arm64-v8a.so (BuildId: 889808dc3f74e5a60c59232ed4229eb4876ef52f)

#02 pc 0x0000000000326950 /data/app/~~S9NoRUd-p7e3zZ8w5wBD5w==/ch.opengis.qfield-Av2aUp1ZNSqKfLozdBFVQA==/lib/arm64/libQt6Qml_arm64-v8a.so (QV4::Object::internalPut(QV4::PropertyKey, QV4::Value const&, QV4::Value*)+900) (BuildId: 889808dc3f74e5a60c59232ed4229eb4876ef52f)

#03 pc 0x0000000000326898 /data/app/~~S9NoRUd-p7e3zZ8w5wBD5w==/ch.opengis.qfield-Av2aUp1ZNSqKfLozdBFVQA==/lib/arm64/libQt6Qml_arm64-v8a.so (QV4::Object::internalPut(QV4::PropertyKey, QV4::Value const&, QV4::Value*)+716) (BuildId: 889808dc3f74e5a60c59232ed4229eb4876ef52f)

#04 pc 0x000000000036d174 /data/app/~~S9NoRUd-p7e3zZ8w5wBD5w==/ch.opengis.qfield-Av2aUp1ZNSqKfLozdBFVQA==/lib/arm64/libQt6Qml_arm64-v8a.so (BuildId: 889808dc3f74e5a60c59232ed4229eb4876ef52f)

#05 pc 0x000000000036cec8 /data/app/~~S9NoRUd-p7e3zZ8w5wBD5w==/ch.opengis.qfield-Av2aUp1ZNSqKfLozdBFVQA==/lib/arm64/libQt6Qml_arm64-v8a.so (QV4::Runtime::StoreElement::call(QV4::ExecutionEngine*, QV4::Value const&, QV4::Value const&, QV4::Value const&)+56) (BuildId: 889808dc3f74e5a60c59232ed4229eb4876ef52f)

#06 pc 0x0000000000006448 
```

Bouh, we can't really get much out of this, other than we're dealing with the Javascript engine inserting into an array / object.

Looking on the play store for the oldest version number over the last 90 days (not ideal, but that's the range we got), I see the oldest version is 3.5. 

In this version, we added the project grid renderer. This class _does_ expose some complex QList<QList<QPointF> properties. This feels like _maybe_ it could have something to do with this. Since QField 4.0, we also show a grid _below_ the rendered map canvas to help animate long pan and zoom movements, which further increases the exposure to these properties.

While I'll admit this is a shot in the dark, I think it'd make sense to avoid passing on these array of arrays. We can actually do the line SVG paths creation on the C++ side and pass on a simple QString. _Even if it's a mix on the crash_, it ends up being a nice little optimization.

This dive into madness was helped by Gemini.