### PR TITLE
Add "Update Project from ZIP" support for desktop platforms

### DIFF
--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -58,7 +58,7 @@ PlatformUtilities::~PlatformUtilities()
 
 PlatformUtilities::Capabilities PlatformUtilities::capabilities() const
 {
-  PlatformUtilities::Capabilities capabilities = PlatformUtilities::Capabilities() | FilePicker | NativeLocalDataPicker;
+  PlatformUtilities::Capabilities capabilities = PlatformUtilities::Capabilities() | FilePicker | NativeLocalDataPicker | UpdateProjectFromArchive;
 #if WITH_SENTRY
   capabilities |= SentryFramework;
 #endif
@@ -281,7 +281,21 @@ void PlatformUtilities::importDatasets() const
 
 void PlatformUtilities::updateProjectFromArchive( const QString &projectPath ) const
 {
-  Q_UNUSED( projectPath )
+  const QString zipFilePath = QFileDialog::getOpenFileName( nullptr,
+                                                            tr( "Select ZIP Archive" ),
+                                                            QFileInfo( projectPath ).absolutePath(),
+                                                            tr( "ZIP Archives (*.zip)" ) );
+  if ( zipFilePath.isEmpty() )
+  {
+    return;
+  }
+
+  QStringList extractedFiles;
+  const QString projectFolder = QFileInfo( projectPath ).absolutePath();
+  if ( FileUtils::unzip( zipFilePath, projectFolder, extractedFiles, false ) )
+  {
+    AppInterface::instance()->loadFile( projectPath );
+  }
 }
 
 void PlatformUtilities::exportFolderTo( const QString &path ) const


### PR DESCRIPTION
### 🚀 Description

Previously, the ability to update a local project from a ZIP archive was only available on Android. The feature existed in the UI but was gated behind a capability flag that was never set for desktop platforms, making the action invisible on Linux, macOS, and Windows.

<img width="750" height="572" alt="image" src="https://github.com/user-attachments/assets/51c8013a-9c41-46bc-8f53-de1e5bbf0b91" />

### ✨ Key Changes

- Enable UpdateProjectFromArchive capability for desktop (base PlatformUtilities)
Platforms affected: Linux, macOS, Windows



### ✨ Now:

https://github.com/user-attachments/assets/562cb235-7d39-4616-9e6b-42dc3dc676ba


---

iOS support (**https://github.com/opengisch/QField/pull/7591**)