### PR TITLE
 Add a new section in the settings dialog to show imported authentication configurations details and allow for a clearing of all authentication configuration caches

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -11,6 +11,7 @@ set(QFIELD_CORE_SRCS
     3d/quick3dgeometry.cpp
     3d/quick3dgeometryutils.cpp
     3d/maptoview3d.cpp
+    utils/authutils.cpp
     utils/coordinatereferencesystemutils.cpp
     utils/expressioncontextutils.cpp
     utils/featureutils.cpp
@@ -163,6 +164,7 @@ set(QFIELD_CORE_HDRS
     3d/quick3dgeometryutils.h
     3d/quick3dgeometry.h
     3d/maptoview3d.h
+    utils/authutils.h
     utils/coordinatereferencesystemutils.h
     utils/expressioncontextutils.h
     utils/featureutils.h

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -39,7 +39,6 @@
 #include <QTemporaryFile>
 #include <QTranslator>
 #include <qgsapplication.h>
-#include <qgsauthmanager.h>
 #include <qgsmessagelog.h>
 #include <qgsnetworkaccessmanager.h>
 #include <qgsproject.h>
@@ -376,13 +375,6 @@ bool AppInterface::isFileExtensionSupported( const QString &filename ) const
   const QFileInfo fi( filename );
   const QString suffix = fi.suffix().toLower();
   return SUPPORTED_PROJECT_EXTENSIONS.contains( suffix ) || SUPPORTED_VECTOR_EXTENSIONS.contains( suffix ) || SUPPORTED_RASTER_EXTENSIONS.contains( suffix );
-}
-
-bool AppInterface::isAuthenticationConfigurationAvailable( const QString &id ) const
-{
-  QgsAuthManager *authManager = QgsApplication::authManager();
-  QgsAuthMethodConfigsMap configs = authManager->availableAuthMethodConfigs();
-  return configs.contains( id );
 }
 
 void AppInterface::logMessage( const QString &message )

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -135,11 +135,6 @@ class AppInterface : public QObject
     Q_INVOKABLE bool isFileExtensionSupported( const QString &filename ) const;
 
     /**
-     * Returns TRUE if the authentication configuration \a id is available.
-     */
-    Q_INVOKABLE bool isAuthenticationConfigurationAvailable( const QString &id ) const;
-
-    /**
      * Adds a log \a message that will be visible to the user through the
      * message log panel, as well as added into the device's system logs
      * which will be captured by the sentry's reporting framework when enabled.

--- a/src/core/qgismobileapp.cpp
+++ b/src/core/qgismobileapp.cpp
@@ -42,6 +42,7 @@
 #include "attributeformmodel.h"
 #include "audioanalyzer.h"
 #include "audiorecorder.h"
+#include "authutils.h"
 #include "badlayerhandler.h"
 #include "barcodedecoder.h"
 #include "barcodeimageprovider.h"
@@ -614,6 +615,7 @@ void QgisMobileapp::initDeclarative( QQmlEngine *engine )
     return t;
   } );
 
+  REGISTER_SINGLETON( "org.qfield", AuthUtils, "AuthUtils" );
   REGISTER_SINGLETON( "org.qfield", ExpressionContextUtils, "ExpressionContextUtils" );
   REGISTER_SINGLETON( "org.qfield", GeometryEditorsModel, "GeometryEditorsModelSingleton" );
   REGISTER_SINGLETON( "org.qfield", GeometryUtils, "GeometryUtils" );

--- a/src/core/utils/authutils.cpp
+++ b/src/core/utils/authutils.cpp
@@ -1,0 +1,32 @@
+/***************************************************************************
+  authutils.cpp - AuthUtils
+
+ ---------------------
+ begin                : 19.06.2026
+ copyright            : (C) 2026 by Mathieu Pellerin
+ email                : mathieu@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "authutils.h"
+
+#include <qgsapplication.h>
+#include <qgsauthmanager.h>
+
+AuthUtils::AuthUtils( QObject *parent )
+  : QObject( parent )
+{
+}
+
+bool AuthUtils::isAuthenticationConfigurationAvailable( const QString &id )
+{
+  QgsAuthManager *authManager = QgsApplication::authManager();
+  QgsAuthMethodConfigsMap configs = authManager->availableAuthMethodConfigs();
+  return configs.contains( id );
+}

--- a/src/core/utils/authutils.cpp
+++ b/src/core/utils/authutils.cpp
@@ -24,9 +24,53 @@ AuthUtils::AuthUtils( QObject *parent )
 {
 }
 
+bool AuthUtils::hasAuthenticationConfigurations()
+{
+  QgsAuthManager *authManager = QgsApplication::authManager();
+  const QgsAuthMethodConfigsMap configs = authManager->availableAuthMethodConfigs();
+  return !configs.isEmpty();
+}
+
+QVariantList AuthUtils::authenticationConfigurationDetails( const QString &id )
+{
+  QVariantList details;
+  QgsAuthManager *authManager = QgsApplication::authManager();
+  const QgsAuthMethodConfigsMap configs = authManager->availableAuthMethodConfigs();
+  for ( const QgsAuthMethodConfig &config : configs )
+  {
+    if ( config.name() == QStringLiteral( "qfieldcloud-credentials" ) )
+    {
+      continue;
+    }
+
+    if ( id.isEmpty() || config.id() == id )
+    {
+      QVariantMap configDetails;
+      configDetails.insert( QStringLiteral( "id" ), config.id() );
+      configDetails.insert( QStringLiteral( "name" ), config.name() );
+      configDetails.insert( QStringLiteral( "uri" ), config.uri() );
+      details << configDetails;
+    }
+  }
+  return details;
+}
+
 bool AuthUtils::isAuthenticationConfigurationAvailable( const QString &id )
 {
   QgsAuthManager *authManager = QgsApplication::authManager();
-  QgsAuthMethodConfigsMap configs = authManager->availableAuthMethodConfigs();
+  const QgsAuthMethodConfigsMap configs = authManager->availableAuthMethodConfigs();
   return configs.contains( id );
+}
+
+void AuthUtils::clearAuthenticationConfigurationCache( const QString &id )
+{
+  QgsAuthManager *authManager = QgsApplication::authManager();
+  if ( !id.isEmpty() )
+  {
+    authManager->clearCachedConfig( id );
+  }
+  else
+  {
+    authManager->clearAllCachedConfigs();
+  }
 }

--- a/src/core/utils/authutils.h
+++ b/src/core/utils/authutils.h
@@ -1,0 +1,38 @@
+/***************************************************************************
+  authutils.h - AuthUtils
+
+ ---------------------
+ begin                : 19.06.2026
+ copyright            : (C) 2026 by Mathieu Pellerin
+ email                : mathieu@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef AUTHUTILS_H
+#define AUTHUTILS_H
+
+#include <QObject>
+
+/**
+ * \ingroup core
+ */
+class AuthUtils : public QObject
+{
+    Q_OBJECT
+
+  public:
+    explicit AuthUtils( QObject *parent = nullptr );
+
+    /**
+     * Returns TRUE if the authentication configuration \a id is available.
+     */
+    Q_INVOKABLE static bool isAuthenticationConfigurationAvailable( const QString &id );
+};
+
+#endif // AUTHUTILS_H

--- a/src/core/utils/authutils.h
+++ b/src/core/utils/authutils.h
@@ -35,7 +35,7 @@ class AuthUtils : public QObject
     Q_INVOKABLE static bool hasAuthenticationConfigurations();
 
     /**
-     * Returns authentication configuration \id details. If no id is provided,
+     * Returns authentication configuration \a id details. If no id is provided,
      * details for all authentication configuration will be returned.
      */
     Q_INVOKABLE static QVariantList authenticationConfigurationDetails( const QString &id = QString() );
@@ -46,7 +46,7 @@ class AuthUtils : public QObject
     Q_INVOKABLE static bool isAuthenticationConfigurationAvailable( const QString &id );
 
     /**
-     * Clears any cache associated to the authentication configuration \id. If no id is
+     * Clears any cache associated to the authentication configuration \a id. If no id is
      * provided, cache for all authentication configurations will be cleared.
      */
     Q_INVOKABLE static void clearAuthenticationConfigurationCache( const QString &id = QString() );

--- a/src/core/utils/authutils.h
+++ b/src/core/utils/authutils.h
@@ -30,9 +30,26 @@ class AuthUtils : public QObject
     explicit AuthUtils( QObject *parent = nullptr );
 
     /**
+     * Returns TRUE if the authentication manager has one or more stored configurations.
+     */
+    Q_INVOKABLE static bool hasAuthenticationConfigurations();
+
+    /**
+     * Returns authentication configuration \id details. If no id is provided,
+     * details for all authentication configuration will be returned.
+     */
+    Q_INVOKABLE static QVariantList authenticationConfigurationDetails( const QString &id = QString() );
+
+    /**
      * Returns TRUE if the authentication configuration \a id is available.
      */
     Q_INVOKABLE static bool isAuthenticationConfigurationAvailable( const QString &id );
+
+    /**
+     * Clears any cache associated to the authentication configuration \id. If no id is
+     * provided, cache for all authentication configurations will be cleared.
+     */
+    Q_INVOKABLE static void clearAuthenticationConfigurationCache( const QString &id = QString() );
 };
 
 #endif // AUTHUTILS_H

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -855,18 +855,20 @@ Page {
               }
 
               Label {
+                Layout.fillWidth: true
+                Layout.columnSpan: 2
+                visible: authenticationConfigurationsListView.count > 0
                 text: qsTr("Available authentication configurations:")
                 font: Theme.defaultFont
                 color: Theme.mainTextColor
                 wrapMode: Text.WordWrap
-                Layout.fillWidth: true
-                Layout.columnSpan: 2
               }
 
               Rectangle {
                 Layout.fillWidth: true
                 Layout.columnSpan: 2
                 Layout.preferredHeight: 140
+                visible: authenticationConfigurationsListView.count > 0
                 color: Theme.controlBackgroundColor
                 border.width: 1
                 border.color: Theme.controlBorderColor
@@ -921,6 +923,7 @@ Page {
               QfButton {
                 Layout.fillWidth: true
                 Layout.columnSpan: 2
+                visible: authenticationConfigurationsListView.count > 0
 
                 text: qsTr("Clear authentication cache")
 

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -106,6 +106,8 @@ Page {
     const typeIdx = proxyTypeComboBox.indexOfValue(proxyType);
     proxyTypeComboBox.currentIndex = typeIdx >= 0 ? typeIdx : 0;
     proxySettingsLoaded = true;
+
+    authenticationConfigurationsListView.model = AuthUtils.authenticationConfigurationDetails();
   }
 
   function reset() {
@@ -850,6 +852,82 @@ Page {
                 Layout.fillWidth: true
                 Layout.topMargin: 10
                 Layout.columnSpan: 2
+              }
+
+              Label {
+                text: qsTr("Available authentication configurations:")
+                font: Theme.defaultFont
+                color: Theme.mainTextColor
+                wrapMode: Text.WordWrap
+                Layout.fillWidth: true
+                Layout.columnSpan: 2
+              }
+
+              Rectangle {
+                Layout.fillWidth: true
+                Layout.columnSpan: 2
+                Layout.preferredHeight: 140
+                color: Theme.controlBackgroundColor
+                border.width: 1
+                border.color: Theme.controlBorderColor
+
+                ListView {
+                  id: authenticationConfigurationsListView
+                  anchors.fill: parent
+                  clip: true
+
+                  model: []
+
+                  delegate: Rectangle {
+                    width: ListView.view.width
+                    height: authenticationConfigurationDetailsLayout.childrenRect.height + 10
+                    color: "transparent"
+
+                    ColumnLayout {
+                      id: authenticationConfigurationDetailsLayout
+                      width: parent.width - 10
+                      anchors.horizontalCenter: parent.horizontalCenter
+
+                      Text {
+                        Layout.fillWidth: true
+                        Layout.topMargin: 5
+                        font: Theme.defaultFont
+                        color: Theme.mainTextColor
+                        text: modelData["name"] + ' (' + modelData["id"] + ')'
+                        wrapMode: Text.Wrap
+                      }
+
+                      Text {
+                        Layout.fillWidth: true
+                        visible: modelData["uri"] !== ""
+                        font: Theme.tipFont
+                        color: Theme.secondaryTextColor
+                        text: modelData["uri"]
+                        wrapMode: Text.Wrap
+                      }
+                    }
+
+                    Rectangle {
+                      anchors.left: parent.left
+                      anchors.bottom: parent.bottom
+                      width: parent.width
+                      height: 1
+                      color: Theme.controlBorderColor
+                    }
+                  }
+                }
+              }
+
+              QfButton {
+                Layout.fillWidth: true
+                Layout.columnSpan: 2
+
+                text: qsTr("Clear authentication cache")
+
+                onClicked: {
+                  AuthUtils.clearAuthenticationConfigurationCache();
+                  displayToast(qsTr('Authentication cache cleared'));
+                }
               }
 
               Label {

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -87,7 +87,7 @@ EditorWidgetBase {
       if (!isHttp && !FileUtils.fileExists(fullValue)) {
         prepareValue("");
         if (externalStorage.type != "") {
-          if (config["StorageAuthConfigId"] !== "" && !iface.isAuthenticationConfigurationAvailable(config["StorageAuthConfigId"])) {
+          if (config["StorageAuthConfigId"] !== "" && !AuthUtils.isAuthenticationConfigurationAvailable(config["StorageAuthConfigId"])) {
             mainWindow.displayToast(qsTr("The external storage's authentication configuration ID is missing, please insure it is imported into %1").arg(appName), "error", qsTr("Learn more"), function () {
               Qt.openUrlExternally('https://docs.qfield.org/how-to/advanced-how-tos/authentication/');
             });

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -508,7 +508,7 @@ RelationEditorBase {
     // File not found locally; attempt on-demand download
     if (externalStorage.type !== "") {
       const authConfigId = referencingFeatureListModel.attachmentStorageAuthConfigId;
-      if (authConfigId !== "" && !iface.isAuthenticationConfigurationAvailable(authConfigId)) {
+      if (authConfigId !== "" && !AuthUtils.isAuthenticationConfigurationAvailable(authConfigId)) {
         failedDownloads[path] = true;
         mainWindow.displayToast(qsTr("The external storage's authentication configuration ID is missing, please insure it is imported into %1").arg(appName), "error", qsTr("Learn more"), function () {
           Qt.openUrlExternally('https://docs.qfield.org/how-to/advanced-how-tos/authentication/');


### PR DESCRIPTION
As the title says, this adds a new UI under the network section within the QField settings panel that displays details of imported authentication configurations:

<img width="438" height="732" alt="image" src="https://github.com/user-attachments/assets/42204878-8727-418a-af6c-56f2abaabd15" />

Below the list, a button is available that, when clicked, clears any cache associated with the listed authentication configurations (e.g. an oauth2 method configuration would clear its token cache).

Small implementation detail: the UI will _not_ appear unless authentication configurations have been imported into QField, no need to scare people off :)

This fixes https://github.com/opengisch/QField/issues/7583