### PR TITLE
Simplify geometry to match the map canvas MUPP

### DIFF
--- a/src/core/linepolygonshape.cpp
+++ b/src/core/linepolygonshape.cpp
@@ -39,6 +39,8 @@ void LinePolygonShape::createPolylines()
   mPolylines.clear();
 
   QgsGeometry geometry( mGeometry ? mGeometry->qgsGeometry() : QgsGeometry() );
+  geometry = geometry.simplify( mMapSettings->mapUnitsPerPoint() );
+
   Qgis::GeometryType geomType = Qgis::GeometryType::Null;
   if ( mGeometry && !geometry.isEmpty() && geometry.type() != Qgis::GeometryType::Point )
   {


### PR DESCRIPTION
Objective here is to try and see if it has a positive impact on qTriangulate crashes (a top crasher).