### PR TITLE
Fix a pair of crashes on Android as seen on the play console

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -1634,7 +1634,7 @@ public class QFieldActivity extends QtActivity {
 
             updateProjectFromArchive(uri);
         } else if (requestCode == EXPORT_TO_FOLDER &&
-                   resultCode == Activity.RESULT_OK) {
+                   resultCode == Activity.RESULT_OK && pathsToExport != null) {
             Log.d("QField", "handling export to folder");
 
             String[] paths = pathsToExport.split("--;--");

--- a/platform/android/src/ch/opengis/qfield/QFieldCloudService.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldCloudService.java
@@ -31,6 +31,7 @@
 
 package ch.opengis.qfield;
 
+import android.app.ForegroundServiceStartNotAllowedException;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -149,10 +150,20 @@ public class QFieldCloudService extends QtService {
             } else {
                 startForeground(NOTIFICATION_ID, notification);
             }
-        } catch (SecurityException e) {
-            Log.v("QFieldCloudService",
-                  "Missing permission to launch the QFieldCloud service");
-            return START_NOT_STICKY;
+        } catch (Exception e) {
+            if (e instanceof SecurityException) {
+                Log.v("QFieldCloudService",
+                      "Missing permission to launch the QFieldCloud service");
+                return START_NOT_STICKY;
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                       e instanceof ForegroundServiceStartNotAllowedException) {
+                Log.v(
+                    "QFieldCloudService",
+                    "The QFieldCloud service already ran for the permitted 6 hours during the last 24 hours window");
+                return START_NOT_STICKY;
+            } else {
+                throw e;
+            }
         }
 
         return START_STICKY;

--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -290,6 +290,11 @@ void AndroidPlatformUtilities::sendDatasetTo( const QString &path ) const
 
 void AndroidPlatformUtilities::exportDatasetTo( const QString &path ) const
 {
+  if ( path.trimmed().isEmpty() )
+  {
+    return;
+  }
+
   if ( mActivity.isValid() )
   {
     runOnAndroidMainThread( [path] {
@@ -339,6 +344,11 @@ void AndroidPlatformUtilities::removeDataset( const QString &path ) const
 
 void AndroidPlatformUtilities::exportFolderTo( const QString &path ) const
 {
+  if ( path.trimmed().isEmpty() )
+  {
+    return;
+  }
+
   if ( mActivity.isValid() )
   {
     runOnAndroidMainThread( [path] {


### PR DESCRIPTION
First crash occurred when users were exporting a folder or dataset to an external folder on an Android device.

```
Exception java.lang.RuntimeException:
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:5402)
  at android.app.ActivityThread.handleResumeActivity (ActivityThread.java:5435)
  at android.app.servertransaction.ResumeActivityItem.execute (ResumeActivityItem.java:57)
  at android.app.servertransaction.ActivityTransactionItem.execute (ActivityTransactionItem.java:60)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleItem (TransactionExecutor.java:225)
  at android.app.servertransaction.TransactionExecutor.executeTransactionItems (TransactionExecutor.java:107)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:81)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2695)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loopOnce (Looper.java:232)
  at android.os.Looper.loop (Looper.java:317)
  at android.app.ActivityThread.main (ActivityThread.java:8842)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:681)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:902)
Caused by java.lang.RuntimeException:
  at android.app.ActivityThread.deliverResults (ActivityThread.java:5971)
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:5374)
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String[] java.lang.String.split(java.lang.String)' on a null object reference
  at ch.opengis.qfield.QFieldActivity.onActivityResult (QFieldActivity.java:1615)
  at android.app.Activity.onActivityResult (Activity.java:7556)
  at android.app.Activity.internalDispatchActivityResult (Activity.java:9452)
  at android.app.Activity.dispatchActivityResult (Activity.java:9429)
  at android.app.ActivityThread.deliverResults (ActivityThread.java:5960)
```

The second crash is more interesting. Android foreground datasync service is only permitted to run for 6 hours out of a 24 hour rolling window (https://developer.android.com/develop/background-work/services/fgs/timeout#timeout-behavior). TIL.

```
Exception java.lang.RuntimeException:
  at android.app.ActivityThread.handleServiceArgs (ActivityThread.java:5539)
  at android.app.ActivityThread.-$$Nest$mhandleServiceArgs (ActivityThread.java)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2719)
  at android.os.Handler.dispatchMessage (Handler.java:107)
  at android.os.Looper.loopOnce (Looper.java:282)
  at android.os.Looper.loop (Looper.java:387)
  at android.app.ActivityThread.main (ActivityThread.java:9500)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:600)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1005)
Caused by android.app.ForegroundServiceStartNotAllowedException: Time limit already exhausted for foreground service type dataSync
  at android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel (ForegroundServiceStartNotAllowedException.java:54)
  at android.app.ForegroundServiceStartNotAllowedException$1.createFromParcel (ForegroundServiceStartNotAllowedException.java:50)
  at android.os.Parcel.readParcelableInternal (Parcel.java:5104)
  at android.os.Parcel.readParcelable (Parcel.java:5086)
  at android.os.Parcel.createExceptionOrNull (Parcel.java:3266)
  at android.os.Parcel.createException (Parcel.java:3255)
  at android.os.Parcel.readException (Parcel.java:3238)
  at android.os.Parcel.readException (Parcel.java:3180)
  at android.app.IActivityManager$Stub$Proxy.setServiceForeground (IActivityManager.java:7193)
  at android.app.Service.startForeground (Service.java:863)
  at ch.opengis.qfield.QFieldCloudService.onStartCommand (QFieldCloudService.java:147)
  at android.app.ActivityThread.handleServiceArgs (ActivityThread.java:5521)
``` 