### PR TITLE
Fix QField network user agent settings using obsolete key

### DIFF
--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -248,13 +248,11 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
     mScreenDimmer->setTimeout( settings.value( QStringLiteral( "dimTimeoutSeconds" ), 40 ).toInt() );
   }
 
-  QgsNetworkAccessManager::settingsNetworkTimeout->setValue( 60 * 1000 );
-
-  QgsNetworkAccessManager::instance()->setupDefaultProxyAndCache();
-
   // we cannot use "/" as separator, since QGIS puts a suffix QGIS/31700 anyway
   const QString userAgent = QStringLiteral( "qfield|%1|%2|%3|" ).arg( qfield::appVersion, qfield::appVersionStr.normalized( QString::NormalizationForm_KD ), qfield::gitRev );
-  settings.setValue( QStringLiteral( "/qgis/networkAndProxy/userAgent" ), userAgent );
+  QgsNetworkAccessManager::settingsUserAgent->setValue( userAgent );
+  QgsNetworkAccessManager::settingsNetworkTimeout->setValue( 60 * 1000 );
+  QgsNetworkAccessManager::instance()->setupDefaultProxyAndCache();
 
   AppInterface::setInstance( mIface );
 


### PR DESCRIPTION
We are QField, let's not pretend we're QFieldSync :wink: 

Regression from this change upstream: https://github.com/qgis/QGIS/commit/918c478e4d5b8850e8ef86fb48f4e43e84437d44