### PR TITLE
[3D] Add extrusion support

### DIFF
--- a/src/core/3d/quick3dgeometry.cpp
+++ b/src/core/3d/quick3dgeometry.cpp
@@ -161,6 +161,20 @@ void Quick3DGeometry::setAltitudeClamping( AltitudeClamping clamping )
   updateGeometry();
 }
 
+void Quick3DGeometry::setExtrusionHeight( float height )
+{
+  height = std::max( 0.0f, height );
+  if ( qFuzzyCompare( mExtrusionHeight, height ) )
+  {
+    return;
+  }
+
+  mExtrusionHeight = height;
+  mDirty = true;
+  emit extrusionHeightChanged();
+  updateGeometry();
+}
+
 void Quick3DGeometry::markDirtyAndUpdate()
 {
   mDirty = true;
@@ -426,6 +440,11 @@ void Quick3DGeometry::updateGeometry()
       }
       totalFillVertices += ringSize;
       totalFillIndices += ( ringSize - 2 ) * 3;
+      if ( mExtrusionHeight > 0.0f )
+      {
+        totalFillVertices += Quick3DGeometryUtils::polygonWallsVertexCount( ringSize );
+        totalFillIndices += Quick3DGeometryUtils::polygonWallsIndexCount( ringSize );
+      }
     }
   }
 
@@ -465,7 +484,12 @@ void Quick3DGeometry::updateGeometry()
     {
       if ( path.size() >= 3 )
       {
-        Quick3DGeometryUtils::generatePolygonFill( path, r, g, b, fillAlpha, vptr, iptr, vertexOffset, minBound, maxBound );
+        if ( mExtrusionHeight > 0.0f )
+        {
+          Quick3DGeometryUtils::generatePolygonWalls( path, mExtrusionHeight, r, g, b, a, vptr, iptr, vertexOffset, minBound, maxBound );
+        }
+        const float capAlpha = mExtrusionHeight > 0.0f ? a : fillAlpha;
+        Quick3DGeometryUtils::generatePolygonFill( path, r, g, b, capAlpha, vptr, iptr, vertexOffset, minBound, maxBound, mExtrusionHeight );
       }
     }
   }

--- a/src/core/3d/quick3dgeometry.cpp
+++ b/src/core/3d/quick3dgeometry.cpp
@@ -161,17 +161,17 @@ void Quick3DGeometry::setAltitudeClamping( AltitudeClamping clamping )
   updateGeometry();
 }
 
-void Quick3DGeometry::setExtrusionHeight( float height )
+void Quick3DGeometry::setExtrusion( float extrusion )
 {
-  height = std::max( 0.0f, height );
-  if ( qFuzzyCompare( mExtrusionHeight, height ) )
+  extrusion = std::max( 0.0f, extrusion );
+  if ( qFuzzyCompare( mExtrusion, extrusion ) )
   {
     return;
   }
 
-  mExtrusionHeight = height;
+  mExtrusion = extrusion;
   mDirty = true;
-  emit extrusionHeightChanged();
+  emit extrusionChanged();
   updateGeometry();
 }
 
@@ -440,7 +440,7 @@ void Quick3DGeometry::updateGeometry()
       }
       totalFillVertices += ringSize;
       totalFillIndices += ( ringSize - 2 ) * 3;
-      if ( mExtrusionHeight > 0.0f )
+      if ( mExtrusion > 0.0f )
       {
         totalFillVertices += Quick3DGeometryUtils::polygonWallsVertexCount( ringSize );
         totalFillIndices += Quick3DGeometryUtils::polygonWallsIndexCount( ringSize );
@@ -484,12 +484,12 @@ void Quick3DGeometry::updateGeometry()
     {
       if ( path.size() >= 3 )
       {
-        if ( mExtrusionHeight > 0.0f )
+        if ( mExtrusion > 0.0f )
         {
-          Quick3DGeometryUtils::generatePolygonWalls( path, mExtrusionHeight, r, g, b, a, vptr, iptr, vertexOffset, minBound, maxBound );
+          Quick3DGeometryUtils::generatePolygonWalls( path, mExtrusion, r, g, b, a, vptr, iptr, vertexOffset, minBound, maxBound );
         }
-        const float capAlpha = mExtrusionHeight > 0.0f ? a : fillAlpha;
-        Quick3DGeometryUtils::generatePolygonFill( path, r, g, b, capAlpha, vptr, iptr, vertexOffset, minBound, maxBound, mExtrusionHeight );
+        const float capAlpha = mExtrusion > 0.0f ? a : fillAlpha;
+        Quick3DGeometryUtils::generatePolygonFill( path, r, g, b, capAlpha, vptr, iptr, vertexOffset, minBound, maxBound, mExtrusion );
       }
     }
   }

