### PR TITLE
Unlock a webview embed for QField on Windows

### DIFF
--- a/src/qml/BrowserPanel.qml
+++ b/src/qml/BrowserPanel.qml
@@ -22,7 +22,7 @@ QfPopup {
 
   width: mainWindow.width - (browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeHorizontalMargin * 2)
   height: mainWindow.height - (browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeVerticalMargin * 2)
-  x: browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeVerticalMargin
+  x: browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeHorizontalMargin
   y: browserPanel.fullscreen ? 0 : Theme.popupScreenEdgeVerticalMargin
   padding: fullscreen ? 0 : 5
   closePolicy: Popup.CloseOnEscape

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -101,7 +101,15 @@
         "qml"
       ]
     },
-    "qtwebview",
+    {
+      "name": "qtwebview",
+      "features": [
+        {
+          "name": "webview2",
+          "platform": "windows"
+        }
+      ]
+    },
     {
       "name": "sentry-cocoa",
       "platform": "ios"

--- a/vcpkg/ports/qtwebview/portfile.cmake
+++ b/vcpkg/ports/qtwebview/portfile.cmake
@@ -7,6 +7,7 @@ set(${PORT}_PATCHES)
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 FEATURES
     "webengine"     CMAKE_REQUIRE_FIND_PACKAGE_WebEngineCore
+    "webview2"      FEATURE_webview_webview2_plugin
 INVERTED_FEATURES
     "webengine"     CMAKE_DISABLE_FIND_PACKAGE_WebEngineCore
 )

--- a/vcpkg/ports/qtwebview/vcpkg.json
+++ b/vcpkg/ports/qtwebview/vcpkg.json
@@ -30,6 +30,13 @@
           ]
         }
       ]
+    },
+    "webview2": {
+      "description": "Build with webview2",
+      "supports": "windows",
+      "dependencies": [
+        "webview2"
+      ]
     }
   }
 }


### PR DESCRIPTION
This PR aims at replacing void with content:

<img width="874" height="449" alt="image" src="https://github.com/user-attachments/assets/d2043516-f5ea-4df4-a7da-aaecf7eb1151" />
