### PR TITLE
When a feature form tab is not visible, its content contraint(s) should not be taken into account

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -1097,16 +1097,19 @@ void AttributeFormModelBase::updateVisibilityAndConstraints( int fieldIndex )
 
         QStandardItem *tab = root->child( i, 0 );
         _checkChildrenValidity( tab, hardValidity, softValidity );
-        if ( !hardValidity )
-        {
-          allConstraintsHardValid = false;
-        }
-        if ( !softValidity )
-        {
-          allConstraintsSoftValid = false;
-        }
         tab->setData( hardValidity, AttributeFormModel::ConstraintHardValid );
         tab->setData( softValidity, AttributeFormModel::ConstraintSoftValid );
+        if ( tab->data( AttributeFormModel::CurrentlyVisible ).toBool() )
+        {
+          if ( !hardValidity )
+          {
+            allConstraintsHardValid = false;
+          }
+          if ( !softValidity )
+          {
+            allConstraintsSoftValid = false;
+          }
+        }
       }
     }
     else

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -10,8 +10,8 @@ EditorWidgetBase {
 
   // if the field type is boolean, ignore the configured 'CheckedState' and 'UncheckedState' values and work with true/false always
   readonly property bool isBool: field.type == 1  // needs type coercion
-  property string checkedLabel: config['TextDisplayMethod'] === 1 && config['CheckedState'] !== null && config['CheckedState'] !== '' ? config['CheckedState'] : qsTr('True')
-  property string uncheckedLabel: config['TextDisplayMethod'] === 1 && config['UncheckedState'] !== null && config['UncheckedState'] !== '' ? config['UncheckedState'] : qsTr('False')
+  property string checkedLabel: config['TextDisplayMethod'] === 1 && config['CheckedState'] !== undefined && config['CheckedState'] !== '' ? config['CheckedState'] : qsTr('True')
+  property string uncheckedLabel: config['TextDisplayMethod'] === 1 && config['UncheckedState'] !== undefined && config['UncheckedState'] !== '' ? config['UncheckedState'] : qsTr('False')
 
   anchors {
     right: parent.right


### PR DESCRIPTION
While we properly ignore hidden attributes' constraint state, we did not do so for the root tabs of the feature form. In turn, this could lead to a hard constraint failure even though the completed form would not have any visible hard constraint failure. This PR fixes that