--- a/src/core/3d/quick3dgeometry.h
+++ b/src/core/3d/quick3dgeometry.h
@@ -73,8 +73,8 @@ class Quick3DGeometry : public QQuick3DGeometry
     Q_PROPERTY( bool fillPolygons READ fillPolygons WRITE setFillPolygons NOTIFY fillPolygonsChanged )
     //! How the geometry's Z values are combined with the terrain elevation
     Q_PROPERTY( AltitudeClamping altitudeClamping READ altitudeClamping WRITE setAltitudeClamping NOTIFY altitudeClampingChanged )
-    //! Extrusion height in scene units; when > 0, polygons are rendered as volumetric solids with walls and a roof cap
-    Q_PROPERTY( float extrusionHeight READ extrusionHeight WRITE setExtrusionHeight NOTIFY extrusionHeightChanged )
+    //! Extrusion in scene units; when > 0, polygons are rendered as volumetric solids with walls and a roof cap
+    Q_PROPERTY( float extrusion READ extrusion WRITE setExtrusion NOTIFY extrusionChanged )
 
   public:
     explicit Quick3DGeometry( QQuick3DObject *parent = nullptr );
@@ -103,8 +103,8 @@ class Quick3DGeometry : public QQuick3DGeometry
     AltitudeClamping altitudeClamping() const { return mAltitudeClamping; }
     void setAltitudeClamping( AltitudeClamping clamping );
 
-    float extrusionHeight() const { return mExtrusionHeight; }
-    void setExtrusionHeight( float height );
+    float extrusion() const { return mExtrusion; }
+    void setExtrusion( float extrusion );
 
   signals:
     void qgsGeometryChanged();
@@ -115,7 +115,7 @@ class Quick3DGeometry : public QQuick3DGeometry
     void heightOffsetChanged();
     void fillPolygonsChanged();
     void altitudeClampingChanged();
-    void extrusionHeightChanged();
+    void extrusionChanged();
 
   private slots:
     void markDirtyAndUpdate();
@@ -145,7 +145,7 @@ class Quick3DGeometry : public QQuick3DGeometry
 
     float mLineWidth = 3.0f;
     float mHeightOffset = 15.0f;
-    float mExtrusionHeight = 0.0f;
+    float mExtrusion = 0.0f;
     bool mFillPolygons = true;
     bool mDirty = true;
     AltitudeClamping mAltitudeClamping = AltitudeClamping::Ignore;

--- a/src/core/3d/quick3dgeometry.h
+++ b/src/core/3d/quick3dgeometry.h
@@ -73,6 +73,8 @@ class Quick3DGeometry : public QQuick3DGeometry
     Q_PROPERTY( bool fillPolygons READ fillPolygons WRITE setFillPolygons NOTIFY fillPolygonsChanged )
     //! How the geometry's Z values are combined with the terrain elevation
     Q_PROPERTY( AltitudeClamping altitudeClamping READ altitudeClamping WRITE setAltitudeClamping NOTIFY altitudeClampingChanged )
+    //! Extrusion height in scene units; when > 0, polygons are rendered as volumetric solids with walls and a roof cap
+    Q_PROPERTY( float extrusionHeight READ extrusionHeight WRITE setExtrusionHeight NOTIFY extrusionHeightChanged )
 
   public:
     explicit Quick3DGeometry( QQuick3DObject *parent = nullptr );
@@ -101,6 +103,9 @@ class Quick3DGeometry : public QQuick3DGeometry
     AltitudeClamping altitudeClamping() const { return mAltitudeClamping; }
     void setAltitudeClamping( AltitudeClamping clamping );
 
+    float extrusionHeight() const { return mExtrusionHeight; }
+    void setExtrusionHeight( float height );
+
   signals:
     void qgsGeometryChanged();
     void crsChanged();
@@ -110,6 +115,7 @@ class Quick3DGeometry : public QQuick3DGeometry
     void heightOffsetChanged();
     void fillPolygonsChanged();
     void altitudeClampingChanged();
+    void extrusionHeightChanged();
 
   private slots:
     void markDirtyAndUpdate();
