### PR TITLE
[Backport release-4_2] Insure that the attachment / external resource editor widget UI state is properly reset when passing on null/empty value

### DIFF
--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -129,7 +129,6 @@ EditorWidgetBase {
       mediaFrame.height = 200;
 
       image.visible = true;
-      image.hasImage = true;
       image.opacity = 1;
       image.anchors.topMargin = 0;
       image.source = UrlUtils.fromString(fullValue);
@@ -312,13 +311,10 @@ EditorWidgetBase {
     Image {
       id: image
 
-      property bool hasImage: false
-
-      visible: isImage
-      enabled: isImage
+      visible: false
       anchors.centerIn: parent
-      width: hasImage ? parent.width : 24
-      height: hasImage ? parent.height : 24
+      width: isImage ? parent.width : 24
+      height: isImage ? parent.height : 24
       opacity: 0.25
       autoTransform: true
       fillMode: Image.PreserveAspectFit

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -114,48 +114,69 @@ EditorWidgetBase {
   property string audioSourcePath: ''
 
   function prepareValue(fullValue) {
-    if (fullValue !== "") {
+    if (fullValue != "" && !config.UseLink) { // coercion needed
       const mimeType = FileUtils.mimeTypeName(fullValue);
-      isImage = !config.UseLink && mimeType.startsWith("image/") && FileUtils.isImageMimeTypeSupported(mimeType);
-      isAudio = !config.UseLink && mimeType.startsWith("audio/");
-      isVideo = !config.UseLink && mimeType.startsWith("video/");
-      image.visible = isImage;
-      geoTagBadge.visible = isImage;
-
-      if (isImage) {
-        mediaFrame.height = 200;
-        image.visible = true;
-        image.hasImage = true;
-        image.opacity = 1;
-        image.anchors.topMargin = 0;
-        image.source = UrlUtils.fromString(fullValue);
-        geoTagBadge.hasGeoTag = ExifTools.hasGeoTag(fullValue);
-        audioSourcePath = '';
-      } else if (isAudio) {
-        mediaFrame.height = 148;
-        image.visible = false;
-        image.opacity = 0.5;
-        image.source = '';
-        audioSourcePath = fullValue;
-        player.firstFrameDrawn = false;
-        player.sourceUrl = UrlUtils.fromString(fullValue);
-        audioAnalyzer.analyze(player.sourceUrl);
-      } else if (isVideo) {
-        mediaFrame.height = 48;
-        image.visible = false;
-        image.opacity = 0.5;
-        image.source = '';
-        audioSourcePath = '';
-        player.firstFrameDrawn = false;
-        player.sourceUrl = UrlUtils.fromString(fullValue);
-      }
+      isImage = mimeType.startsWith("image/") && FileUtils.isImageMimeTypeSupported(mimeType);
+      isAudio = mimeType.startsWith("audio/");
+      isVideo = mimeType.startsWith("video/");
     } else {
+      isImage = false;
+      isAudio = false;
+      isVideo = false;
+    }
+
+    if (isImage) {
+      mediaFrame.height = 200;
+
+      image.visible = true;
+      image.hasImage = true;
+      image.opacity = 1;
+      image.anchors.topMargin = 0;
+      image.source = UrlUtils.fromString(fullValue);
+      geoTagBadge.visible = true;
+      geoTagBadge.hasGeoTag = ExifTools.hasGeoTag(fullValue);
+
+      player.sourceUrl = '';
+      player.firstFrameDrawn = false;
+
+      audioSourcePath = '';
+    } else if (isAudio) {
+      mediaFrame.height = 148;
+
+      image.visible = false;
+      image.opacity = 0.5;
+      image.source = '';
+      geoTagBadge.visible = false;
+
+      player.firstFrameDrawn = false;
+      player.sourceUrl = UrlUtils.fromString(fullValue);
+
+      audioSourcePath = fullValue;
+      audioAnalyzer.analyze(player.sourceUrl);
+    } else if (isVideo) {
+      mediaFrame.height = 48;
+
+      image.visible = false;
+      image.opacity = 0.5;
+      image.source = '';
+      geoTagBadge.visible = false;
+
+      player.firstFrameDrawn = false;
+      player.sourceUrl = UrlUtils.fromString(fullValue);
+
+      audioSourcePath = '';
+    } else {
+      mediaFrame.height = 48;
+
       image.source = '';
       image.visible = documentViewer == ExternalResource.DocumentImage;
       image.opacity = 0.15;
       geoTagBadge.visible = false;
-      audioSourcePath = '';
+
       player.sourceUrl = '';
+      player.firstFrameDrawn = false;
+
+      audioSourcePath = '';
     }
   }
 


### PR DESCRIPTION
Backport #7641
 **Authored by:** @nirvn