### PR TITLE
Attempt to fix mysterious V4 engine crash, try 2

### DIFF
--- a/src/core/linepolygonshape.cpp
+++ b/src/core/linepolygonshape.cpp
@@ -58,7 +58,7 @@ void LinePolygonShape::createPolylines()
           {
             polyline << QPointF( ( point.x() - visibleExtent.xMinimum() ) * scaleFactor, ( point.y() - visibleExtent.yMaximum() ) * -scaleFactor );
           }
-          mPolylines << polyline;
+          mPolylines.append( polyline );
         }
         break;
       }
@@ -68,14 +68,14 @@ void LinePolygonShape::createPolylines()
         const QgsMultiPolygonXY polygons = geometry.isMultipart() ? geometry.asMultiPolygon() : QgsMultiPolygonXY() << geometry.asPolygon();
         for ( const QgsPolygonXY &polygon : polygons )
         {
-          for ( const QgsPolylineXY line : polygon )
+          for ( const QgsPolylineXY &line : polygon )
           {
             QPolygonF polyline;
             for ( const QgsPointXY &point : line )
             {
               polyline << QPointF( ( point.x() - visibleExtent.xMinimum() ) * scaleFactor, ( point.y() - visibleExtent.yMaximum() ) * -scaleFactor );
             }
-            mPolylines << polyline;
+            mPolylines.append( polyline );
           }
         }
         break;

--- a/src/core/linepolygonshape.h
+++ b/src/core/linepolygonshape.h
@@ -38,7 +38,7 @@ class LinePolygonShape : public QQuickItem
     Q_PROPERTY( QgsGeometryWrapper *geometry READ geometry WRITE setGeometry NOTIFY qgsGeometryChanged )
 
     //! List of polylines representing the geometry
-    Q_PROPERTY( QList<QPolygonF> polylines READ polylines NOTIFY polylinesChanged )
+    Q_PROPERTY( QVariantList polylines READ polylines NOTIFY polylinesChanged )
     //! The geometry type associated to the polylines
     Q_PROPERTY( Qgis::GeometryType polylinesType READ polylinesType NOTIFY polylinesTypeChanged )
 
@@ -58,7 +58,7 @@ class LinePolygonShape : public QQuickItem
     void setLineWidth( float width );
 
     //! \copydoc polylines
-    QList<QPolygonF> polylines() const { return mPolylines; }
+    QVariantList polylines() const { return mPolylines; }
 
     //! \copydoc polylinesType
     Qgis::GeometryType polylinesType() const { return mPolylinesType; }
@@ -91,7 +91,7 @@ class LinePolygonShape : public QQuickItem
     QgsGeometryWrapper *mGeometry = nullptr;
     QgsPoint mGeometryCorner;
     double mGeometryMUPP = 0.0;
-    QList<QPolygonF> mPolylines;
+    QVariantList mPolylines;
     Qgis::GeometryType mPolylinesType = Qgis::GeometryType::Null;
 };
 

--- a/src/core/rubberbandshape.cpp
+++ b/src/core/rubberbandshape.cpp
@@ -230,7 +230,7 @@ void RubberbandShape::createPolylines()
 
   mPolylines.clear();
 
-  QList<QPointF> polyline;
+  QPolygonF polyline;
   QVector<QgsPoint> allVertices = QVector<QgsPoint>();
   Qgis::GeometryType geomType = mGeometryType;
   if ( mRubberbandModel && !mRubberbandModel->isEmpty() )
@@ -253,7 +253,7 @@ void RubberbandShape::createPolylines()
   {
     polyline << QPointF( ( point.x() - visibleExtent.xMinimum() ) * scaleFactor, ( point.y() - visibleExtent.yMaximum() ) * -scaleFactor );
   }
-  mPolylines << polyline;
+  mPolylines.append( polyline );
 
   if ( geomType != mPolylinesType )
   {

--- a/src/core/rubberbandshape.h
+++ b/src/core/rubberbandshape.h
@@ -53,7 +53,7 @@ class RubberbandShape : public QQuickItem
     Q_PROPERTY( qreal lineWidth READ lineWidth WRITE setLineWidth NOTIFY lineWidthChanged )
 
     //! List of polylines representing the rubber band
-    Q_PROPERTY( QList<QList<QPointF>> polylines READ polylines NOTIFY polylinesChanged )
+    Q_PROPERTY( QVariantList polylines READ polylines NOTIFY polylinesChanged )
     //! The geometry type associated to the polylines
     Q_PROPERTY( Qgis::GeometryType polylinesType READ polylinesType NOTIFY polylinesTypeChanged )
 
@@ -95,7 +95,7 @@ class RubberbandShape : public QQuickItem
     void setGeometryType( const Qgis::GeometryType geometryType );
 
     //! \copydoc polylines
-    QList<QList<QPointF>> polylines() const { return mPolylines; }
+    QVariantList polylines() const { return mPolylines; }
 
     //! \copydoc polylinesType
     Qgis::GeometryType polylinesType() const { return mPolylinesType; }
@@ -139,7 +139,7 @@ class RubberbandShape : public QQuickItem
     Qgis::GeometryType mGeometryType = Qgis::GeometryType::Null;
     QgsPoint mGeometryCorner;
     double mGeometryMUPP = 0.0;
-    QList<QList<QPointF>> mPolylines;
+    QVariantList mPolylines;
     Qgis::GeometryType mPolylinesType = Qgis::GeometryType::Null;
 };
 