@@ -139,6 +145,7 @@ class Quick3DGeometry : public QQuick3DGeometry
 
     float mLineWidth = 3.0f;
     float mHeightOffset = 15.0f;
+    float mExtrusionHeight = 0.0f;
     bool mFillPolygons = true;
     bool mDirty = true;
     AltitudeClamping mAltitudeClamping = AltitudeClamping::Ignore;

--- a/src/core/3d/quick3dgeometryutils.cpp
+++ b/src/core/3d/quick3dgeometryutils.cpp
@@ -215,11 +215,15 @@ void Quick3DGeometryUtils::generatePolygonWalls( const QVector<QVector3D> &verti
 {
   QVector<QVector3D> ring = vertices;
   if ( ring.size() > 3 && ( ring.first() - ring.last() ).length() < 0.001f )
+  {
     ring.removeLast();
+  }
 
   const int n = ring.size();
   if ( n < 2 )
+  {
     return;
+  }
 
   for ( int i = 0; i < n; ++i )
   {

--- a/src/core/3d/quick3dgeometryutils.cpp
+++ b/src/core/3d/quick3dgeometryutils.cpp
@@ -207,7 +207,7 @@ bool Quick3DGeometryUtils::polygonIsEar( const QVector<QVector3D> &ring, const Q
 }
 
 void Quick3DGeometryUtils::generatePolygonWalls( const QVector<QVector3D> &vertices,
-                                                 float extrusionHeight,
+                                                 float extrusion,
                                                  float r, float g, float b, float a,
                                                  float *&vptr, quint32 *&iptr,
                                                  quint32 &vertexOffset,
@@ -229,8 +229,8 @@ void Quick3DGeometryUtils::generatePolygonWalls( const QVector<QVector3D> &verti
   {
     const QVector3D &edgeStart = ring[i];
     const QVector3D &edgeEnd = ring[( i + 1 ) % n];
-    const QVector3D edgeStartTop = edgeStart + QVector3D( 0, extrusionHeight, 0 );
-    const QVector3D edgeEndTop = edgeEnd + QVector3D( 0, extrusionHeight, 0 );
+    const QVector3D edgeStartTop = edgeStart + QVector3D( 0, extrusion, 0 );
+    const QVector3D edgeEndTop = edgeEnd + QVector3D( 0, extrusion, 0 );
 
     const float dx = edgeEnd.x() - edgeStart.x();
     const float dz = edgeEnd.z() - edgeStart.z();
@@ -263,7 +263,7 @@ void Quick3DGeometryUtils::generatePolygonFill( const QVector<QVector3D> &vertic
                                                 float *&vptr, quint32 *&iptr,
                                                 quint32 &vertexOffset,
                                                 QVector3D &minBound, QVector3D &maxBound,
-                                                float extrusionHeight )
+                                                float extrusion )
 {
   QVector<QVector3D> ring = vertices;
   if ( ring.size() > 3 && ( ring.first() - ring.last() ).length() < 0.001f )
@@ -279,7 +279,7 @@ void Quick3DGeometryUtils::generatePolygonFill( const QVector<QVector3D> &vertic
 
   const quint32 baseVertex = vertexOffset;
   const QVector3D upNormal( 0.0f, 1.0f, 0.0f );
-  const QVector3D lift( 0.0f, extrusionHeight, 0.0f );
+  const QVector3D lift( 0.0f, extrusion, 0.0f );
 
   for ( int i = 0; i < n; ++i )
   {

--- a/src/core/3d/quick3dgeometryutils.cpp
+++ b/src/core/3d/quick3dgeometryutils.cpp
@@ -206,11 +206,60 @@ bool Quick3DGeometryUtils::polygonIsEar( const QVector<QVector3D> &ring, const Q
   return true;
 }
 
+void Quick3DGeometryUtils::generatePolygonWalls( const QVector<QVector3D> &vertices,
+                                                 float extrusionHeight,
+                                                 float r, float g, float b, float a,
+                                                 float *&vptr, quint32 *&iptr,
+                                                 quint32 &vertexOffset,
+                                                 QVector3D &minBound, QVector3D &maxBound )
+{
+  QVector<QVector3D> ring = vertices;
+  if ( ring.size() > 3 && ( ring.first() - ring.last() ).length() < 0.001f )
+    ring.removeLast();
+
+  const int n = ring.size();
+  if ( n < 2 )
+    return;
+
+  for ( int i = 0; i < n; ++i )
+  {
+    const QVector3D &edgeStart = ring[i];
+    const QVector3D &edgeEnd = ring[( i + 1 ) % n];
+    const QVector3D edgeStartTop = edgeStart + QVector3D( 0, extrusionHeight, 0 );
+    const QVector3D edgeEndTop = edgeEnd + QVector3D( 0, extrusionHeight, 0 );
+
+    const float dx = edgeEnd.x() - edgeStart.x();
+    const float dz = edgeEnd.z() - edgeStart.z();
+    const float len = std::sqrt( dx * dx + dz * dz );
+    const QVector3D normal = len > 1e-6f ? QVector3D( dz / len, 0.0f, -dx / len ) : QVector3D( 0.0f, 0.0f, 1.0f );
+
+    const quint32 base = vertexOffset;
+    // CCW winding seen from outside (outward normal): start, startTop, endTop, end
+    writeVertex( vptr, edgeStart, normal, r, g, b, a );
+    updateBounds( minBound, maxBound, edgeStart );
+    writeVertex( vptr, edgeStartTop, normal, r, g, b, a );
+    updateBounds( minBound, maxBound, edgeStartTop );
+    writeVertex( vptr, edgeEndTop, normal, r, g, b, a );
+    updateBounds( minBound, maxBound, edgeEndTop );
+    writeVertex( vptr, edgeEnd, normal, r, g, b, a );
+    updateBounds( minBound, maxBound, edgeEnd );
+    vertexOffset += 4;
+
+    *iptr++ = base + 0;
+    *iptr++ = base + 1;
+    *iptr++ = base + 2;
+    *iptr++ = base + 0;
+    *iptr++ = base + 2;
+    *iptr++ = base + 3;
+  }
+}
+
 void Quick3DGeometryUtils::generatePolygonFill( const QVector<QVector3D> &vertices,
                                                 float r, float g, float b, float a,
                                                 float *&vptr, quint32 *&iptr,
                                                 quint32 &vertexOffset,
-                                                QVector3D &minBound, QVector3D &maxBound )
+                                                QVector3D &minBound, QVector3D &maxBound,
+                                                float extrusionHeight )
 {
   QVector<QVector3D> ring = vertices;
   if ( ring.size() > 3 && ( ring.first() - ring.last() ).length() < 0.001f )
@@ -226,11 +275,13 @@ void Quick3DGeometryUtils::generatePolygonFill( const QVector<QVector3D> &vertic
 
   const quint32 baseVertex = vertexOffset;
   const QVector3D upNormal( 0.0f, 1.0f, 0.0f );
+  const QVector3D lift( 0.0f, extrusionHeight, 0.0f );
 
   for ( int i = 0; i < n; ++i )
   {
-    writeVertex( vptr, ring[i], upNormal, r, g, b, a );
-    updateBounds( minBound, maxBound, ring[i] );
+    const QVector3D pos = ring[i] + lift;
+    writeVertex( vptr, pos, upNormal, r, g, b, a );
+    updateBounds( minBound, maxBound, pos );
   }
   vertexOffset += n;
 

--- a/src/core/3d/quick3dgeometryutils.h
+++ b/src/core/3d/quick3dgeometryutils.h
@@ -70,7 +70,7 @@ class QFIELD_CORE_EXPORT Quick3DGeometryUtils
      * keeps degenerate or self-touching rings from leaving uninitialised
      * indices in the buffer).
      *
-     * When \a extrusionHeight is non-zero every fill vertex is shifted upward
+     * When \a extrusion is non-zero every fill vertex is shifted upward
      * by that amount so the fill becomes a roof cap on top of extruded walls.
      */
     static void generatePolygonFill( const QVector<QVector3D> &vertices,
@@ -78,15 +78,15 @@ class QFIELD_CORE_EXPORT Quick3DGeometryUtils
                                      float *&vptr, quint32 *&iptr,
                                      quint32 &vertexOffset,
                                      QVector3D &minBound, QVector3D &maxBound,
-                                     float extrusionHeight = 0.0f );
+                                     float extrusion = 0.0f );
 
     /**
      * Generates vertical wall quads for each edge of a closed polygon ring,
-     * extruding from the base vertices upward by \a extrusionHeight scene units.
+     * extruding from the base vertices upward by \a extrusion scene units.
      * Each edge produces 4 vertices and 2 triangles (6 indices).
      */
     static void generatePolygonWalls( const QVector<QVector3D> &vertices,
-                                      float extrusionHeight,
+                                      float extrusion,
                                       float r, float g, float b, float a,
                                       float *&vptr, quint32 *&iptr,
                                       quint32 &vertexOffset,

--- a/src/core/3d/quick3dgeometryutils.h
+++ b/src/core/3d/quick3dgeometryutils.h
@@ -69,12 +69,34 @@ class QFIELD_CORE_EXPORT Quick3DGeometryUtils
      * fan from vertex 0 when ear clipping cannot make further progress (which
      * keeps degenerate or self-touching rings from leaving uninitialised
      * indices in the buffer).
+     *
+     * When \a extrusionHeight is non-zero every fill vertex is shifted upward
+     * by that amount so the fill becomes a roof cap on top of extruded walls.
      */
     static void generatePolygonFill( const QVector<QVector3D> &vertices,
                                      float r, float g, float b, float a,
                                      float *&vptr, quint32 *&iptr,
                                      quint32 &vertexOffset,
-                                     QVector3D &minBound, QVector3D &maxBound );
+                                     QVector3D &minBound, QVector3D &maxBound,
+                                     float extrusionHeight = 0.0f );
+
+    /**
+     * Generates vertical wall quads for each edge of a closed polygon ring,
+     * extruding from the base vertices upward by \a extrusionHeight scene units.
+     * Each edge produces 4 vertices and 2 triangles (6 indices).
+     */
+    static void generatePolygonWalls( const QVector<QVector3D> &vertices,
+                                      float extrusionHeight,
+                                      float r, float g, float b, float a,
+                                      float *&vptr, quint32 *&iptr,
+                                      quint32 &vertexOffset,
+                                      QVector3D &minBound, QVector3D &maxBound );
+
+    //! Returns the number of vertices produced by generatePolygonWalls() for a ring with \a ringSize unique vertices.
+    static int polygonWallsVertexCount( int ringSize ) { return ringSize * 4; }
+
+    //! Returns the number of indices produced by generatePolygonWalls() for a ring with \a ringSize unique vertices.
+    static int polygonWallsIndexCount( int ringSize ) { return ringSize * 6; }
 
   private:
     //! Returns true if the triangle ( prev, cur, next ) of \a indices is an ear of \a ring on the XZ plane.

--- a/src/core/3d/quick3dterrainprovider.cpp
+++ b/src/core/3d/quick3dterrainprovider.cpp
@@ -387,6 +387,27 @@ void Quick3DTerrainProvider::calcNormalizedData()
       delete terrainProvider;
     }
 
+    // Reject gross low outliers (DEM spikes) as missing so they don't drag the height range down.
+    const double outlierFence = Quick3DTerrainProvider::lowerOutlierFence( heights, 3.0 );
+    lowestHeight = std::numeric_limits<double>::max();
+    for ( int index = 0; index < heights.size(); ++index )
+    {
+      double &height = heights[index];
+      if ( std::isnan( height ) )
+      {
+        continue;
+      }
+      if ( height < outlierFence )
+      {
+        height = std::numeric_limits<double>::quiet_NaN();
+        missingValueIndexes << index;
+      }
+      else if ( lowestHeight > height )
+      {
+        lowestHeight = height;
+      }
+    }
+
     if ( !missingValueIndexes.isEmpty() )
     {
       if ( lowestHeight == std::numeric_limits<double>::max() )
@@ -405,6 +426,25 @@ void Quick3DTerrainProvider::calcNormalizedData()
 
   mFutureExtent = mExtent;
   mFutureWatcher->setFuture( future );
+}
+
+double Quick3DTerrainProvider::lowerOutlierFence( QVector<double> samples, double factor )
+{
+  samples.erase( std::remove_if( samples.begin(), samples.end(), []( double value ) { return std::isnan( value ); } ), samples.end() );
+  if ( samples.size() < 8 )
+  {
+    return std::numeric_limits<double>::lowest();
+  }
+
+  const auto quantileValue = [&samples]( double quantile ) {
+    const int index = qBound( 0, static_cast<int>( quantile * ( samples.size() - 1 ) ), static_cast<int>( samples.size() ) - 1 );
+    std::nth_element( samples.begin(), samples.begin() + index, samples.end() );
+    return samples[index];
+  };
+
+  const double firstQuartile = quantileValue( 0.25 );
+  const double thirdQuartile = quantileValue( 0.75 );
+  return firstQuartile - factor * ( thirdQuartile - firstQuartile );
 }
 
 double Quick3DTerrainProvider::sampleHeightFromTerrainProvider( double x, double y ) const

--- a/src/core/3d/quick3dterrainprovider.h
+++ b/src/core/3d/quick3dterrainprovider.h
@@ -206,6 +206,9 @@ class Quick3DTerrainProvider : public QObject
     void onTerrainDataCalculated();
     double sampleHeightFromTerrainProvider( double x, double y ) const;
 
+    //! Returns the Tukey lower fence ( Q1 - factor * IQR ) for the samples; heights below it are gross DEM spikes.
+    static double lowerOutlierFence( QVector<double> samples, double factor );
+
   private:
     QgsProject *mProject = nullptr;
     QgsQuickMapSettings *mMapSettings = nullptr;

--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -63,6 +63,7 @@ class MultiFeatureListModel : public QSortFilterProxyModel
       ConditionalFontItalicRole,
       ConditionalFontUnderlineRole,
       ConditionalFontStrikeOutRole,
+      ExtrusionHeightRole,
     };
 
     explicit MultiFeatureListModel( QObject *parent = nullptr );

--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -63,7 +63,7 @@ class MultiFeatureListModel : public QSortFilterProxyModel
       ConditionalFontItalicRole,
       ConditionalFontUnderlineRole,
       ConditionalFontStrikeOutRole,
-      ExtrusionHeightRole,
+      ExtrusionRole,
     };
 
     explicit MultiFeatureListModel( QObject *parent = nullptr );

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -470,9 +470,14 @@ QVariant MultiFeatureListModelBase::data( const QModelIndex &index, int role ) c
 
     case MultiFeatureListModel::ExtrusionHeightRole:
     {
-      const QString heightField = LayerUtils::guessFriendlyHeightField( vlayer );
-      if ( !heightField.isEmpty() )
-        return feature->second.attribute( heightField ).toDouble();
+      if ( vlayer )
+      {
+        const QString heightField = LayerUtils::guessFriendlyHeightField( vlayer );
+        if ( !heightField.isEmpty() )
+        {
+          return feature->second.attribute( heightField ).toDouble();
+        }
+      }
       return 0.0;
     }
   }

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -288,6 +288,7 @@ QHash<int, QByteArray> MultiFeatureListModelBase::roleNames() const
   roleNames[MultiFeatureListModel::ConditionalFontStrikeOutRole] = "conditionalFontStrikeOut";
   roleNames[MultiFeatureListModel::ConditionalFontItalicRole] = "conditionalFontItalic";
   roleNames[MultiFeatureListModel::ConditionalFontBoldRole] = "conditionalFontBold";
+  roleNames[MultiFeatureListModel::ExtrusionHeightRole] = "extrusionHeight";
 
   return roleNames;
 }
@@ -466,6 +467,14 @@ QVariant MultiFeatureListModelBase::data( const QModelIndex &index, int role ) c
 
       return false;
       break;
+
+    case MultiFeatureListModel::ExtrusionHeightRole:
+    {
+      const QString heightField = LayerUtils::guessFriendlyHeightField( vlayer );
+      if ( !heightField.isEmpty() )
+        return feature->second.attribute( heightField ).toDouble();
+      return 0.0;
+    }
   }
 
   return QVariant();

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -288,7 +288,7 @@ QHash<int, QByteArray> MultiFeatureListModelBase::roleNames() const
   roleNames[MultiFeatureListModel::ConditionalFontStrikeOutRole] = "conditionalFontStrikeOut";
   roleNames[MultiFeatureListModel::ConditionalFontItalicRole] = "conditionalFontItalic";
   roleNames[MultiFeatureListModel::ConditionalFontBoldRole] = "conditionalFontBold";
-  roleNames[MultiFeatureListModel::ExtrusionHeightRole] = "extrusionHeight";
+  roleNames[MultiFeatureListModel::ExtrusionRole] = "extrusion";
 
   return roleNames;
 }
