### PR TITLE
Add QML tests for the split feature geometry editor tool

### DIFF
--- a/src/qml/geometryeditors/SplitFeature.qml
+++ b/src/qml/geometryeditors/SplitFeature.qml
@@ -31,6 +31,7 @@ GeometryEditorBase {
 
   DigitizingToolbar {
     id: drawLineToolbar
+    objectName: "splitDigitizingToolbar"
     showConfirmButton: true
     screenHovering: splitFeatureToolbar.screenHovering
 

--- a/test/qml/tst_geometryeditor_split.qml
+++ b/test/qml/tst_geometryeditor_split.qml
@@ -11,17 +11,21 @@ TestCase {
   name: "GeometryEditorSplit"
 
   property var testLayer: null
+  property var lineLayer: null
   property string lastToastType: ""
   readonly property string squareJson: '{"type":"FeatureCollection","features":[{"type":"Feature","id":0,"geometry":{"type":"Polygon","coordinates":[[[0,0],[10,0],[10,10],[0,10],[0,0]]]},"properties":{}}]}'
+  readonly property string lineJson: '{"type":"FeatureCollection","features":[{"type":"Feature","id":0,"geometry":{"type":"LineString","coordinates":[[0,5],[10,5]]},"properties":{}}]}'
 
   function init() {
     lastToastType = "";
     testLayer = LayerUtils.memoryLayerFromJsonString("split_test", squareJson, CoordinateReferenceSystemUtils.fromDescription("EPSG:3857"));
+    lineLayer = LayerUtils.memoryLayerFromJsonString("split_line_test", lineJson, CoordinateReferenceSystemUtils.fromDescription("EPSG:3857"));
   }
 
   function cleanup() {
     splitTool.cancel();
     testLayer = null;
+    lineLayer = null;
   }
 
   // set up the feature model on the memory layer and
@@ -30,6 +34,14 @@ TestCase {
     featureModel.currentLayer = testLayer;
     featureModel.feature = testLayer.getFeature(1);
     rubberband.vectorLayer = testLayer;
+    splitTool.init(featureModel, mapSettingsItem, rubberband, null);
+    return featureModel;
+  }
+
+  function initSplitOnLine() {
+    featureModel.currentLayer = lineLayer;
+    featureModel.feature = lineLayer.getFeature(1);
+    rubberband.vectorLayer = lineLayer;
     splitTool.init(featureModel, mapSettingsItem, rubberband, null);
     return featureModel;
   }
@@ -120,6 +132,22 @@ TestCase {
 
     // the split commits a new feature, so the layer reports one features-added commit
     compare(committedFeaturesAddedSpy.count, 1);
+  }
+
+  function test_splitLineProducesExpectedGeometries() {
+    initSplitOnLine();
+    const tb = toolbar();
+
+    // a vertical line crossing the horizontal line feature at x=5
+    addToolVertex(tb, 5, 4);
+    addToolVertex(tb, 5, 6);
+
+    tb.confirm();
+
+    // the line is cut at x=5: the original feature keeps the left segment and a
+    // new feature holds the right segment
+    compare(lineLayer.getFeature(1).geometry.asWkt(2), "LineString (0 5, 5 5)");
+    compare(lineLayer.getFeature(2).geometry.asWkt(2), "LineString (5 5, 10 5)");
   }
 
   function test_confirmWithInvalidLineToasts() {

--- a/test/qml/tst_geometryeditor_split.qml
+++ b/test/qml/tst_geometryeditor_split.qml
@@ -152,7 +152,8 @@ TestCase {
     property string positionInformation: ""
     property string topSnappingResult: ""
     property bool positionLocked: false
-    function flash() {}
+    function flash() {
+    }
   }
 
   Item {

--- a/test/qml/tst_geometryeditor_split.qml
+++ b/test/qml/tst_geometryeditor_split.qml
@@ -1,0 +1,178 @@
+import QtQuick
+import QtTest
+import org.qfield
+import org.qgis
+import Theme
+import "../../src/qml/geometryeditors" as GeometryEditors
+
+TestCase {
+  id: testCase
+  name: "GeometryEditorSplit"
+
+  property var fieldsLayer: qgisProject.mapLayersByName("Fields")[0]
+  property string lastToastType: ""
+
+  function init() {
+    lastToastType = "";
+  }
+
+  function cleanup() {
+    splitTool.cancel();
+    if (fieldsLayer.editBuffer()) {
+      fieldsLayer.rollBack();
+    }
+  }
+
+  function initSplitOnFields() {
+    featureModel.currentLayer = fieldsLayer;
+    featureModel.feature = fieldsLayer.getFeature("39");
+    rubberband.vectorLayer = fieldsLayer;
+    splitTool.init(featureModel, mapSettingsItem, rubberband, null);
+    return featureModel;
+  }
+
+  MapSettings {
+    id: mapSettingsItem
+    destinationCrs: CoordinateReferenceSystemUtils.fromDescription("EPSG:3857")
+  }
+
+  RubberbandModel {
+    id: rubberband
+    crs: CoordinateReferenceSystemUtils.fromDescription("EPSG:3857")
+  }
+
+  FeatureModel {
+    id: featureModel
+    project: qgisProject
+
+    vertexModel: VertexModel {
+      id: geometryEditingVertexModel
+    }
+  }
+
+  GeometryEditors.SplitFeature {
+    id: splitTool
+    featureModel: featureModel
+    mapSettings: mapSettingsItem
+  }
+
+  SignalSpy {
+    id: finishedSpy
+    target: splitTool
+    signalName: "finished"
+  }
+
+  function test_initSetsUpToolForLineSplit() {
+    initSplitOnFields();
+
+    // init wires the feature model and sets the rubberband to line mode, since
+    // the split is drawn as a line across the feature
+    compare(splitTool.featureModel, featureModel);
+    compare(Number(rubberband.geometryType), Qgis.GeometryType.Line);
+  }
+
+  function test_blockingFollowsRubberbandVertexCount() {
+    initSplitOnFields();
+    // blocking mirrors isDigitizing, which is vertexCount > 1
+    compare(splitTool.blocking, false);
+
+    rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
+    rubberband.addVertexFromPoint(GeometryUtils.point(1031000, 5911500));
+
+    compare(splitTool.blocking, true);
+  }
+
+  function test_confirmWithInvalidLineToasts() {
+    initSplitOnFields();
+    const before = fieldsLayer.getFeature("39").geometry.asWkt();
+
+    // a single point is not a valid split line, so splitFeatureFromRubberband
+    // returns non-Success and rolls back. the handler should toast an error and
+    // leave the feature unchanged
+    rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
+    splitTool.children[0].confirm();
+
+    compare(lastToastType, "error");
+    const after = fieldsLayer.getFeature("39").geometry.asWkt();
+    compare(after, before);
+  }
+
+  function test_confirmEmitsFinished() {
+    initSplitOnFields();
+    finishedSpy.clear();
+
+    // confirm always emits finished so the editor closes, even on a failed split
+    rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
+    splitTool.children[0].confirm();
+
+    compare(finishedSpy.count, 1);
+  }
+
+  function test_cancelResetsRubberband() {
+    initSplitOnFields();
+    rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
+    rubberband.addVertexFromPoint(GeometryUtils.point(1031000, 5911500));
+    verify(rubberband.vertexCount > 1);
+
+    splitTool.cancel();
+
+    // cancel clears the rubberband back down
+    verify(rubberband.vertexCount <= 1);
+  }
+
+  // scope objects the tool and DigitizingToolbar expect from the app
+  Item {
+    id: mainWindow
+    property var contentItem: mainWindow
+  }
+
+  Item {
+    id: dashBoard
+    property bool shouldReturnHome: false
+  }
+
+  Item {
+    id: stateMachine
+    property string state: "digitize"
+  }
+
+  function displayToast(message, type, actionText, actionCallback) {
+    lastToastType = type !== undefined ? type : "";
+  }
+
+  Item {
+    id: qfieldSettings
+    property bool autoSave: false
+  }
+
+  Item {
+    id: coordinateLocator
+    property var currentCoordinate: GeometryUtils.point(0, 0)
+    property string positionInformation: ""
+    property string topSnappingResult: ""
+    property bool positionLocked: false
+    function flash() {}
+  }
+
+  Item {
+    id: projectInfo
+    property string cloudUserInformation: ""
+  }
+
+  Item {
+    id: positionSource
+    property string positionInformation: ""
+    property bool averagedPosition: false
+    property int averagedPositionCount: 0
+  }
+
+  Item {
+    id: positioningSettings
+    property bool averagedPositioning: false
+    property int averagedPositioningMinimumCount: 0
+    property bool averagedPositioningAutomaticStop: false
+    property bool accuracyIndicator: false
+    property bool accuracyRequirement: false
+    property real accuracyBad: 0
+  }
+}

--- a/test/qml/tst_geometryeditor_split.qml
+++ b/test/qml/tst_geometryeditor_split.qml
@@ -3,32 +3,44 @@ import QtTest
 import org.qfield
 import org.qgis
 import Theme
+import "Utils.js" as Utils
 import "../../src/qml/geometryeditors" as GeometryEditors
 
 TestCase {
   id: testCase
   name: "GeometryEditorSplit"
 
-  property var fieldsLayer: qgisProject.mapLayersByName("Fields")[0]
+  property var testLayer: null
   property string lastToastType: ""
+  readonly property string squareJson: '{"type":"FeatureCollection","features":[{"type":"Feature","id":0,"geometry":{"type":"Polygon","coordinates":[[[0,0],[10,0],[10,10],[0,10],[0,0]]]},"properties":{}}]}'
 
   function init() {
     lastToastType = "";
+    testLayer = LayerUtils.memoryLayerFromJsonString("split_test", squareJson, CoordinateReferenceSystemUtils.fromDescription("EPSG:3857"));
   }
 
   function cleanup() {
     splitTool.cancel();
-    if (fieldsLayer.editBuffer()) {
-      fieldsLayer.rollBack();
-    }
+    testLayer = null;
   }
 
-  function initSplitOnFields() {
-    featureModel.currentLayer = fieldsLayer;
-    featureModel.feature = fieldsLayer.getFeature("39");
-    rubberband.vectorLayer = fieldsLayer;
+  // set up the feature model on the memory layer and
+  // hand the tool a fresh rubberband like the app does through init
+  function initSplit() {
+    featureModel.currentLayer = testLayer;
+    featureModel.feature = testLayer.getFeature(1);
+    rubberband.vectorLayer = testLayer;
     splitTool.init(featureModel, mapSettingsItem, rubberband, null);
     return featureModel;
+  }
+
+  function addToolVertex(toolbar, x, y) {
+    rubberband.currentCoordinate = GeometryUtils.point(x, y);
+    toolbar.addVertex();
+  }
+
+  function toolbar() {
+    return Utils.findChildren(splitTool, "splitDigitizingToolbar");
   }
 
   MapSettings {
@@ -63,7 +75,7 @@ TestCase {
   }
 
   function test_initSetsUpToolForLineSplit() {
-    initSplitOnFields();
+    initSplit();
 
     // init wires the feature model and sets the rubberband to line mode, since
     // the split is drawn as a line across the feature
@@ -72,50 +84,70 @@ TestCase {
   }
 
   function test_blockingFollowsRubberbandVertexCount() {
-    initSplitOnFields();
+    initSplit();
     // blocking mirrors isDigitizing, which is vertexCount > 1
     compare(splitTool.blocking, false);
 
-    rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
-    rubberband.addVertexFromPoint(GeometryUtils.point(1031000, 5911500));
+    const tb = toolbar();
+    addToolVertex(tb, 5, 5);
+    addToolVertex(tb, 6, 6);
 
     compare(splitTool.blocking, true);
   }
 
+  function test_splitWithValidLineProducesExpectedGeometries() {
+    initSplit();
+    const tb = toolbar();
+
+    // a vertical line crossing the square, splitting it into two halves
+    addToolVertex(tb, 5, -1);
+    addToolVertex(tb, 5, 11);
+
+    // drive the tool through confirm so its onConfirmed runs the split
+    tb.confirm();
+
+    // the square is cut at x=5 into two rectangles: the original feature keeps
+    // the right half and a new feature holds the left half
+    compare(testLayer.getFeature(1).geometry.asWkt(2), "Polygon ((5 0, 5 10, 10 10, 10 0, 5 0))");
+    compare(testLayer.getFeature(2).geometry.asWkt(2), "Polygon ((5 10, 5 0, 0 0, 0 10, 5 10))");
+  }
+
   function test_confirmWithInvalidLineToasts() {
-    initSplitOnFields();
-    const before = fieldsLayer.getFeature("39").geometry.asWkt();
+    initSplit();
+    const before = testLayer.getFeature(1).geometry.asWkt();
+    const tb = toolbar();
 
     // a single point is not a valid split line, so splitFeatureFromRubberband
-    // returns non-Success and rolls back. the handler should toast an error and
-    // leave the feature unchanged
-    rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
-    splitTool.children[0].confirm();
+    // returns non-Success. the handler should toast an error and leave the
+    // feature unchanged
+    addToolVertex(tb, 5, 5);
+    tb.confirm();
 
     compare(lastToastType, "error");
-    const after = fieldsLayer.getFeature("39").geometry.asWkt();
+    const after = testLayer.getFeature(1).geometry.asWkt();
     compare(after, before);
   }
 
   function test_confirmEmitsFinished() {
-    initSplitOnFields();
+    initSplit();
     finishedSpy.clear();
+    const tb = toolbar();
 
     // confirm always emits finished so the editor closes, even on a failed split
-    rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
-    splitTool.children[0].confirm();
+    addToolVertex(tb, 5, 5);
+    tb.confirm();
 
     compare(finishedSpy.count, 1);
   }
 
   function test_cancelResetsRubberband() {
-    initSplitOnFields();
-    rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
-    rubberband.addVertexFromPoint(GeometryUtils.point(1031000, 5911500));
-    // each added point carries a trailing cursor vertex, so two points give three
+    initSplit();
+    const tb = toolbar();
+    addToolVertex(tb, 5, 5);
+    addToolVertex(tb, 6, 6);
     compare(rubberband.vertexCount, 3);
 
-    splitTool.cancel();
+    tb.cancel();
 
     // cancel resets the rubberband down to its single trailing vertex
     compare(rubberband.vertexCount, 1);

--- a/test/qml/tst_geometryeditor_split.qml
+++ b/test/qml/tst_geometryeditor_split.qml
@@ -112,12 +112,13 @@ TestCase {
     initSplitOnFields();
     rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
     rubberband.addVertexFromPoint(GeometryUtils.point(1031000, 5911500));
-    verify(rubberband.vertexCount > 1);
+    // each added point carries a trailing cursor vertex, so two points give three
+    compare(rubberband.vertexCount, 3);
 
     splitTool.cancel();
 
-    // cancel clears the rubberband back down
-    verify(rubberband.vertexCount <= 1);
+    // cancel resets the rubberband down to its single trailing vertex
+    compare(rubberband.vertexCount, 1);
   }
 
   // scope objects the tool and DigitizingToolbar expect from the app

--- a/test/qml/tst_geometryeditor_split.qml
+++ b/test/qml/tst_geometryeditor_split.qml
@@ -74,6 +74,12 @@ TestCase {
     signalName: "finished"
   }
 
+  SignalSpy {
+    id: committedFeaturesAddedSpy
+    target: testLayer
+    signalName: "committedFeaturesAdded"
+  }
+
   function test_initSetsUpToolForLineSplit() {
     initSplit();
 
@@ -97,6 +103,7 @@ TestCase {
 
   function test_splitWithValidLineProducesExpectedGeometries() {
     initSplit();
+    committedFeaturesAddedSpy.clear();
     const tb = toolbar();
 
     // a vertical line crossing the square, splitting it into two halves
@@ -110,10 +117,14 @@ TestCase {
     // the right half and a new feature holds the left half
     compare(testLayer.getFeature(1).geometry.asWkt(2), "Polygon ((5 0, 5 10, 10 10, 10 0, 5 0))");
     compare(testLayer.getFeature(2).geometry.asWkt(2), "Polygon ((5 10, 5 0, 0 0, 0 10, 5 10))");
+
+    // the split commits a new feature, so the layer reports one features-added commit
+    compare(committedFeaturesAddedSpy.count, 1);
   }
 
   function test_confirmWithInvalidLineToasts() {
     initSplit();
+    committedFeaturesAddedSpy.clear();
     const before = testLayer.getFeature(1).geometry.asWkt();
     const tb = toolbar();
 
@@ -126,6 +137,9 @@ TestCase {
     compare(lastToastType, "error");
     const after = testLayer.getFeature(1).geometry.asWkt();
     compare(after, before);
+
+    // nothing was committed, so the layer reports no features-added commit
+    compare(committedFeaturesAddedSpy.count, 0);
   }
 
   function test_confirmEmitsFinished() {


### PR DESCRIPTION
This adds a QML test for the split tool covering the tool wiring around the split maths (which is already tested in test_geometryutils.cpp): init sets up the feature model and puts the rubberband in line mode, blocking mirrors the rubberband digitizing state, the confirm handler failure path toasts an error and leaves the feature unchanged, confirm emits finished so the editor closes, and cancel resets the rubberband.
The successful split is left to the C++ tests. Driving a valid split through confirm() here would mean reproducing the live digitizing rubberband state, which is awkward headless and adds little over the C++ coverage that already tests splitFeatureFromRubberband directly.
All tests pass locally.