--- a/src/qml/Rubberband.qml
+++ b/src/qml/Rubberband.qml
@@ -10,53 +10,49 @@ RubberbandShape {
   id: rubberbandShape
 
   property bool showVertices: false
+  property var activePolyline: rubberbandShape.polylines.length > 0 ? rubberbandShape.polylines[0] : []
 
-  Repeater {
-    id: rubberbandPaths
-    model: rubberbandShape.polylines
+  Shape {
+    anchors.fill: parent
+    ShapePath {
+      strokeColor: rubberbandShape.outlineColor
+      strokeWidth: rubberbandShape.lineWidth / rubberbandShape.scale + 2
+      strokeStyle: ShapePath.SolidLine
+      fillColor: "transparent"
+      joinStyle: ShapePath.RoundJoin
+      capStyle: ShapePath.RoundCap
 
-    Shape {
-      anchors.fill: parent
-      ShapePath {
-        strokeColor: rubberbandShape.outlineColor
-        strokeWidth: rubberbandShape.lineWidth / rubberbandShape.scale + 2
-        strokeStyle: ShapePath.SolidLine
-        fillColor: "transparent"
-        joinStyle: ShapePath.RoundJoin
-        capStyle: ShapePath.RoundCap
-
-        PathPolyline {
-          path: modelData
-        }
+      PathPolyline {
+        path: activePolyline
       }
-      ShapePath {
-        strokeColor: rubberbandShape.color
-        strokeWidth: rubberbandShape.lineWidth / rubberbandShape.scale
-        strokeStyle: ShapePath.SolidLine
-        fillColor: rubberbandShape.polylinesType === Qgis.GeometryType.Polygon ? Qt.hsla(strokeColor.hslHue, strokeColor.hslSaturation, strokeColor.hslLightness, 0.25) : "transparent"
-        joinStyle: ShapePath.RoundJoin
-        capStyle: ShapePath.RoundCap
+    }
+    ShapePath {
+      strokeColor: rubberbandShape.color
+      strokeWidth: rubberbandShape.lineWidth / rubberbandShape.scale
+      strokeStyle: ShapePath.SolidLine
+      fillColor: rubberbandShape.polylinesType === Qgis.GeometryType.Polygon ? Qt.hsla(strokeColor.hslHue, strokeColor.hslSaturation, strokeColor.hslLightness, 0.25) : "transparent"
+      joinStyle: ShapePath.RoundJoin
+      capStyle: ShapePath.RoundCap
 
-        PathPolyline {
-          path: modelData
-        }
+      PathPolyline {
+        path: activePolyline
       }
+    }
 
-      Repeater {
-        id: rubberbandVertices
-        model: showVertices && rubberbandShape.model.vertexCount > 1 ? modelData : []
+    Repeater {
+      id: rubberbandVertices
+      model: showVertices && activePolyline.length > 1 ? activePolyline : []
 
-        Rectangle {
-          width: rubberbandShape.lineWidth / rubberbandShape.scale * 2
-          height: width
+      Rectangle {
+        width: rubberbandShape.lineWidth / rubberbandShape.scale * 2
+        height: width
 
-          x: modelData.x - width / 2
-          y: modelData.y - width / 2
+        x: modelData.x - width / 2
+        y: modelData.y - width / 2
 
-          color: rubberbandShape.color
-          border.width: 1
-          border.color: rubberbandShape.outlineColor
-        }
+        color: rubberbandShape.color
+        border.width: 1
+        border.color: rubberbandShape.outlineColor
       }
     }
   }


### PR DESCRIPTION
Alright, the initial attempt did not cover LinePolygon (where we did similar for loop or raw QList objects) and did not appear to have any significant impact on crash rates.

This second attempt transforms QList<QList<QPointF>> properties into QVariantList, which the internet says is safer as it reportedly triggers a full conversion when called. 