@@ -468,7 +468,7 @@ QVariant MultiFeatureListModelBase::data( const QModelIndex &index, int role ) c
       return false;
       break;
 
-    case MultiFeatureListModel::ExtrusionHeightRole:
+    case MultiFeatureListModel::ExtrusionRole:
     {
       if ( vlayer )
       {

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -551,6 +551,45 @@ bool LayerUtils::hasMValue( QgsVectorLayer *layer )
   return QgsWkbTypes::hasM( layer->wkbType() );
 }
 
+QString LayerUtils::guessFriendlyHeightField( QgsVectorLayer *layer )
+{
+  if ( !layer )
+    return QString();
+
+  const QgsFields fields = layer->fields();
+  if ( fields.isEmpty() )
+    return QString();
+
+  static const QStringList sCandidates {
+    QStringLiteral( "extrusion" ),
+    QStringLiteral( "height" ),
+  };
+
+  QString bestPartialMatch;
+  for ( const QString &candidate : sCandidates )
+  {
+    for ( const QgsField &field : fields )
+    {
+      if ( !field.isNumeric() )
+      {
+        continue;
+      }
+
+      const QString fieldName = field.name();
+      if ( fieldName.compare( candidate, Qt::CaseInsensitive ) == 0 )
+      {
+        return fieldName;
+      }
+      if ( bestPartialMatch.isEmpty() && fieldName.contains( candidate, Qt::CaseInsensitive ) )
+      {
+        bestPartialMatch = fieldName;
+      }
+    }
+  }
+
+  return bestPartialMatch;
+}
+
 QSet<QVariant> LayerUtils::uniqueValuesForVectorLayerFieldIndex( QgsVectorLayer *layer, int fieldIndex )
 {
   if ( !layer )

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -39,6 +39,7 @@
 #include <qgsrasterlayer.h>
 #include <qgsrasterlayerelevationproperties.h>
 #include <qgssinglesymbolrenderer.h>
+#include <qgsstringutils.h>
 #include <qgssymbol.h>
 #include <qgssymbollayer.h>
 #include <qgstextbuffersettings.h>
@@ -568,10 +569,9 @@ QString LayerUtils::guessFriendlyHeightField( QgsVectorLayer *layer )
     QStringLiteral( "extrusion" ),
     QStringLiteral( "height" ),
     QStringLiteral( "hauteur" ), // French (height)
-    QStringLiteral( "hoehe" ),   // German (height)
+    QStringLiteral( "hohe" ),    // German (height)
   };
 
-  QString bestPartialMatch;
   for ( const QString &candidate : sCandidates )
   {
     for ( const QgsField &field : fields )
@@ -582,18 +582,14 @@ QString LayerUtils::guessFriendlyHeightField( QgsVectorLayer *layer )
       }
 
       const QString fieldName = field.name();
-      if ( fieldName.compare( candidate, Qt::CaseInsensitive ) == 0 )
+      if ( QgsStringUtils::unaccent( fieldName ).contains( candidate, Qt::CaseInsensitive ) )
       {
         return fieldName;
-      }
-      if ( bestPartialMatch.isEmpty() && fieldName.contains( candidate, Qt::CaseInsensitive ) )
-      {
-        bestPartialMatch = fieldName;
       }
     }
   }
 
