### PR TITLE
Add support for updating project from ZIP archive on iOS

### DIFF
--- a/src/core/platforms/ios/iosplatformutilities.h
+++ b/src/core/platforms/ios/iosplatformutilities.h
@@ -41,6 +41,7 @@ class IosPlatformUtilities : public PlatformUtilities
     void importDatasets() const override;
     void sendDatasetTo( const QString &path ) const override;
     void sendCompressedFolderTo( const QString &path ) const override;
+    void updateProjectFromArchive( const QString &projectPath ) const override;
 
     void setScreenLockPermission( const bool allowLock ) override;
     virtual ResourceSource *getCameraPicture( const QString &prefix,

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -287,13 +287,27 @@ static void copyDirectoryContents(NSURL *sourceURL, NSString *destinationPath) {
 
 - (void)documentPicker:(UIDocumentPickerViewController *)controller
     didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
+  NSLog(@"[QField] documentPicker:didPickDocumentsAtURLs: called, "
+        @"urls.count=%lu, mode=%@",
+        (unsigned long)urls.count, _mode);
+
   if (urls.count == 0) {
+    NSLog(@"[QField] No URLs received, returning early");
     return;
   }
 
   NSURL *url = urls.firstObject;
-  [url startAccessingSecurityScopedResource];
+  NSLog(@"[QField] Selected URL: %@", url);
+  NSLog(@"[QField] URL path: %@", url.path);
+  NSLog(@"[QField] URL isFileURL: %d", url.isFileURL);
+
+  BOOL accessGranted = [url startAccessingSecurityScopedResource];
+  NSLog(@"[QField] startAccessingSecurityScopedResource result: %d",
+        accessGranted);
+
   NSFileManager *fileManager = [NSFileManager defaultManager];
+  NSLog(@"[QField] File exists at URL path: %d",
+        [fileManager fileExistsAtPath:url.path]);
 
   if ([_mode isEqualToString:@"projectFolder"]) {
     NSString *folderName = url.lastPathComponent;
@@ -348,23 +362,49 @@ static void copyDirectoryContents(NSURL *sourceURL, NSString *destinationPath) {
       emit AppInterface::instance()->openPath(importedPath);
     }
   } else if ([_mode isEqualToString:@"updateFromArchive"]) {
-    [url stopAccessingSecurityScopedResource];
-    [url startAccessingSecurityScopedResource];
+    NSLog(@"[QField] updateFromArchive branch entered");
+    NSLog(@"[QField] importPath (destDir): %@", _importPath);
+
+    BOOL destExists = [fileManager fileExistsAtPath:_importPath];
+    BOOL destIsDir = NO;
+    [fileManager fileExistsAtPath:_importPath isDirectory:&destIsDir];
+    NSLog(@"[QField] destDir exists: %d, isDirectory: %d", destExists,
+          destIsDir);
+
+    NSDictionary *zipAttrs = [fileManager attributesOfItemAtPath:url.path
+                                                           error:nil];
+    NSLog(@"[QField] ZIP file size: %@", zipAttrs[NSFileSize]);
 
     QString zipPath = QString::fromNSString(url.path);
     QString destDir = QString::fromNSString(_importPath);
     QStringList extractedFiles;
-    FileUtils::unzip(zipPath, destDir, extractedFiles, false);
+
+    NSLog(@"[QField] Calling FileUtils::unzip...");
+    bool unzipResult =
+        FileUtils::unzip(zipPath, destDir, extractedFiles, false);
+    NSLog(@"[QField] FileUtils::unzip result: %d, extracted files count: %d",
+          unzipResult, extractedFiles.count());
+
+    for (const QString &f : extractedFiles) {
+      NSLog(@"[QField] Extracted: %s", f.toUtf8().constData());
+    }
+
     [url stopAccessingSecurityScopedResource];
+    NSLog(@"[QField] stopAccessingSecurityScopedResource called");
 
     if (AppInterface::instance()) {
-      emit AppInterface::instance()->openPath(destDir);
+      NSLog(@"[QField] AppInterface instance found, calling reloadProject()");
+      AppInterface::instance()->reloadProject();
+      NSLog(@"[QField] reloadProject() called");
+    } else {
+      NSLog(@"[QField] ERROR: AppInterface::instance() is null!");
     }
   }
 }
 
 - (void)documentPickerWasCancelled:
     (UIDocumentPickerViewController *)controller {
+  NSLog(@"[QField] documentPickerWasCancelled called (mode=%@)", _mode);
 }
 
 @end
@@ -510,11 +550,18 @@ void IosPlatformUtilities::sendCompressedFolderTo(const QString &path) const {
 
 void IosPlatformUtilities::updateProjectFromArchive(
     const QString &projectPath) const {
+  NSLog(@"[QField] updateProjectFromArchive called with projectPath: %s",
+        projectPath.toUtf8().constData());
+
   QString importPath = QFileInfo(projectPath).absolutePath();
+  NSLog(@"[QField] computed importPath (destDir): %s",
+        importPath.toUtf8().constData());
+
   NSString *importBasePath = importPath.toNSString();
 
   UIViewController *root = [[[[UIApplication sharedApplication] windows]
       firstObject] rootViewController];
+  NSLog(@"[QField] rootViewController: %@", root);
 
   UIDocumentPickerViewController *picker =
       [[UIDocumentPickerViewController alloc] initForOpeningContentTypes:@[
@@ -529,5 +576,6 @@ void IosPlatformUtilities::updateProjectFromArchive(
   objc_setAssociatedObject(picker, &kIosImportDelegateKey, delegate,
                            OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
+  NSLog(@"[QField] presenting UIDocumentPickerViewController...");
   [root presentViewController:picker animated:YES completion:nil];
 }

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -287,27 +287,13 @@ static void copyDirectoryContents(NSURL *sourceURL, NSString *destinationPath) {
 
 - (void)documentPicker:(UIDocumentPickerViewController *)controller
     didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
-  NSLog(@"[QField] documentPicker:didPickDocumentsAtURLs: called, "
-        @"urls.count=%lu, mode=%@",
-        (unsigned long)urls.count, _mode);
-
   if (urls.count == 0) {
-    NSLog(@"[QField] No URLs received, returning early");
     return;
   }
 
   NSURL *url = urls.firstObject;
-  NSLog(@"[QField] Selected URL: %@", url);
-  NSLog(@"[QField] URL path: %@", url.path);
-  NSLog(@"[QField] URL isFileURL: %d", url.isFileURL);
-
-  BOOL accessGranted = [url startAccessingSecurityScopedResource];
-  NSLog(@"[QField] startAccessingSecurityScopedResource result: %d",
-        accessGranted);
-
+  [url startAccessingSecurityScopedResource];
   NSFileManager *fileManager = [NSFileManager defaultManager];
-  NSLog(@"[QField] File exists at URL path: %d",
-        [fileManager fileExistsAtPath:url.path]);
 
   if ([_mode isEqualToString:@"projectFolder"]) {
     NSString *folderName = url.lastPathComponent;
@@ -362,49 +348,20 @@ static void copyDirectoryContents(NSURL *sourceURL, NSString *destinationPath) {
       emit AppInterface::instance()->openPath(importedPath);
     }
   } else if ([_mode isEqualToString:@"updateFromArchive"]) {
-    NSLog(@"[QField] updateFromArchive branch entered");
-    NSLog(@"[QField] importPath (destDir): %@", _importPath);
-
-    BOOL destExists = [fileManager fileExistsAtPath:_importPath];
-    BOOL destIsDir = NO;
-    [fileManager fileExistsAtPath:_importPath isDirectory:&destIsDir];
-    NSLog(@"[QField] destDir exists: %d, isDirectory: %d", destExists,
-          destIsDir);
-
-    NSDictionary *zipAttrs = [fileManager attributesOfItemAtPath:url.path
-                                                           error:nil];
-    NSLog(@"[QField] ZIP file size: %@", zipAttrs[NSFileSize]);
-
     QString zipPath = QString::fromNSString(url.path);
     QString destDir = QString::fromNSString(_importPath);
     QStringList extractedFiles;
-
-    NSLog(@"[QField] Calling FileUtils::unzip...");
-    bool unzipResult =
-        FileUtils::unzip(zipPath, destDir, extractedFiles, false);
-    NSLog(@"[QField] FileUtils::unzip result: %d, extracted files count: %d",
-          unzipResult, extractedFiles.count());
-
-    for (const QString &f : extractedFiles) {
-      NSLog(@"[QField] Extracted: %s", f.toUtf8().constData());
-    }
-
+    FileUtils::unzip(zipPath, destDir, extractedFiles, false);
     [url stopAccessingSecurityScopedResource];
-    NSLog(@"[QField] stopAccessingSecurityScopedResource called");
 
     if (AppInterface::instance()) {
-      NSLog(@"[QField] AppInterface instance found, calling reloadProject()");
       AppInterface::instance()->reloadProject();
-      NSLog(@"[QField] reloadProject() called");
-    } else {
-      NSLog(@"[QField] ERROR: AppInterface::instance() is null!");
     }
   }
 }
 
 - (void)documentPickerWasCancelled:
     (UIDocumentPickerViewController *)controller {
-  NSLog(@"[QField] documentPickerWasCancelled called (mode=%@)", _mode);
 }
 
 @end
@@ -550,18 +507,11 @@ void IosPlatformUtilities::sendCompressedFolderTo(const QString &path) const {
 
 void IosPlatformUtilities::updateProjectFromArchive(
     const QString &projectPath) const {
-  NSLog(@"[QField] updateProjectFromArchive called with projectPath: %s",
-        projectPath.toUtf8().constData());
-
   QString importPath = QFileInfo(projectPath).absolutePath();
-  NSLog(@"[QField] computed importPath (destDir): %s",
-        importPath.toUtf8().constData());
-
   NSString *importBasePath = importPath.toNSString();
 
   UIViewController *root = [[[[UIApplication sharedApplication] windows]
       firstObject] rootViewController];
-  NSLog(@"[QField] rootViewController: %@", root);
 
   UIDocumentPickerViewController *picker =
       [[UIDocumentPickerViewController alloc] initForOpeningContentTypes:@[
@@ -576,6 +526,5 @@ void IosPlatformUtilities::updateProjectFromArchive(
   objc_setAssociatedObject(picker, &kIosImportDelegateKey, delegate,
                            OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-  NSLog(@"[QField] presenting UIDocumentPickerViewController...");
   [root presentViewController:picker animated:YES completion:nil];
 }

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -30,6 +30,7 @@
 #include <UIKit/UIKit.h>
 #include <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
+#include <QFileInfo>
 #include <QGuiApplication>
 #include <QStandardPaths>
 #include <objc/runtime.h>
@@ -72,9 +73,9 @@ IosPlatformUtilities::IosPlatformUtilities() : PlatformUtilities() {
 }
 
 PlatformUtilities::Capabilities IosPlatformUtilities::capabilities() const {
-  PlatformUtilities::Capabilities capabilities = Capabilities() | NativeCamera |
-                                                 AdjustBrightness | FilePicker |
-                                                 CustomImport | CustomSend;
+  PlatformUtilities::Capabilities capabilities =
+      Capabilities() | NativeCamera | AdjustBrightness | FilePicker |
+      CustomImport | CustomSend | UpdateProjectFromArchive;
 #if WITH_SENTRY
   capabilities |= SentryFramework;
 #endif
@@ -346,6 +347,19 @@ static void copyDirectoryContents(NSURL *sourceURL, NSString *destinationPath) {
     if (AppInterface::instance()) {
       emit AppInterface::instance()->openPath(importedPath);
     }
+  } else if ([_mode isEqualToString:@"updateFromArchive"]) {
+    [url stopAccessingSecurityScopedResource];
+    [url startAccessingSecurityScopedResource];
+
+    QString zipPath = QString::fromNSString(url.path);
+    QString destDir = QString::fromNSString(_importPath);
+    QStringList extractedFiles;
+    FileUtils::unzip(zipPath, destDir, extractedFiles, false);
+    [url stopAccessingSecurityScopedResource];
+
+    if (AppInterface::instance()) {
+      emit AppInterface::instance()->openPath(destDir);
+    }
   }
 }
 
@@ -492,4 +506,28 @@ void IosPlatformUtilities::sendCompressedFolderTo(const QString &path) const {
                  root.view.bounds.size.height / 2.0, 1.0, 1.0);
 
   [root presentViewController:activityVC animated:YES completion:nil];
+}
+
+void IosPlatformUtilities::updateProjectFromArchive(
+    const QString &projectPath) const {
+  QString importPath = QFileInfo(projectPath).absolutePath();
+  NSString *importBasePath = importPath.toNSString();
+
+  UIViewController *root = [[[[UIApplication sharedApplication] windows]
+      firstObject] rootViewController];
+
+  UIDocumentPickerViewController *picker =
+      [[UIDocumentPickerViewController alloc] initForOpeningContentTypes:@[
+        [UTType typeWithIdentifier:@"public.zip-archive"]
+      ]];
+  picker.allowsMultipleSelection = NO;
+
+  IosImportDelegate *delegate = [[IosImportDelegate alloc] init];
+  delegate.importPath = importBasePath;
+  delegate.mode = @"updateFromArchive";
+  picker.delegate = delegate;
+  objc_setAssociatedObject(picker, &kIosImportDelegateKey, delegate,
+                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+  [root presentViewController:picker animated:YES completion:nil];
 }


### PR DESCRIPTION
### 🚀 Description
Enable selecting a ZIP via document picker, extract it into the project directory, and open the updated project so users can update projects from archived exports.

### Demo
(Import project from ZIP -> `Update` Project from ZIP)

https://github.com/user-attachments/assets/297305ee-ed64-495b-b160-ef18339d7b70

