### PR TITLE
Guard the Bluetooth Low Energy (BLE) receiver from buffer overflow + TCP receiver NTRIP fix

### DIFF
--- a/src/core/positioning/bluetoothlowenergyreceiver.cpp
+++ b/src/core/positioning/bluetoothlowenergyreceiver.cpp
@@ -235,11 +235,17 @@ void BluetoothLowEnergyReceiver::serviceStateChanged( QLowEnergyService::Service
 
       if ( mRxCharacteristic.isValid() )
       {
+        qInfo() << "BluetoothLowEnergyReceiver: Subscribing to RX characteristic notification";
         QLowEnergyDescriptor notificationDesc = mRxCharacteristic.descriptor( QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration );
         if ( notificationDesc.isValid() )
         {
           mService->writeDescriptor( notificationDesc, QByteArray::fromHex( "0100" ) );
           qInfo() << "BluetoothLowEnergyReceiver: Subscribed to RX characteristic notifications.";
+        }
+
+        if ( mTxCharacteristic.isValid() )
+        {
+          qInfo() << "BluetoothLowEnergyReceiver: Valid TX characteristic.";
         }
 
         mBufferData.clear();

--- a/src/core/positioning/bluetoothlowenergyreceiver.cpp
+++ b/src/core/positioning/bluetoothlowenergyreceiver.cpp
@@ -90,6 +90,7 @@ void BluetoothLowEnergyReceiver::handleConnectDevice()
 
 void BluetoothLowEnergyReceiver::handleDisconnectDevice()
 {
+  setSocketState( QAbstractSocket::UnconnectedState );
   mConnectOnDisconnect = false;
   doDisconnectDevice();
 }
@@ -139,15 +140,7 @@ void BluetoothLowEnergyReceiver::deviceConnected()
 
 void BluetoothLowEnergyReceiver::deviceDisconnected()
 {
-  qInfo() << "BluetoothLowEnergyReceiver: Disconnected.";
-  setSocketState( QAbstractSocket::UnconnectedState );
-
-  clearService();
-
-  if ( mConnectOnDisconnect )
-  {
-    doConnectDevice();
-  }
+  qInfo() << "BluetoothLowEnergyReceiver: Received disconnected signal.";
 }
 
 void BluetoothLowEnergyReceiver::controllerErrorOccurred( QLowEnergyController::Error error )

--- a/src/core/positioning/bluetoothlowenergyreceiver.cpp
+++ b/src/core/positioning/bluetoothlowenergyreceiver.cpp
@@ -41,6 +41,9 @@ BluetoothLowEnergyReceiver::BluetoothLowEnergyReceiver( const QString &address, 
 {
   qInfo() << "BluetoothLowEnergyReceiver: Creating the receiver";
 
+  mCorrectionTimer.setInterval( 20 );
+  connect( &mCorrectionTimer, &QTimer::timeout, this, &BluetoothLowEnergyReceiver::forwardCorrectionDataChunk );
+
   initNmeaConnection( mBuffer );
   setValid( !mAddress.isEmpty() );
 }
@@ -365,12 +368,26 @@ void BluetoothLowEnergyReceiver::onCorrectionDataReceived( const QByteArray &dat
     return;
   }
 
+  mCorrectionData.append( data );
+
+  if ( !mCorrectionTimer.isActive() )
+  {
+    mCorrectionTimer.start();
+  }
+}
+
+void BluetoothLowEnergyReceiver::forwardCorrectionDataChunk()
+{
+  if ( mCorrectionData.isEmpty() || !mService || !mTxCharacteristic.isValid() )
+  {
+    mCorrectionTimer.stop();
+    return;
+  }
+
   // Payloag must not be longer than 20 bytes
   // https://doc.qt.io/qt-6/qlowenergyservice.html#WriteMode-enum
-  const int chunkSize = 20;
-  for ( int i = 0; i < data.length(); i += chunkSize )
-  {
-    QByteArray chunk = data.mid( i, chunkSize );
-    mService->writeCharacteristic( mTxCharacteristic, chunk, QLowEnergyService::WriteWithoutResponse );
-  }
+  const qsizetype chunkSize = std::min( static_cast<qsizetype>( 20 ), mCorrectionData.size() );
+  QByteArray chunk = mCorrectionData.left( chunkSize );
+  mCorrectionData.remove( 0, chunkSize );
+  mService->writeCharacteristic( mTxCharacteristic, chunk, QLowEnergyService::WriteWithoutResponse );
 }

--- a/src/core/positioning/bluetoothlowenergyreceiver.h
+++ b/src/core/positioning/bluetoothlowenergyreceiver.h
@@ -21,6 +21,7 @@
 
 #include <QBuffer>
 #include <QObject>
+#include <QTimer>
 #include <QtBluetooth/QBluetoothUuid>
 #include <QtBluetooth/QLowEnergyController>
 #include <QtBluetooth/QLowEnergyService>
@@ -65,6 +66,8 @@ class BluetoothLowEnergyReceiver : public NmeaGnssReceiver
     void serviceErrorOccurred( QLowEnergyService::ServiceError error );
     void characteristicChanged( const QLowEnergyCharacteristic &characteristic, const QByteArray &value );
 
+    void forwardCorrectionDataChunk();
+
   private:
     void clearService();
 
@@ -85,6 +88,9 @@ class BluetoothLowEnergyReceiver : public NmeaGnssReceiver
 
     QBuffer *mBuffer = nullptr;
     QByteArray mBufferData;
+
+    QByteArray mCorrectionData;
+    QTimer mCorrectionTimer;
 
     bool mDisconnecting = false;
     bool mConnectOnDisconnect = false;

--- a/src/core/positioning/nmeagnssreceiver.cpp
+++ b/src/core/positioning/nmeagnssreceiver.cpp
@@ -221,6 +221,7 @@ void NmeaGnssReceiver::onCorrectionDataReceived( const QByteArray &data )
   {
     return;
   }
+
   qint64 bytesWritten = mIODevice->write( data );
   if ( bytesWritten == -1 )
   {

--- a/src/core/positioning/ntripclient.cpp
+++ b/src/core/positioning/ntripclient.cpp
@@ -187,7 +187,7 @@ void NtripClient::logData( const QByteArray &data )
 void NtripClient::nmeaSentenceReceived( const QString &sentence )
 {
   const qint64 epoch = QDateTime::currentMSecsSinceEpoch();
-  if ( mLastNtripGgaSent != 0 && ( epoch - mLastNtripGgaSent ) < 30000 )
+  if ( mLastNtripGgaSent != 0 && ( epoch - mLastNtripGgaSent ) < 10000 )
   {
     return;
   }

--- a/src/core/positioning/tcpreceiver.cpp
+++ b/src/core/positioning/tcpreceiver.cpp
@@ -43,7 +43,7 @@ TcpReceiver::TcpReceiver( const QString &address, const int port, QObject *paren
 
   mReconnectTimer.setSingleShot( true );
   connect( &mReconnectTimer, &QTimer::timeout, this, [this]() {
-    mSocket->connectToHost( mAddress, mPort, QTcpSocket::ReadOnly );
+    mSocket->connectToHost( mAddress, mPort, QTcpSocket::ReadWrite );
   } );
 
   setValid( !mAddress.isEmpty() && mPort > 0 );


### PR DESCRIPTION
This is aimed at fixing https://github.com/opengisch/QField/issues/7578 . There are two important fixes here:

- Our TCP receiver was connecting to the TCP socket in read-only mode, which meant correction data was never sent (doh!)
- Our BLE receiver was properly splitting correction data in chunks, but we were sending it all in one for loop, which can cause buffer overflow issues on iOS and Android

@mbernasocchi , this might actually help with the perceived stability issue you mentioned yesterday.