-  return bestPartialMatch;
+  return QString();
 }
 
 QSet<QVariant> LayerUtils::uniqueValuesForVectorLayerFieldIndex( QgsVectorLayer *layer, int fieldIndex )

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -567,6 +567,8 @@ QString LayerUtils::guessFriendlyHeightField( QgsVectorLayer *layer )
   static const QStringList sCandidates {
     QStringLiteral( "extrusion" ),
     QStringLiteral( "height" ),
+    QStringLiteral( "hauteur" ), // French (height)
+    QStringLiteral( "hoehe" ),   // German (height)
   };
 
   QString bestPartialMatch;

--- a/src/core/utils/layerutils.cpp
+++ b/src/core/utils/layerutils.cpp
@@ -554,11 +554,15 @@ bool LayerUtils::hasMValue( QgsVectorLayer *layer )
 QString LayerUtils::guessFriendlyHeightField( QgsVectorLayer *layer )
 {
   if ( !layer )
+  {
     return QString();
+  }
 
   const QgsFields fields = layer->fields();
   if ( fields.isEmpty() )
+  {
     return QString();
+  }
 
   static const QStringList sCandidates {
     QStringLiteral( "extrusion" ),

--- a/src/core/utils/layerutils.h
+++ b/src/core/utils/layerutils.h
@@ -181,6 +181,12 @@ class LayerUtils : public QObject
     Q_INVOKABLE static bool hasMValue( QgsVectorLayer *layer );
 
     /**
+     * Guesses the name of the field in \a layer most likely to carry a per-feature
+     * height/extrusion value, or an empty string when no suitable field is found.
+     */
+    Q_INVOKABLE static QString guessFriendlyHeightField( QgsVectorLayer *layer );
+
+    /**
      * Returns a list of unique values for a given \a fieldIndex from the \a layer.
      */
     Q_INVOKABLE QSet<QVariant> uniqueValuesForVectorLayerFieldIndex( QgsVectorLayer *layer, int fieldIndex );

--- a/src/qml/3d/FeatureListSelectionHighlight3D.qml
+++ b/src/qml/3d/FeatureListSelectionHighlight3D.qml
@@ -37,6 +37,7 @@ Node {
           lineWidth: featureListSelectionHighlight3D.lineWidth
           heightOffset: featureListSelectionHighlight3D.heightOffset
           altitudeClamping: featureListSelectionHighlight3D.altitudeClamping
+          extrusionHeight: model.extrusionHeight
           color: model.featureSelected ? featureListSelectionHighlight3D.selectedColor : featureListSelectionHighlight3D.selectionModel.model.selectedCount === 0 && index === featureListSelectionHighlight3D.selectionModel.focusedItem ? featureListSelectionHighlight3D.focusedColor : featureListSelectionHighlight3D.color
         }
 
@@ -46,7 +47,8 @@ Node {
             metalness: 0.0
             roughness: 1.0
             vertexColorsEnabled: true
-            alphaMode: PrincipledMaterial.Blend
+            alphaMode: model.extrusionHeight > 0 ? PrincipledMaterial.Opaque : PrincipledMaterial.Blend
+            depthDrawMode: Material.AlwaysDepthDraw
             cullMode: PrincipledMaterial.NoCulling
           }
         ]

--- a/src/qml/3d/FeatureListSelectionHighlight3D.qml
+++ b/src/qml/3d/FeatureListSelectionHighlight3D.qml
@@ -37,7 +37,7 @@ Node {
           lineWidth: featureListSelectionHighlight3D.lineWidth
           heightOffset: featureListSelectionHighlight3D.heightOffset
           altitudeClamping: featureListSelectionHighlight3D.altitudeClamping
-          extrusionHeight: model.extrusionHeight
+          extrusion: model.extrusion
           color: model.featureSelected ? featureListSelectionHighlight3D.selectedColor : featureListSelectionHighlight3D.selectionModel.model.selectedCount === 0 && index === featureListSelectionHighlight3D.selectionModel.focusedItem ? featureListSelectionHighlight3D.focusedColor : featureListSelectionHighlight3D.color
         }
 
@@ -47,7 +47,7 @@ Node {
             metalness: 0.0
             roughness: 1.0
             vertexColorsEnabled: true
-            alphaMode: model.extrusionHeight > 0 ? PrincipledMaterial.Opaque : PrincipledMaterial.Blend
+            alphaMode: model.extrusion > 0 ? PrincipledMaterial.Opaque : PrincipledMaterial.Blend
             depthDrawMode: Material.AlwaysDepthDraw
             cullMode: PrincipledMaterial.NoCulling
           }


### PR DESCRIPTION
### 🚀 Description

Adds optional polygon extrusion to the 3D feature selection highlight. When a selected polygon's layer carries a height attribute, the highlight is rendered as a volumetric solid (vertical walls + a roof cap) instead of a flat fill, with
the height taken per-feature from that attribute. 


<img width="810" height="274" alt="image" src="https://github.com/user-attachments/assets/82e8c156-d4cb-4f79-b8a4-d8e4da89b9a2" />



### ✨ Key Changes

- **Quick3DGeometryUtils**: add `generatePolygonWalls()`.
- **Quick3DGeometry**: new `extrusionHeight` property.
- **MultiFeatureListModel / LayerUtils** : new `extrusionHeight` model role, backed by `LayerUtils::guessFriendlyHeightField()`.

### ℹ️ How the extrusion height is determined

`LayerUtils::guessFriendlyHeightField()` scans the layer's numeric fields for a name matching candidate list (`extrusion`, `height`). The model role returns that field's value for each feature. When no suitable field exists it returns 0, so polygons keep rendering flat exactly as before.

### 🐛 A bug Fix:  Terrain sampling (independent fix in this branch)

`Quick3DTerrainProvider` now rejects gross low DEM outliers: extreme low samples are marked as missing so isolated DEMspikes no longer drag down the computed height range.


### Demo



https://github.com/user-attachments/assets/acdc649d-5f1d-4063-a3c6-ad87fd71f955

