### PR TITLE
When importing a compressed project via URL, insure the .zip file doesn't linger in the imported datasets folder

### DIFF
--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -541,15 +541,16 @@ void AppInterface::importUrl( const QString &url, const QString &title, bool loa
               }
 
               // Project archive successfully imported
+              QFile::remove( filePath );
               emit importEnded( loadOnImport && projectFilePaths.size() == 1 ? projectFilePaths.at( 0 ) : zipDirectory, url );
               return;
             }
             else
             {
               // Broken project archive, bail out
+              QFile::remove( filePath );
               QDir dir( zipDirectory );
               dir.removeRecursively();
-              filePath.clear();
               emit importEnded();
               return;
             }


### PR DESCRIPTION
Beyond removing any confusion as to where the imported project lives, it also avoids wasting space.