### PR TITLE
Remove redundant "Remove folder" action from local data picker

### DIFF
--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -643,7 +643,7 @@ Page {
       }
 
       MenuSeparator {
-        enabled: deleteFile.visible || removeDataset.visible || removeProjectFolder.visible
+        enabled: deleteFile.visible || removeDataset.visible
         visible: enabled
         width: parent.width
         height: enabled ? undefined : 0
@@ -679,23 +679,6 @@ Page {
         text: qsTr("Remove dataset")
         onTriggered: {
           platformUtilities.removeDataset(itemMenu.itemPath);
-          table.model.resetToPath(table.model.currentPath);
-        }
-      }
-
-      MenuItem {
-        id: removeProjectFolder
-        enabled: itemMenu.itemMetaType == LocalFilesModel.Folder && !qfieldLocalDataPickerScreen.projectFolderView && table.model.isDeletedAllowedInCurrentPath
-        visible: enabled
-
-        font: Theme.defaultFont
-        width: parent.width
-        height: enabled ? 48 : 0
-        leftPadding: Theme.menuItemLeftPadding
-
-        text: qsTr("Remove folder")
-        onTriggered: {
-          platformUtilities.removeFolder(itemMenu.itemPath);
           table.model.resetToPath(table.model.currentPath);
         }
       }


### PR DESCRIPTION
### 🚀 Description
The original **Delete file** action was upgraded in #7397 to cover both files and folders (becoming **Delete folder** / **Delete file**), but the older folder-only **Remove folder** action was never cleaned up, so both ended up in the menu. This PR fix this issue.

### Issue: 
<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/1329ee3d-c6c9-4ffb-b238-07b171d25baa" />
