### PR TITLE
 Add ability to take notes onto line and polygon geometry layers within our project creation wizard

### DIFF
--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -177,6 +177,11 @@ QgsSymbol *LayerUtils::defaultSymbol( QgsVectorLayer *layer, const QString &atta
     case Qgis::GeometryType::Polygon:
     {
       QgsSimpleFillSymbolLayer *symbolLayer = new QgsSimpleFillSymbolLayer( QColor( 55, 126, 184, 100 ), DEFAULT_SIMPLEFILL_STYLE, QColor( 55, 126, 184 ), DEFAULT_SIMPLEFILL_BORDERSTYLE, 0.6 ); // cppcheck-suppress constVariablePointer
+      if ( !colorField.isEmpty() )
+      {
+        symbolLayer->setDataDefinedProperty( QgsSymbolLayer::Property::FillColor, QgsProperty::fromExpression( QStringLiteral( "if(\"%1\" is not null and \"%1\" != '', set_color_part(\"%1\", 'alpha', 100), @value)" ).arg( colorField ), true ) );
+        symbolLayer->setDataDefinedProperty( QgsSymbolLayer::Property::StrokeColor, QgsProperty::fromExpression( QStringLiteral( "if(\"%1\" is not null and \"%1\" != '', \"%1\", @value)" ).arg( colorField ), true ) );
+      }
       symbolLayers << symbolLayer;
       symbol = new QgsFillSymbol( symbolLayers );
       break;

--- a/src/core/utils/projectutils.cpp
+++ b/src/core/utils/projectutils.cpp
@@ -155,7 +155,7 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
     notesLayers << notesPointLayer;
 
     LayerUtils::setDefaultRenderer( notesPointLayer, nullptr,
-                                    options.value( QStringLiteral( "camera_capture" ) ).toBool() ? QStringLiteral( "relation_aggregate('notes_attachments_relation', 'max', \"media\")" ) : QString(),
+                                    options.value( QStringLiteral( "camera_capture" ) ).toBool() ? QStringLiteral( "relation_aggregate('notes_attachments_relation_%1', 'max', \"media\")" ).arg( notesPointLayer->id() ) : QString(),
                                     QStringLiteral( "color" ) );
     LayerUtils::setDefaultLabeling( notesPointLayer );
 

--- a/src/core/utils/projectutils.cpp
+++ b/src/core/utils/projectutils.cpp
@@ -122,116 +122,65 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
   createdProject->displaySettings()->setCoordinateType( Qgis::CoordinateDisplayType::CustomCrs );
   createdProject->displaySettings()->setCoordinateCustomCrs( QgsCoordinateReferenceSystem( "EPSG:4326" ) );
 
-  // Notes layer
-  QgsVectorLayer *notesLayer = nullptr;
+  // Notes-related layers
+  QgsVectorLayer *notesPointLayer = nullptr;
+  QgsVectorLayer *notesLineLayer = nullptr;
+  QgsVectorLayer *notesPolygonLayer = nullptr;
   QgsVectorLayer *attachmentsLayer = nullptr;
   if ( options.value( QStringLiteral( "notes" ) ).toBool() )
   {
+    QList<QgsVectorLayer *> notesLayers;
+
     createdProject->writeEntry( QStringLiteral( "qfieldsync" ), QStringLiteral( "initialMapMode" ), QStringLiteral( "digitize" ) );
 
     const QString notesFilepath = QStringLiteral( "%1/notes.gpkg" ).arg( createdProjectDir );
+    const bool notesHasAdditionalGeometries = options.value( QStringLiteral( "notes_on_lines_polygons" ) ).toBool();
+    const bool notesHasAttachments = options.value( QStringLiteral( "camera_capture" ) ).toBool();
 
-    QgsFields fields;
-    fields.append( QgsField( QStringLiteral( "uuid" ), QMetaType::QString ) );
-    fields.append( QgsField( QStringLiteral( "color" ), QMetaType::QString ) );
-    fields.append( QgsField( QStringLiteral( "title" ), QMetaType::QString ) );
-    fields.append( QgsField( QStringLiteral( "note" ), QMetaType::QString ) );
-    fields.append( QgsField( QStringLiteral( "timestamp" ), QMetaType::QDateTime ) );
+    QgsFields notesFields;
+    notesFields.append( QgsField( QStringLiteral( "uuid" ), QMetaType::QString ) );
+    notesFields.append( QgsField( QStringLiteral( "color" ), QMetaType::QString ) );
+    notesFields.append( QgsField( QStringLiteral( "title" ), QMetaType::QString ) );
+    notesFields.append( QgsField( QStringLiteral( "note" ), QMetaType::QString ) );
+    notesFields.append( QgsField( QStringLiteral( "timestamp" ), QMetaType::QDateTime ) );
 
     QgsVectorFileWriter::SaveVectorOptions writerOptions;
-    QgsVectorFileWriter *writer = QgsVectorFileWriter::create( notesFilepath, fields, Qgis::WkbType::PointZ, QgsCoordinateReferenceSystem( "EPSG:4326" ), createdProject->transformContext(), writerOptions );
+    writerOptions.layerName = "notes_point";
+    QgsVectorFileWriter *writer = QgsVectorFileWriter::create( notesFilepath, notesFields, Qgis::WkbType::PointZ, QgsCoordinateReferenceSystem( "EPSG:4326" ), createdProject->transformContext(), writerOptions );
     delete writer;
 
-    notesLayer = new QgsVectorLayer( notesFilepath, tr( "Notes" ) );
-    fields = notesLayer->fields();
-    LayerUtils::setDefaultRenderer( notesLayer, nullptr,
+    writerOptions.actionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
+
+    notesPointLayer = new QgsVectorLayer( QStringLiteral( "%1|layername=%2" ).arg( notesFilepath, writerOptions.layerName ), notesHasAdditionalGeometries ? QStringLiteral( "%1 — %2" ).arg( tr( "Notes" ), tr( "Point" ) ) : ( "Notes" ) );
+    notesLayers << notesPointLayer;
+
+    LayerUtils::setDefaultRenderer( notesPointLayer, nullptr,
                                     options.value( QStringLiteral( "camera_capture" ) ).toBool() ? QStringLiteral( "relation_aggregate('notes_attachments_relation', 'max', \"media\")" ) : QString(),
                                     QStringLiteral( "color" ) );
-    LayerUtils::setDefaultLabeling( notesLayer );
+    LayerUtils::setDefaultLabeling( notesPointLayer );
 
-    // Set a nice display expression for the feature list
-    notesLayer->setDisplayExpression( "COALESCE( title , 'Note #' || fid || ' from ' || format_date( timestamp, 'yyyy-MM-dd HH:mm' ) )" );
-
-    int fieldIndex;
-    QVariantMap widgetOptions;
-    QgsEditorWidgetSetup widgetSetup;
-
-    // Configure fid field
-    fieldIndex = fields.indexOf( QStringLiteral( "fid" ) );
-    if ( fieldIndex >= 0 )
+    if ( notesHasAdditionalGeometries )
     {
-      widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), widgetOptions );
-      notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
+      writerOptions.layerName = "notes_line";
+      writer = QgsVectorFileWriter::create( notesFilepath, notesFields, Qgis::WkbType::LineStringZ, QgsCoordinateReferenceSystem( "EPSG:4326" ), createdProject->transformContext(), writerOptions );
+      delete writer;
+
+      notesLineLayer = new QgsVectorLayer( QStringLiteral( "%1|layername=%2" ).arg( notesFilepath, writerOptions.layerName ), QStringLiteral( "%1 — %2" ).arg( tr( "Notes" ), tr( "Line" ) ) );
+      notesLayers << notesLineLayer;
+
+      LayerUtils::setDefaultRenderer( notesLineLayer, nullptr, QString(), QStringLiteral( "color" ) );
+
+      writerOptions.layerName = "notes_polygon";
+      writer = QgsVectorFileWriter::create( notesFilepath, notesFields, Qgis::WkbType::PolygonZ, QgsCoordinateReferenceSystem( "EPSG:4326" ), createdProject->transformContext(), writerOptions );
+      delete writer;
+
+      notesPolygonLayer = new QgsVectorLayer( QStringLiteral( "%1|layername=%2" ).arg( notesFilepath, writerOptions.layerName ), QStringLiteral( "%1 — %2" ).arg( tr( "Notes" ), tr( "Polygon" ) ) );
+      notesLayers << notesPolygonLayer;
+
+      LayerUtils::setDefaultRenderer( notesPolygonLayer, nullptr, QString(), QStringLiteral( "color" ) );
     }
 
-    // Configure uuid field (referenced key for relations)
-    fieldIndex = fields.indexOf( QStringLiteral( "uuid" ) );
-    if ( fieldIndex >= 0 )
-    {
-      widgetOptions.clear();
-      widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), widgetOptions );
-      notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
-      notesLayer->setDefaultValueDefinition( fieldIndex, QgsDefaultValue( QStringLiteral( "uuid()" ), false ) );
-    }
-
-    // Configure time field
-    fieldIndex = fields.indexOf( QStringLiteral( "timestamp" ) );
-    if ( fieldIndex >= 0 )
-    {
-      widgetOptions.clear();
-      widgetOptions[QStringLiteral( "display_format" )] = QStringLiteral( "yyyy-MM-dd HH:mm" );
-      widgetOptions[QStringLiteral( "field_format" )] = QStringLiteral( "yyyy-MM-dd HH:mm" );
-      widgetOptions[QStringLiteral( "field_format_overwrite" )] = true;
-      widgetOptions[QStringLiteral( "allow_null" )] = true;
-      widgetOptions[QStringLiteral( "calendar_popup" )] = true;
-      widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "DateTime" ), widgetOptions );
-      notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
-      notesLayer->setDefaultValueDefinition( fieldIndex, QgsDefaultValue( QStringLiteral( "now()" ), false ) );
-      notesLayer->setFieldAlias( fieldIndex, tr( "Time" ) );
-    }
-
-    // Configure color field
-    fieldIndex = fields.indexOf( QStringLiteral( "color" ) );
-    if ( fieldIndex >= 0 )
-    {
-      widgetOptions.clear();
-      widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Color" ), widgetOptions );
-      notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
-      notesLayer->setDefaultValueDefinition( fieldIndex, QgsDefaultValue( QStringLiteral( "'#377eb8'" ), false ) );
-      notesLayer->setFieldAlias( fieldIndex, tr( "Marker color" ) );
-    }
-
-    // Configure note field
-    fieldIndex = fields.indexOf( QStringLiteral( "title" ) );
-    if ( fieldIndex >= 0 )
-    {
-      widgetOptions.clear();
-      widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "TextEdit" ), widgetOptions );
-      notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
-      notesLayer->setFieldAlias( fieldIndex, tr( "Title" ) );
-    }
-
-    // Configure note field
-    fieldIndex = fields.indexOf( QStringLiteral( "note" ) );
-    if ( fieldIndex >= 0 )
-    {
-      widgetOptions.clear();
-      widgetOptions[QStringLiteral( "IsMultiline" )] = true;
-      widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "TextEdit" ), widgetOptions );
-      notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
-      notesLayer->setFieldAlias( fieldIndex, tr( "Note" ) );
-    }
-
-    // Insure the layer is ready cloud-friendly
-    notesLayer->setCustomProperty( QStringLiteral( "QFieldSync/cloud_action" ), QStringLiteral( "offline" ) );
-    notesLayer->setCustomProperty( QStringLiteral( "QFieldSync/action" ), QStringLiteral( "offline" ) );
-
-    notesLayer->setDisplayExpression( QStringLiteral( "\"title\"" ) );
-
-    createdProjectLayers << notesLayer;
-
-    // Attachments child layer (when camera capture is enabled)
-    if ( options.value( QStringLiteral( "camera_capture" ) ).toBool() )
+    if ( notesHasAttachments )
     {
       // Second layer in the same notes.gpkg
       QgsFields attachFields;
@@ -241,16 +190,11 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
       attachFields.append( QgsField( QStringLiteral( "description" ), QMetaType::QString ) );
       attachFields.append( QgsField( QStringLiteral( "timestamp" ), QMetaType::QDateTime ) );
 
-      QgsVectorFileWriter::SaveVectorOptions attachWriterOptions;
-      attachWriterOptions.layerName = QStringLiteral( "notes_attachments" );
-      attachWriterOptions.actionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
-      QgsVectorFileWriter *attachWriter = QgsVectorFileWriter::create(
-        notesFilepath, attachFields, Qgis::WkbType::NoGeometry,
-        QgsCoordinateReferenceSystem(),
-        createdProject->transformContext(), attachWriterOptions );
+      writerOptions.layerName = QStringLiteral( "notes_attachments" );
+      QgsVectorFileWriter *attachWriter = QgsVectorFileWriter::create( notesFilepath, attachFields, Qgis::WkbType::NoGeometry, QgsCoordinateReferenceSystem(), createdProject->transformContext(), writerOptions );
       delete attachWriter;
 
-      const QString attachUri = QStringLiteral( "%1|layername=notes_attachments" ).arg( notesFilepath );
+      const QString attachUri = QStringLiteral( "%1|layername=%2" ).arg( notesFilepath, writerOptions.layerName );
       attachmentsLayer = new QgsVectorLayer( attachUri, tr( "Note attachments" ) );
       QgsFields liveAttachFields = attachmentsLayer->fields();
 
@@ -325,28 +269,116 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
       attachmentsLayer->setFlags( attachmentsLayer->flags() | QgsMapLayer::Private );
 
       createdProjectLayers << attachmentsLayer;
+    }
 
