### PR TITLE
[Backport release-4_2] Insure referencing feature list model always update when the underlying layer data changes

### DIFF
--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -16,6 +16,7 @@
 
 #include "referencingfeaturelistmodel.h"
 
+#include <QTimer>
 #include <qgsmessagelog.h>
 #include <qgsproject.h>
 
@@ -122,8 +123,24 @@ QgsFeature ReferencingFeatureListModelBase::feature() const
 
 void ReferencingFeatureListModelBase::setRelation( const QgsRelation &relation )
 {
+  if ( mRelation.isValid() && mRelation.referencingLayer() )
+  {
+    disconnect( mRelation.referencingLayer(), &QgsVectorLayer::committedAttributeValuesChanges, this, &ReferencingFeatureListModelBase::referencingLayerCommittedAttributeValuesChanges );
+    disconnect( mRelation.referencingLayer(), &QgsVectorLayer::committedGeometriesChanges, this, &ReferencingFeatureListModelBase::referencingLayerCommittedGeometriesChanges );
+    disconnect( mRelation.referencingLayer(), &QgsVectorLayer::committedFeaturesAdded, this, &ReferencingFeatureListModelBase::referencingLayerCommittedFeaturesAdded );
+    disconnect( mRelation.referencingLayer(), &QgsVectorLayer::committedFeaturesRemoved, this, &ReferencingFeatureListModelBase::referencingLayerCommittedFeaturesRemoved );
+  }
+
   mRelation = relation;
   emit relationChanged();
+
+  if ( mRelation.isValid() && mRelation.referencingLayer() )
+  {
+    connect( mRelation.referencingLayer(), &QgsVectorLayer::committedAttributeValuesChanges, this, &ReferencingFeatureListModelBase::referencingLayerCommittedAttributeValuesChanges );
+    connect( mRelation.referencingLayer(), &QgsVectorLayer::committedGeometriesChanges, this, &ReferencingFeatureListModelBase::referencingLayerCommittedGeometriesChanges );
+    connect( mRelation.referencingLayer(), &QgsVectorLayer::committedFeaturesAdded, this, &ReferencingFeatureListModelBase::referencingLayerCommittedFeaturesAdded );
+    connect( mRelation.referencingLayer(), &QgsVectorLayer::committedFeaturesRemoved, this, &ReferencingFeatureListModelBase::referencingLayerCommittedFeaturesRemoved );
+  }
 
   mLastGathererFeaturesFilter.clear();
   updateAttachmentFieldInfo();
@@ -219,6 +236,37 @@ void ReferencingFeatureListModelBase::gathererThreadFinished()
   emit isLoadingChanged();
 }
 
+void ReferencingFeatureListModelBase::referencingLayerCommittedAttributeValuesChanges( const QString &layerId, const QgsChangedAttributesMap &changedAttributesValues )
+{
+  const QList<QgsFeatureId> featureIds = changedAttributesValues.keys();
+  if ( std::any_of( mEntries.begin(), mEntries.end(), [&featureIds]( const Entry &entry ) { return featureIds.contains( entry.referencingFeature.id() ); } ) )
+  {
+    QTimer::singleShot( 50, this, &ReferencingFeatureListModelBase::reload );
+  }
+}
+
+void ReferencingFeatureListModelBase::referencingLayerCommittedGeometriesChanges( const QString &layerId, const QgsGeometryMap &changedGeometries )
+{
+  const QList<QgsFeatureId> featureIds = changedGeometries.keys();
+  if ( std::any_of( mEntries.begin(), mEntries.end(), [&featureIds]( const Entry &entry ) { return featureIds.contains( entry.referencingFeature.id() ); } ) )
+  {
+    QTimer::singleShot( 50, this, &ReferencingFeatureListModelBase::reload );
+  }
+}
+
+void ReferencingFeatureListModelBase::referencingLayerCommittedFeaturesAdded( const QString &layerId, const QgsFeatureList &addedFeatures )
+{
+  QTimer::singleShot( 50, this, &ReferencingFeatureListModelBase::reload );
+}
+
+void ReferencingFeatureListModelBase::referencingLayerCommittedFeaturesRemoved( const QString &layerId, const QgsFeatureIds &deletedFeatureIds )
+{
+  if ( std::any_of( mEntries.begin(), mEntries.end(), [&deletedFeatureIds]( const Entry &entry ) { return deletedFeatureIds.contains( entry.referencingFeature.id() ); } ) )
+  {
+    QTimer::singleShot( 50, this, &ReferencingFeatureListModelBase::reload );
+  }
+}
+
 void ReferencingFeatureListModelBase::reload()
 {
   if ( !mRelation.isValid() || !mFeature.isValid() )
@@ -309,8 +357,6 @@ bool ReferencingFeatureListModelBase::deleteFeature( QgsFeatureId referencingFea
 
     return false;
   }
-
-  reload();
 
   return true;
 }

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -213,6 +213,11 @@ class QFIELD_CORE_EXPORT ReferencingFeatureListModelBase : public QAbstractItemM
     void updateModel();
     void gathererThreadFinished();
 
+    void referencingLayerCommittedAttributeValuesChanges( const QString &layerId, const QgsChangedAttributesMap &changedAttributesValues );
+    void referencingLayerCommittedGeometriesChanges( const QString &layerId, const QgsGeometryMap &changedGeometries );
+    void referencingLayerCommittedFeaturesAdded( const QString &layerId, const QgsFeatureList &addedFeatures );
+    void referencingLayerCommittedFeaturesRemoved( const QString &layerId, const QgsFeatureIds &deletedFeatureIds );
+
   private:
     struct Entry
     {
@@ -482,7 +487,6 @@ class FeatureGatherer : public QThread
     void run() override
     {
       mWasCanceled = false;
-
 
       QgsFeatureIterator relatedFeaturesIt = mReferencingSource->getFeatures( mRequest );
       QgsExpression expression( mDisplayExpression );

--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -247,15 +247,8 @@ EditorWidgetBase {
       digitizingToolbar: form.digitizingToolbar
       codeReader: form.codeReader
 
-      onFeatureCancelled: {
-        if (autoSave) {
-          relationEditorModel.reload();
-        }
-      }
-
       onFeatureSaved: id => {
         relationEditorModel.featureFocus = id;
-        relationEditorModel.reload();
         form.model.applyRelationshipDefaultValues();
       }
 

--- a/test/qml/tst_relations.qml
+++ b/test/qml/tst_relations.qml
@@ -118,7 +118,6 @@ TestCase {
     child3.setAttribute(3, 3000);
     verify(LayerUtils.addFeature(referencingLayer, child3), "Child3 insertion failed");
     referencingLayer.commitChanges();
-    relation_editor.item.relationEditorModel.reload();
     wait(200);
     compare(relation_editor.item.relationEditorModel.rowCount(), 3);
     const delegate3TextString = relation_editor.item.listView.itemAtIndex(2).children[2].children[0].text;


### PR DESCRIPTION
Backport #7610
 **Authored by:** @nirvn