### PR TITLE
Avoid crash when processing camera activity result

### DIFF
--- a/platform/android/src/ch/opengis/qfield/QFieldActivity.java
+++ b/platform/android/src/ch/opengis/qfield/QFieldActivity.java
@@ -1351,7 +1351,7 @@ public class QFieldActivity extends QtActivity {
     protected void onActivityResult(int requestCode, int resultCode,
                                     Intent data) {
         if (requestCode == CAMERA_RESOURCE) {
-            if (resultCode == RESULT_OK) {
+            if (resultCode == RESULT_OK && resourceTempFilePath != null) {
                 File file = new File(resourceTempFilePath);
                 String finalFilePath = QFieldUtils.replaceFilenameTags(
                     resourceFilePath, file.getName());


### PR DESCRIPTION
Fixes the following stack trace on Android:

```
Exception java.lang.RuntimeException:
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:4439)
  at android.app.ActivityThread.handleResumeActivity (ActivityThread.java:4471)
  at android.app.servertransaction.ResumeActivityItem.execute (ResumeActivityItem.java:52)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleState (TransactionExecutor.java:176)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:97)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2067)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:223)
  at android.app.ActivityThread.main (ActivityThread.java:7705)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:592)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:964)
Caused by java.lang.RuntimeException:
  at android.app.ActivityThread.deliverResults (ActivityThread.java:5014)
  at android.app.ActivityThread.performResumeActivity (ActivityThread.java:4426)
Caused by java.lang.NullPointerException:
  at java.io.File.<init> (File.java:283)
  at ch.opengis.qfield.QFieldActivity.onActivityResult (QFieldActivity.java:1355)
  at android.app.Activity.dispatchActivityResult (Activity.java:8304)
  at android.app.ActivityThread.deliverResults (ActivityThread.java:5007)
```