-      QgsEditFormConfig notesFormConfig = notesLayer->editFormConfig();
-      notesFormConfig.clearTabs();
-      notesFormConfig.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
-      QgsAttributeEditorContainer *root = notesFormConfig.invisibleRootContainer();
-      QgsAttributeEditorRelation *relationElement = new QgsAttributeEditorRelation( QStringLiteral( "notes_attachments_relation_%1" ).arg( notesLayer->id() ), root );
-      root->addChildElement( relationElement );
-      const QStringList orderedFields = {
-        QStringLiteral( "color" ),
-        QStringLiteral( "title" ),
-        QStringLiteral( "note" ),
-        QStringLiteral( "timestamp" ) };
-      for ( const QString &fieldName : orderedFields )
+    for ( QgsVectorLayer *notesLayer : notesLayers )
+    {
+      QgsFields fields = notesLayer->fields();
+      // Set a nice display expression for the feature list
+      notesLayer->setDisplayExpression( "COALESCE( title , 'Note #' || fid || ' from ' || format_date( timestamp, 'yyyy-MM-dd HH:mm' ) )" );
+
+      int fieldIndex;
+      QVariantMap widgetOptions;
+      QgsEditorWidgetSetup widgetSetup;
+
+      // Configure fid field
+      fieldIndex = fields.indexOf( QStringLiteral( "fid" ) );
+      if ( fieldIndex >= 0 )
       {
-        const int idx = notesLayer->fields().indexOf( fieldName );
-        if ( idx >= 0 )
-        {
-          root->addChildElement( new QgsAttributeEditorField( fieldName, idx, root ) );
-        }
+        widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), widgetOptions );
+        notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
       }
 
