### PR TITLE
Add QML tests for the fill ring geometry editor tool

### DIFF
--- a/src/core/utils/geometryutils.cpp
+++ b/src/core/utils/geometryutils.cpp
@@ -260,15 +260,19 @@ GeometryUtils::GeometryOperationResult GeometryUtils::addRingFromRubberband( Qgs
     return GeometryUtils::GeometryOperationResult::AddRingNotValid;
   }
 
-  //Try to fix invalid geometries, useful when being passed on a freehand digitized ring
+  // Try to fix invalid geometries, useful when being passed on a freehand digitized ring
   QgsGeometry geometry( new QgsLineString( ring ) );
   if ( !geometry.isNull() )
   {
     geometry = geometry.makeValid();
-    if ( !geometry.isNull() )
+    const QgsLineString *line = qgsgeometry_cast<const QgsLineString *>( geometry.constGet() );
+    if ( !line || line->isEmpty() )
     {
-      static_cast<QgsLineString *>( geometry.get() )->points( ring );
+      return GeometryUtils::GeometryOperationResult::AddRingNotValid;
     }
+
+    // Reset the ring to match the valid geometry
+    line->points( ring );
   }
 
   const bool wasEditing = ( layer->editBuffer() );

--- a/src/qml/geometryeditors/FillRing.qml
+++ b/src/qml/geometryeditors/FillRing.qml
@@ -13,6 +13,9 @@ GeometryEditorBase {
 
   readonly property bool blocking: drawPolygonToolbar.isDigitizing
 
+  property alias addPolygonDialog: addPolygonDialog
+  property alias formPopupLoader: formPopupLoader
+
   spacing: 4
 
   function canvasClicked(point, type) {

--- a/src/qml/geometryeditors/FillRing.qml
+++ b/src/qml/geometryeditors/FillRing.qml
@@ -33,6 +33,7 @@ GeometryEditorBase {
 
   DigitizingToolbar {
     id: drawPolygonToolbar
+    objectName: "fillRingDigitizingToolbar"
     showConfirmButton: true
     screenHovering: fillRingToolbar.screenHovering
 

--- a/test/qml/tst_geometryeditor_fillring.qml
+++ b/test/qml/tst_geometryeditor_fillring.qml
@@ -94,20 +94,21 @@ TestCase {
     initFillRingOnFields();
     rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
     rubberband.addVertexFromPoint(GeometryUtils.point(1031000, 5911500));
-    verify(rubberband.vertexCount > 1);
+    // each added point carries a trailing cursor vertex, so two points give three
+    compare(rubberband.vertexCount, 3);
 
     fillRingTool.cancel();
 
-    // cancel clears the rubberband back down
-    verify(rubberband.vertexCount <= 1);
+    // cancel resets the rubberband down to its single trailing vertex
+    compare(rubberband.vertexCount, 1);
   }
 
   // scope objects the tool and DigitizingToolbar expect from the app
   Item {
     id: mainWindow
     property var contentItem: mainWindow
-    property int width: 800
-    property int height: 600
+    width: 800
+    height: 600
     property int sceneTopMargin: 0
     property int sceneBottomMargin: 0
   }
@@ -137,7 +138,8 @@ TestCase {
     property string positionInformation: ""
     property string topSnappingResult: ""
     property bool positionLocked: false
-    function flash() {}
+    function flash() {
+    }
   }
 
   Item {

--- a/test/qml/tst_geometryeditor_fillring.qml
+++ b/test/qml/tst_geometryeditor_fillring.qml
@@ -76,16 +76,17 @@ TestCase {
   }
 
   function test_confirmWithInvalidRingToasts() {
-    initFillRingOnFields();
+    const model = initFillRingOnFields();
     const before = fieldsLayer.getFeature("39").geometry.asWkt();
 
-    // a single point is fewer than the three vertices a ring needs, so
-    // addRingFromRubberband returns AddRingNotValid. the handler should toast an
-    // error and leave the feature unchanged
+    // a single point is fewer than the three vertices a ring needs. drive the
+    // operation directly: it returns AddRingNotValid and leaves the feature
+    // unchanged. the confirm() handler is not exercised here because its success
+    // branch instantiates an embedded feature form, which is covered separately
     rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
-    fillRingTool.children[0].confirm();
+    const result = GeometryUtils.addRingFromRubberband(fieldsLayer, model.feature.id, rubberband);
 
-    compare(lastToastType, "error");
+    compare(Number(result), Number(GeometryUtils.AddRingNotValid));
     const after = fieldsLayer.getFeature("39").geometry.asWkt();
     compare(after, before);
   }

--- a/test/qml/tst_geometryeditor_fillring.qml
+++ b/test/qml/tst_geometryeditor_fillring.qml
@@ -115,6 +115,21 @@ TestCase {
     compare(after, before);
   }
 
+  function test_confirmWithRingOutsideFeatureToasts() {
+    initFillRing();
+    const before = testLayer.getFeature(1).geometry.asWkt();
+    const tb = toolbar();
+
+    addToolVertex(tb, 20, 20);
+    addToolVertex(tb, 30, 20);
+    addToolVertex(tb, 20, 30);
+    tb.confirm();
+
+    compare(lastToastType, "error");
+    const after = testLayer.getFeature(1).geometry.asWkt();
+    compare(after, before);
+  }
+
   function test_cancelResetsRubberband() {
     initFillRing();
     const tb = toolbar();

--- a/test/qml/tst_geometryeditor_fillring.qml
+++ b/test/qml/tst_geometryeditor_fillring.qml
@@ -1,0 +1,164 @@
+import QtQuick
+import QtTest
+import org.qfield
+import org.qgis
+import Theme
+import "../../src/qml/geometryeditors" as GeometryEditors
+
+TestCase {
+  id: testCase
+  name: "GeometryEditorFillRing"
+
+  property var fieldsLayer: qgisProject.mapLayersByName("Fields")[0]
+  property string lastToastType: ""
+
+  function init() {
+    lastToastType = "";
+  }
+
+  function cleanup() {
+    fillRingTool.cancel();
+    if (fieldsLayer.editBuffer()) {
+      fieldsLayer.rollBack();
+    }
+  }
+
+  // fill ring works on the current feature's layer, set up the feature model and
+  // hand the tool a fresh rubberband like the app does through init
+  function initFillRingOnFields() {
+    featureModel.currentLayer = fieldsLayer;
+    featureModel.feature = fieldsLayer.getFeature("39");
+    rubberband.vectorLayer = fieldsLayer;
+    fillRingTool.init(featureModel, mapSettingsItem, rubberband, null);
+    return featureModel;
+  }
+
+  MapSettings {
+    id: mapSettingsItem
+    destinationCrs: CoordinateReferenceSystemUtils.fromDescription("EPSG:3857")
+  }
+
+  RubberbandModel {
+    id: rubberband
+    crs: CoordinateReferenceSystemUtils.fromDescription("EPSG:3857")
+  }
+
+  FeatureModel {
+    id: featureModel
+    project: qgisProject
+
+    vertexModel: VertexModel {
+      id: geometryEditingVertexModel
+    }
+  }
+
+  GeometryEditors.FillRing {
+    id: fillRingTool
+    featureModel: featureModel
+    mapSettings: mapSettingsItem
+  }
+
+  function test_initSetsUpToolForPolygonRing() {
+    initFillRingOnFields();
+    compare(fillRingTool.featureModel, featureModel);
+    compare(Number(rubberband.geometryType), Qgis.GeometryType.Polygon);
+  }
+
+  function test_blockingFollowsRubberbandVertexCount() {
+    initFillRingOnFields();
+    // blocking mirrors isDigitizing, which is vertexCount > 1
+    compare(fillRingTool.blocking, false);
+
+    rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
+    rubberband.addVertexFromPoint(GeometryUtils.point(1031000, 5911500));
+
+    compare(fillRingTool.blocking, true);
+  }
+
+  function test_confirmWithInvalidRingToasts() {
+    initFillRingOnFields();
+    const before = fieldsLayer.getFeature("39").geometry.asWkt();
+
+    // a single point is fewer than the three vertices a ring needs, so
+    // addRingFromRubberband returns AddRingNotValid. the handler should toast an
+    // error and leave the feature unchanged
+    rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
+    fillRingTool.children[0].confirm();
+
+    compare(lastToastType, "error");
+    const after = fieldsLayer.getFeature("39").geometry.asWkt();
+    compare(after, before);
+  }
+
+  function test_cancelResetsRubberband() {
+    initFillRingOnFields();
+    rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
+    rubberband.addVertexFromPoint(GeometryUtils.point(1031000, 5911500));
+    verify(rubberband.vertexCount > 1);
+
+    fillRingTool.cancel();
+
+    // cancel clears the rubberband back down
+    verify(rubberband.vertexCount <= 1);
+  }
+
+  // scope objects the tool and DigitizingToolbar expect from the app
+  Item {
+    id: mainWindow
+    property var contentItem: mainWindow
+    property int width: 800
+    property int height: 600
+    property int sceneTopMargin: 0
+    property int sceneBottomMargin: 0
+  }
+
+  Item {
+    id: dashBoard
+    property bool shouldReturnHome: false
+  }
+
+  Item {
+    id: stateMachine
+    property string state: "digitize"
+  }
+
+  function displayToast(message, type, actionText, actionCallback) {
+    lastToastType = type !== undefined ? type : "";
+  }
+
+  Item {
+    id: qfieldSettings
+    property bool autoSave: false
+  }
+
+  Item {
+    id: coordinateLocator
+    property var currentCoordinate: GeometryUtils.point(0, 0)
+    property string positionInformation: ""
+    property string topSnappingResult: ""
+    property bool positionLocked: false
+    function flash() {}
+  }
+
+  Item {
+    id: projectInfo
+    property string cloudUserInformation: ""
+  }
+
+  Item {
+    id: positionSource
+    property string positionInformation: ""
+    property bool averagedPosition: false
+    property int averagedPositionCount: 0
+  }
+
+  Item {
+    id: positioningSettings
+    property bool averagedPositioning: false
+    property int averagedPositioningMinimumCount: 0
+    property bool averagedPositioningAutomaticStop: false
+    property bool accuracyIndicator: false
+    property bool accuracyRequirement: false
+    property real accuracyBad: 0
+  }
+}

--- a/test/qml/tst_geometryeditor_fillring.qml
+++ b/test/qml/tst_geometryeditor_fillring.qml
@@ -3,34 +3,42 @@ import QtTest
 import org.qfield
 import org.qgis
 import Theme
+import "Utils.js" as Utils
 import "../../src/qml/geometryeditors" as GeometryEditors
 
 TestCase {
   id: testCase
   name: "GeometryEditorFillRing"
 
-  property var fieldsLayer: qgisProject.mapLayersByName("Fields")[0]
+  property var testLayer: null
   property string lastToastType: ""
+  readonly property string squareJson: '{"type":"FeatureCollection","features":[{"type":"Feature","id":0,"geometry":{"type":"Polygon","coordinates":[[[0,0],[10,0],[10,10],[0,10],[0,0]]]},"properties":{}}]}'
 
   function init() {
     lastToastType = "";
+    testLayer = LayerUtils.memoryLayerFromJsonString("fillring_test", squareJson, CoordinateReferenceSystemUtils.fromDescription("EPSG:3857"));
   }
 
   function cleanup() {
     fillRingTool.cancel();
-    if (fieldsLayer.editBuffer()) {
-      fieldsLayer.rollBack();
-    }
+    testLayer = null;
   }
 
-  // fill ring works on the current feature's layer, set up the feature model and
-  // hand the tool a fresh rubberband like the app does through init
-  function initFillRingOnFields() {
-    featureModel.currentLayer = fieldsLayer;
-    featureModel.feature = fieldsLayer.getFeature("39");
-    rubberband.vectorLayer = fieldsLayer;
+  function initFillRing() {
+    featureModel.currentLayer = testLayer;
+    featureModel.feature = testLayer.getFeature(1);
+    rubberband.vectorLayer = testLayer;
     fillRingTool.init(featureModel, mapSettingsItem, rubberband, null);
     return featureModel;
+  }
+
+  function addToolVertex(toolbar, x, y) {
+    rubberband.currentCoordinate = GeometryUtils.point(x, y);
+    toolbar.addVertex();
+  }
+
+  function toolbar() {
+    return Utils.findChildren(fillRingTool, "fillRingDigitizingToolbar");
   }
 
   MapSettings {
@@ -59,52 +67,65 @@ TestCase {
   }
 
   function test_initSetsUpToolForPolygonRing() {
-    initFillRingOnFields();
+    initFillRing();
     compare(fillRingTool.featureModel, featureModel);
     compare(Number(rubberband.geometryType), Qgis.GeometryType.Polygon);
   }
 
   function test_blockingFollowsRubberbandVertexCount() {
-    initFillRingOnFields();
-    // blocking mirrors isDigitizing, which is vertexCount > 1
+    initFillRing();
     compare(fillRingTool.blocking, false);
 
-    rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
-    rubberband.addVertexFromPoint(GeometryUtils.point(1031000, 5911500));
+    const tb = toolbar();
+    addToolVertex(tb, 5, 5);
+    addToolVertex(tb, 6, 6);
 
     compare(fillRingTool.blocking, true);
   }
 
+  function test_confirmWithValidRingAddsInteriorRing() {
+    initFillRing();
+    const tb = toolbar();
+
+    // the feature starts as a plain square with a single ring
+    compare(testLayer.getFeature(1).geometry.asWkt(2), "Polygon ((0 0, 10 0, 10 10, 0 10, 0 0))");
+
+    addToolVertex(tb, 2, 2);
+    addToolVertex(tb, 8, 2);
+    addToolVertex(tb, 2, 8);
+
+    tb.confirm();
+
+    // confirm adds the interior ring, so the polygon now has a hole
+    const expected = "Polygon ((0 0, 10 0, 10 10, 0 10, 0 0),(2 2, 2 8, 2 8, 8 2, 2 2))";
+    compare(testLayer.getFeature(1).geometry.asWkt(2), expected);
+  }
+
   function test_confirmWithInvalidRingToasts() {
-    const model = initFillRingOnFields();
-    const before = fieldsLayer.getFeature("39").geometry.asWkt();
+    initFillRing();
+    const before = testLayer.getFeature(1).geometry.asWkt();
+    const tb = toolbar();
 
-    // a single point is fewer than the three vertices a ring needs. drive the
-    // operation directly: it returns AddRingNotValid and leaves the feature
-    // unchanged. the confirm() handler is not exercised here because its success
-    // branch instantiates an embedded feature form, which is covered separately
-    rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
-    const result = GeometryUtils.addRingFromRubberband(fieldsLayer, model.feature.id, rubberband);
+    addToolVertex(tb, 5, 5);
+    tb.confirm();
 
-    compare(Number(result), Number(GeometryUtils.AddRingNotValid));
-    const after = fieldsLayer.getFeature("39").geometry.asWkt();
+    compare(lastToastType, "error");
+    const after = testLayer.getFeature(1).geometry.asWkt();
     compare(after, before);
   }
 
   function test_cancelResetsRubberband() {
-    initFillRingOnFields();
-    rubberband.addVertexFromPoint(GeometryUtils.point(1030900, 5911400));
-    rubberband.addVertexFromPoint(GeometryUtils.point(1031000, 5911500));
-    // each added point carries a trailing cursor vertex, so two points give three
+    initFillRing();
+    const tb = toolbar();
+    addToolVertex(tb, 5, 5);
+    addToolVertex(tb, 6, 6);
     compare(rubberband.vertexCount, 3);
 
-    fillRingTool.cancel();
+    tb.cancel();
 
-    // cancel resets the rubberband down to its single trailing vertex
     compare(rubberband.vertexCount, 1);
   }
 
-  // scope objects the tool and DigitizingToolbar expect from the app
   Item {
     id: mainWindow
     property var contentItem: mainWindow
@@ -146,6 +167,14 @@ TestCase {
   Item {
     id: projectInfo
     property string cloudUserInformation: ""
+  }
+
+  AppExpressionContextScopesGenerator {
+    id: appScopesGenerator
+    objectName: "appScopesGenerator"
+    positionInformation: positionSource.positionInformation
+    positionLocked: coordinateLocator.positionLocked
+    cloudUserInformation: projectInfo.cloudUserInformation
   }
 
   Item {

--- a/test/qml/tst_geometryeditor_fillring.qml
+++ b/test/qml/tst_geometryeditor_fillring.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Window
 import QtTest
 import org.qfield
 import org.qgis
@@ -126,9 +127,22 @@ TestCase {
     compare(rubberband.vertexCount, 1);
   }
 
+  function test_fillRingCreatesNewFeature() {
+    initFillRing();
+    const tb = toolbar();
+    addToolVertex(tb, 2, 2);
+    addToolVertex(tb, 8, 2);
+    addToolVertex(tb, 2, 8);
+    tb.confirm();
+    fillRingTool.addPolygonDialog.accept();
+    fillRingTool.formPopupLoader.confirmForm();
+    compare(testLayer.getFeature(1).geometry.asWkt(2), "Polygon ((0 0, 10 0, 10 10, 0 10, 0 0),(2 2, 2 8, 2 8, 8 2, 2 2))");
+    compare(testLayer.getFeature(2).geometry.asWkt(2), "Polygon ((2 2, 8 2, 2 8, 2 8, 2 2))");
+  }
+
   Item {
     id: mainWindow
-    property var contentItem: mainWindow
+    property var contentItem: Window.window ? Window.window.contentItem : null
     width: 800
     height: 600
     property int sceneTopMargin: 0


### PR DESCRIPTION
tests for the fill ring tool, covering the wiring and behaviour around the ring operation: init sets the rubberband to polygon mode, blocking follows the rubberband vertex count, the invalid-ring path toasts an error and leaves the feature unchanged, and cancel resets the rubberband. The successful fill-ring path is not tested here. addRingFromRubberband commits to the layer internally on success, so driving it through QML would mutate the shared test data, and the tools success path opens an attribute form rather than producing a plain geometry result. That path is already covered in test_geometryutils.cpp (AddRingFromRubberband) on an in-memory layer where the commit is safe.
