### PR TITLE
Add "Compress project and send to" action to project folder menu

### DIFF
--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -438,10 +438,9 @@ Page {
         id: actionButton
         round: true
 
-        // Since the project menu only has one action for now, hide if PlatformUtilities.UpdateProjectFromArchive is missing
         property bool isLocalProject: qgisProject && QFieldCloudUtils.getProjectId(qgisProject.fileName) === '' && (projectInfo.filePath.endsWith('.qgs') || projectInfo.filePath.endsWith('.qgz'))
-        property bool isLocalProjectActionAvailable: updateProjectFromArchive.enabled || uploadProjectToWebdav.enabled
-        visible: (projectFolderView && isLocalProject && table.model.currentDepth === 1) || table.model.currentPath === 'root'
+        property bool isLocalProjectActionAvailable: updateProjectFromArchive.enabled || uploadProjectToWebdav.enabled || (platformUtilities.capabilities & PlatformUtilities.CustomSend)
+        visible: (projectFolderView && isLocalProject && isLocalProjectActionAvailable && table.model.currentDepth === 1) || table.model.currentPath === 'root'
 
         anchors.bottom: parent.bottom
         anchors.right: parent.right
@@ -449,7 +448,7 @@ Page {
         anchors.rightMargin: 10
 
         bgcolor: Theme.mainColor
-        iconSource: Theme.getThemeVectorIcon("ic_add_white_24dp")
+        iconSource: Theme.getThemeVectorIcon("ic_ellipsis_black_24dp")
         iconColor: Theme.toolButtonColor
 
         onClicked: {
@@ -837,6 +836,22 @@ Page {
         text: qsTr("Update project from ZIP")
         onTriggered: {
           platformUtilities.updateProjectFromArchive(projectInfo.filePath);
+        }
+      }
+
+      MenuItem {
+        id: compressProjectAndSendTo
+
+        enabled: platformUtilities.capabilities & PlatformUtilities.CustomSend
+        visible: enabled
+        font: Theme.defaultFont
+        width: parent.width
+        height: enabled ? 48 : 0
+        leftPadding: Theme.menuItemLeftPadding
+
+        text: qsTr("Compress project and send to...")
+        onTriggered: {
+          platformUtilities.sendCompressedFolderTo(FileUtils.absolutePath(projectInfo.filePath));
         }
       }
 

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -439,7 +439,7 @@ Page {
         round: true
 
         property bool isLocalProject: qgisProject && QFieldCloudUtils.getProjectId(qgisProject.fileName) === '' && (projectInfo.filePath.endsWith('.qgs') || projectInfo.filePath.endsWith('.qgz'))
-        property bool isLocalProjectActionAvailable: updateProjectFromArchive.enabled || uploadProjectToWebdav.enabled || (platformUtilities.capabilities & PlatformUtilities.CustomSend)
+        property bool isLocalProjectActionAvailable: updateProjectFromArchive.enabled || uploadProjectToWebdav.enabled || compressProjectAndSendTo.enabled
         visible: (projectFolderView && isLocalProject && isLocalProjectActionAvailable && table.model.currentDepth === 1) || table.model.currentPath === 'root'
 
         anchors.bottom: parent.bottom

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -839,6 +839,12 @@ Page {
         }
       }
 
+      MenuSeparator {
+        visible: updateProjectFromArchive.visible && compressProjectAndSendTo.visible
+        width: parent.width
+        height: visible ? undefined : 0
+      }
+
       MenuItem {
         id: compressProjectAndSendTo
 


### PR DESCRIPTION
### 🚀 Description

Sharing a project from a mobile device required navigating into the file browser, finding the project folder, long-pressing it, and selecting "Send compressed folder to..." — a complex workflow.

This PR exposes the existing compression and sharing functionality directly from the project folder view, which is the natural place users look when they want to package and share their work.

### ✨ Key Changes

- Replaced the `+` button in the project folder view with a `...` (more actions) button 
- Added "Compress project and send to..." to the project action menu, calling the existing `platformUtilities.sendCompressedFolderTo()` on the project's parent folder

### Demo

<img width="200" height="470" alt="image" src="https://github.com/user-attachments/assets/6193ecd9-5ab3-4167-bb23-da3e8865641c" />
<img width="200" height="470" alt="image" src="https://github.com/user-attachments/assets/3ecdccf9-e86a-49e8-983b-6ed0e5108a08" />