-      notesLayer->setEditFormConfig( notesFormConfig );
+      // Configure uuid field (referenced key for relations)
+      fieldIndex = fields.indexOf( QStringLiteral( "uuid" ) );
+      if ( fieldIndex >= 0 )
+      {
+        widgetOptions.clear();
+        widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), widgetOptions );
+        notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
+        notesLayer->setDefaultValueDefinition( fieldIndex, QgsDefaultValue( QStringLiteral( "uuid()" ), false ) );
+      }
+
+      // Configure time field
+      fieldIndex = fields.indexOf( QStringLiteral( "timestamp" ) );
+      if ( fieldIndex >= 0 )
+      {
+        widgetOptions.clear();
+        widgetOptions[QStringLiteral( "display_format" )] = QStringLiteral( "yyyy-MM-dd HH:mm" );
+        widgetOptions[QStringLiteral( "field_format" )] = QStringLiteral( "yyyy-MM-dd HH:mm" );
+        widgetOptions[QStringLiteral( "field_format_overwrite" )] = true;
+        widgetOptions[QStringLiteral( "allow_null" )] = true;
+        widgetOptions[QStringLiteral( "calendar_popup" )] = true;
+        widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "DateTime" ), widgetOptions );
+        notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
+        notesLayer->setDefaultValueDefinition( fieldIndex, QgsDefaultValue( QStringLiteral( "now()" ), false ) );
+        notesLayer->setFieldAlias( fieldIndex, tr( "Time" ) );
+      }
+
+      // Configure color field
+      fieldIndex = fields.indexOf( QStringLiteral( "color" ) );
+      if ( fieldIndex >= 0 )
+      {
+        widgetOptions.clear();
+        widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Color" ), widgetOptions );
+        notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
+        notesLayer->setDefaultValueDefinition( fieldIndex, QgsDefaultValue( QStringLiteral( "'#377eb8'" ), false ) );
+        notesLayer->setFieldAlias( fieldIndex, tr( "Marker color" ) );
+      }
+
+      // Configure note field
+      fieldIndex = fields.indexOf( QStringLiteral( "title" ) );
+      if ( fieldIndex >= 0 )
+      {
+        widgetOptions.clear();
+        widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "TextEdit" ), widgetOptions );
+        notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
+        notesLayer->setFieldAlias( fieldIndex, tr( "Title" ) );
+      }
+
+      // Configure note field
+      fieldIndex = fields.indexOf( QStringLiteral( "note" ) );
+      if ( fieldIndex >= 0 )
+      {
+        widgetOptions.clear();
+        widgetOptions[QStringLiteral( "IsMultiline" )] = true;
+        widgetSetup = QgsEditorWidgetSetup( QStringLiteral( "TextEdit" ), widgetOptions );
+        notesLayer->setEditorWidgetSetup( fieldIndex, widgetSetup );
+        notesLayer->setFieldAlias( fieldIndex, tr( "Note" ) );
+      }
+
+      // Insure the layer is ready cloud-friendly
+      notesLayer->setCustomProperty( QStringLiteral( "QFieldSync/cloud_action" ), QStringLiteral( "offline" ) );
+      notesLayer->setCustomProperty( QStringLiteral( "QFieldSync/action" ), QStringLiteral( "offline" ) );
+
+      notesLayer->setDisplayExpression( QStringLiteral( "\"title\"" ) );
+
+      createdProjectLayers << notesLayer;
+
+      if ( notesHasAttachments )
+      {
+        QgsEditFormConfig notesFormConfig = notesLayer->editFormConfig();
+        notesFormConfig.clearTabs();
+        notesFormConfig.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
+        QgsAttributeEditorContainer *root = notesFormConfig.invisibleRootContainer();
+        QgsAttributeEditorRelation *relationElement = new QgsAttributeEditorRelation( QStringLiteral( "notes_attachments_relation_%1" ).arg( notesLayer->id() ), root );
+        root->addChildElement( relationElement );
+        const QStringList orderedFields = {
+          QStringLiteral( "color" ),
+          QStringLiteral( "title" ),
+          QStringLiteral( "note" ),
+          QStringLiteral( "timestamp" ) };
+        for ( const QString &fieldName : orderedFields )
+        {
+          const int idx = notesLayer->fields().indexOf( fieldName );
+          if ( idx >= 0 )
+          {
+            root->addChildElement( new QgsAttributeEditorField( fieldName, idx, root ) );
+          }
+        }
+
+        notesLayer->setEditFormConfig( notesFormConfig );
+      }
     }
   }
 
