### PR TITLE
Add "Export to folder" support on iOS

### DIFF
--- a/src/core/platforms/ios/iosplatformutilities.h
+++ b/src/core/platforms/ios/iosplatformutilities.h
@@ -39,6 +39,8 @@ class IosPlatformUtilities : public PlatformUtilities
     void importProjectFolder() const override;
     void importProjectArchive() const override;
     void importDatasets() const override;
+    void exportDatasetTo( const QString &path ) const override;
+    void exportFolderTo( const QString &path ) const override;
     void sendDatasetTo( const QString &path ) const override;
     void sendCompressedFolderTo( const QString &path ) const override;
     void updateProjectFromArchive( const QString &projectPath ) const override;

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -253,6 +253,7 @@ void IosPlatformUtilities::requestMicrophonePermission(
 }
 
 static char kIosImportDelegateKey;
+static char kIosExportDelegateKey;
 
 static void copyDirectoryContents(NSURL *sourceURL, NSString *destinationPath) {
   NSFileManager *fileManager = [NSFileManager defaultManager];
@@ -366,33 +367,78 @@ static void copyDirectoryContents(NSURL *sourceURL, NSString *destinationPath) {
 
 @end
 
-void IosPlatformUtilities::exportFolderTo(const QString &path) const {
-  NSURL *folderURL = [NSURL fileURLWithPath:path.toNSString() isDirectory:YES];
+@interface IosExportDelegate : NSObject <UIDocumentPickerDelegate>
+@property(nonatomic, strong) NSArray<NSString *> *sourcePaths;
+@end
 
+@implementation IosExportDelegate
+
+- (void)documentPicker:(UIDocumentPickerViewController *)controller
+    didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
+  if (urls.count == 0) {
+    return;
+  }
+
+  NSURL *destURL = urls.firstObject;
+  [destURL startAccessingSecurityScopedResource];
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+
+  for (NSString *srcPath in _sourcePaths) {
+    NSString *destPath =
+        [destURL.path stringByAppendingPathComponent:srcPath.lastPathComponent];
+    [fileManager removeItemAtPath:destPath error:nil];
+    [fileManager copyItemAtPath:srcPath toPath:destPath error:nil];
+  }
+
+  [destURL stopAccessingSecurityScopedResource];
+}
+
+- (void)documentPickerWasCancelled:
+    (UIDocumentPickerViewController *)controller {
+}
+
+@end
+
+void IosPlatformUtilities::exportFolderTo(const QString &path) const {
   UIViewController *root = [[[[UIApplication sharedApplication] windows]
       firstObject] rootViewController];
 
   UIDocumentPickerViewController *picker =
       [[UIDocumentPickerViewController alloc]
-          initForExportingURLs:@[ folderURL ]];
+          initForOpeningContentTypes:@[ UTTypeFolder ]];
+  picker.allowsMultipleSelection = NO;
+
+  IosExportDelegate *delegate = [[IosExportDelegate alloc] init];
+  delegate.sourcePaths = @[ path.toNSString() ];
+  picker.delegate = delegate;
+  objc_setAssociatedObject(picker, &kIosExportDelegateKey, delegate,
+                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
   [root presentViewController:picker animated:YES completion:nil];
 }
 
 void IosPlatformUtilities::exportDatasetTo(const QString &path) const {
-  NSMutableArray<NSURL *> *urls = [NSMutableArray array];
-  [urls addObject:[NSURL fileURLWithPath:path.toNSString()]];
+  NSMutableArray<NSString *> *sourcePaths = [NSMutableArray array];
+  [sourcePaths addObject:path.toNSString()];
 
   const QSet<QString> sidecarFiles = QgsFileUtils::sidecarFilesForPath(path);
   for (const QString &file : sidecarFiles) {
-    [urls addObject:[NSURL fileURLWithPath:file.toNSString()]];
+    [sourcePaths addObject:file.toNSString()];
   }
 
   UIViewController *root = [[[[UIApplication sharedApplication] windows]
       firstObject] rootViewController];
 
   UIDocumentPickerViewController *picker =
-      [[UIDocumentPickerViewController alloc] initForExportingURLs:urls];
+      [[UIDocumentPickerViewController alloc]
+          initForOpeningContentTypes:@[ UTTypeFolder ]];
+  picker.allowsMultipleSelection = NO;
+
+  IosExportDelegate *delegate = [[IosExportDelegate alloc] init];
+  delegate.sourcePaths = sourcePaths;
+  picker.delegate = delegate;
+  objc_setAssociatedObject(picker, &kIosExportDelegateKey, delegate,
+                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
   [root presentViewController:picker animated:YES completion:nil];
 }

--- a/src/core/platforms/ios/iosplatformutilities.mm
+++ b/src/core/platforms/ios/iosplatformutilities.mm
@@ -75,7 +75,7 @@ IosPlatformUtilities::IosPlatformUtilities() : PlatformUtilities() {
 PlatformUtilities::Capabilities IosPlatformUtilities::capabilities() const {
   PlatformUtilities::Capabilities capabilities =
       Capabilities() | NativeCamera | AdjustBrightness | FilePicker |
-      CustomImport | CustomSend | UpdateProjectFromArchive;
+      CustomImport | CustomSend | CustomExport | UpdateProjectFromArchive;
 #if WITH_SENTRY
   capabilities |= SentryFramework;
 #endif
@@ -365,6 +365,37 @@ static void copyDirectoryContents(NSURL *sourceURL, NSString *destinationPath) {
 }
 
 @end
+
+void IosPlatformUtilities::exportFolderTo(const QString &path) const {
+  NSURL *folderURL = [NSURL fileURLWithPath:path.toNSString() isDirectory:YES];
+
+  UIViewController *root = [[[[UIApplication sharedApplication] windows]
+      firstObject] rootViewController];
+
+  UIDocumentPickerViewController *picker =
+      [[UIDocumentPickerViewController alloc]
+          initForExportingURLs:@[ folderURL ]];
+
+  [root presentViewController:picker animated:YES completion:nil];
+}
+
+void IosPlatformUtilities::exportDatasetTo(const QString &path) const {
+  NSMutableArray<NSURL *> *urls = [NSMutableArray array];
+  [urls addObject:[NSURL fileURLWithPath:path.toNSString()]];
+
+  const QSet<QString> sidecarFiles = QgsFileUtils::sidecarFilesForPath(path);
+  for (const QString &file : sidecarFiles) {
+    [urls addObject:[NSURL fileURLWithPath:file.toNSString()]];
+  }
+
+  UIViewController *root = [[[[UIApplication sharedApplication] windows]
+      firstObject] rootViewController];
+
+  UIDocumentPickerViewController *picker =
+      [[UIDocumentPickerViewController alloc] initForExportingURLs:urls];
+
+  [root presentViewController:picker animated:YES completion:nil];
+}
 
 void IosPlatformUtilities::importProjectFolder() const {
   QString appDir = applicationDirectory();


### PR DESCRIPTION
### 🚀 Description
- Add `CustomExport` capability to `IosPlatformUtilities`
- Implement `exportDatasetTo()` and `exportFolderTo()`
- The "Export to folder..." menu option in the local data picker is now visible and functional on iOS

### Demo


https://github.com/user-attachments/assets/0c92a3d6-cdab-40d0-8d42-db370192b7b6