@@ -515,14 +547,24 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
   createdProject->addMapLayers( createdProjectLayers );
 
   // Register the notes
-  if ( notesLayer && attachmentsLayer )
+  if ( notesPointLayer && attachmentsLayer )
   {
     QgsRelationContext relationContext( createdProject );
     QgsPolymorphicRelation relation( relationContext );
     relation.setId( QStringLiteral( "notes_attachments_relation" ) );
     relation.setName( tr( "Attachments" ) );
     relation.setReferencingLayer( attachmentsLayer->id() );
-    relation.setReferencedLayerIds( QStringList() << notesLayer->id() );
+    QStringList referencedLayerIds;
+    referencedLayerIds << notesPointLayer->id();
+    if ( notesLineLayer )
+    {
+      referencedLayerIds << notesLineLayer->id();
+    }
+    if ( notesPolygonLayer )
+    {
+      referencedLayerIds << notesPolygonLayer->id();
+    }
+    relation.setReferencedLayerIds( referencedLayerIds );
     relation.setReferencedLayerExpression( QStringLiteral( "@layer_id" ) );
     relation.setReferencedLayerField( QStringLiteral( "note_layer" ) );
     relation.addFieldPair( QStringLiteral( "note_uuid" ), QStringLiteral( "uuid" ) );

--- a/src/core/utils/projectutils.cpp
+++ b/src/core/utils/projectutils.cpp
@@ -235,6 +235,7 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
     {
       // Second layer in the same notes.gpkg
       QgsFields attachFields;
+      attachFields.append( QgsField( QStringLiteral( "note_layer" ), QMetaType::QString ) );
       attachFields.append( QgsField( QStringLiteral( "note_uuid" ), QMetaType::QString ) );
       attachFields.append( QgsField( QStringLiteral( "media" ), QMetaType::QString ) );
       attachFields.append( QgsField( QStringLiteral( "description" ), QMetaType::QString ) );
@@ -259,6 +260,13 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
 
       // Hide fid
       attachFieldIndex = liveAttachFields.indexOf( QStringLiteral( "fid" ) );
+      if ( attachFieldIndex >= 0 )
+      {
+        attachWidgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), QVariantMap() );
+        attachmentsLayer->setEditorWidgetSetup( attachFieldIndex, attachWidgetSetup );
+      }
+
+      attachFieldIndex = liveAttachFields.indexOf( QStringLiteral( "note_layer" ) );
       if ( attachFieldIndex >= 0 )
       {
         attachWidgetSetup = QgsEditorWidgetSetup( QStringLiteral( "Hidden" ), QVariantMap() );
@@ -322,7 +330,7 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
       notesFormConfig.clearTabs();
       notesFormConfig.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
       QgsAttributeEditorContainer *root = notesFormConfig.invisibleRootContainer();
-      QgsAttributeEditorRelation *relationElement = new QgsAttributeEditorRelation( QStringLiteral( "notes_attachments_relation" ), root );
+      QgsAttributeEditorRelation *relationElement = new QgsAttributeEditorRelation( QStringLiteral( "notes_attachments_relation_%1" ).arg( notesLayer->id() ), root );
       root->addChildElement( relationElement );
       const QStringList orderedFields = {
         QStringLiteral( "color" ),
@@ -510,16 +518,18 @@ QString ProjectUtils::createProject( const QVariantMap &options, const GnssPosit
   if ( notesLayer && attachmentsLayer )
   {
     QgsRelationContext relationContext( createdProject );
-    QgsRelation rel( relationContext );
-    rel.setId( QStringLiteral( "notes_attachments_relation" ) );
-    rel.setName( tr( "Attachments" ) );
-    rel.setReferencedLayer( notesLayer->id() );
-    rel.setReferencingLayer( attachmentsLayer->id() );
-    rel.addFieldPair( QStringLiteral( "note_uuid" ), QStringLiteral( "uuid" ) );
-    rel.setStrength( Qgis::RelationshipStrength::Association );
-    if ( rel.isValid() )
+    QgsPolymorphicRelation relation( relationContext );
+    relation.setId( QStringLiteral( "notes_attachments_relation" ) );
+    relation.setName( tr( "Attachments" ) );
+    relation.setReferencingLayer( attachmentsLayer->id() );
+    relation.setReferencedLayerIds( QStringList() << notesLayer->id() );
+    relation.setReferencedLayerExpression( QStringLiteral( "@layer_id" ) );
+    relation.setReferencedLayerField( QStringLiteral( "note_layer" ) );
+    relation.addFieldPair( QStringLiteral( "note_uuid" ), QStringLiteral( "uuid" ) );
+    relation.setRelationStrength( Qgis::RelationshipStrength::Association );
+    if ( relation.isValid() )
     {
-      createdProject->relationManager()->addRelation( rel );
+      createdProject->relationManager()->addPolymorphicRelation( relation );
     }
   }
 

--- a/src/qml/ProjectCreationScreen.qml
+++ b/src/qml/ProjectCreationScreen.qml
@@ -387,7 +387,7 @@ Page {
             Label {
               Layout.fillWidth: true
               Layout.alignment: Qt.AlignVCenter
-              text: qsTr("Allow notes on lines and polygons geometries")
+              text: qsTr("Allow notes on lines and polygons")
               font: Theme.defaultFont
               color: Theme.mainTextColor
               wrapMode: Text.WordWrap

--- a/src/qml/ProjectCreationScreen.qml
+++ b/src/qml/ProjectCreationScreen.qml
@@ -324,6 +324,7 @@ Page {
           id: takeNotesColumn
           anchors.left: parent.left
           anchors.right: parent.right
+          spacing: 8
 
           Label {
             text: qsTr("Quickly capture notes with date, time, and comments. Optionally, attach multimedia items such as images and videos to enrich your notes.")
@@ -339,11 +340,13 @@ Page {
 
             CheckBox {
               id: takeMediaCheckBox
+              Layout.alignment: Qt.AlignVCenter
               font: Theme.defaultFont
               indicator.height: 16
               indicator.width: 16
               indicator.implicitHeight: 24
               indicator.implicitWidth: 24
+              implicitHeight: 32
               leftPadding: 1
               checked: true
             }
@@ -360,6 +363,39 @@ Page {
                 anchors.fill: parent
                 onClicked: {
                   takeMediaCheckBox.checked = !takeMediaCheckBox.checked;
+                }
+              }
+            }
+          }
+
+          RowLayout {
+            width: parent.width
+            spacing: 0
+
+            CheckBox {
+              id: notesOnLinesPolygonsCheckBox
+              font: Theme.defaultFont
+              indicator.height: 16
+              indicator.width: 16
+              indicator.implicitHeight: 24
+              indicator.implicitWidth: 24
+              implicitHeight: 32
+              leftPadding: 1
+              checked: false
+            }
+
+            Label {
+              Layout.fillWidth: true
+              Layout.alignment: Qt.AlignVCenter
+              text: qsTr("Allow notes on lines and polygons geometries")
+              font: Theme.defaultFont
+              color: Theme.mainTextColor
+              wrapMode: Text.WordWrap
+
+              MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                  notesOnLinesPolygonsCheckBox.checked = !notesOnLinesPolygonsCheckBox.checked;
                 }
               }
             }
@@ -403,6 +439,7 @@ Page {
               indicator.width: 16
               indicator.implicitHeight: 24
               indicator.implicitWidth: 24
+              implicitHeight: 32
               leftPadding: 1
               checked: false
             }
@@ -463,6 +500,7 @@ Page {
               indicator.width: 16
               indicator.implicitHeight: 24
               indicator.implicitWidth: 24
+              implicitHeight: 32
               leftPadding: 1
               checked: false
             }
@@ -523,6 +561,7 @@ Page {
           "basemap_custom_extent": basemapLoader.item ? basemapLoader.item.customExtent || "" : "",
           "notes": takeNotesGroupBox.checked,
           "camera_capture": takeMediaCheckBox.checked,
+          "notes_on_lines_polygons": notesOnLinesPolygonsCheckBox.checked,
           "tracks": trackPositionGroupBox.checked,
           "track_on_launch": autoTrackPositionCheckBox.checked,
           "auto_push_to_cloud": qfieldCloudGroupBox.checked && autoPushCheckBox.checked

--- a/src/qml/imports/Theme/QfExpandableGroupBox.qml
+++ b/src/qml/imports/Theme/QfExpandableGroupBox.qml
@@ -8,7 +8,7 @@ import org.qfield
  */
 Rectangle {
   id: expandableGroupBox
-  implicitHeight: checked ? header.height + body.childrenRect.height + 20 : 60
+  implicitHeight: checked ? header.height + body.childrenRect.height + 30 : 60
 
   radius: 8
   color: Theme.groupBoxBackgroundColor
@@ -96,12 +96,10 @@ Rectangle {
   Item {
     id: body
     anchors.top: splitter.bottom
-    anchors.bottom: parent.bottom
     anchors.left: parent.left
     anchors.right: parent.right
     anchors.leftMargin: 20
     anchors.rightMargin: 20
     anchors.topMargin: 10
-    anchors.bottomMargin: 10
   }
 }


### PR DESCRIPTION
This PR enhances QField's project creation wizard by allowing notes to be taken against line and polygon geometries (in addition to the preexisting point geometry). 

Project creation UI-wise, this looks like this (note that while the checkbox is checked here, by default it is _not_):

<img width="496" height="921" alt="Screenshot From 2026-06-17 12-03-31" src="https://github.com/user-attachments/assets/74294fa4-6edf-4147-a3aa-369332ebd064" />

It allows people to very rapidly do all sorts of nice things:

<img width="496" height="921" alt="Screenshot From 2026-06-17 12-04-51" src="https://github.com/user-attachments/assets/cb253db8-b0be-4230-b1af-7cc3f7629b67" />

The same attributes (including the ability to capture images, videos, and audio clips) are available on line and polygon note layers.