### PR TITLE
Always open OAuth2 login request in-app on Android and iOS

### DIFF
--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -5040,7 +5040,7 @@ ApplicationWindow {
       }
 
       function onShowLoginBrowser(url) {
-        if (qfieldAuthRequestHandler.isProjectLoading) {
+        if (qfieldAuthRequestHandler.isProjectLoading || Qt.platform.os === "ios" || Qt.platform.os === "android") {
           browserPopup.url = url;
           browserPopup.fullscreen = false;
           browserPopup.clearCookiesOnOpen = true;


### PR DESCRIPTION
Failing to do so means our HTTP server might not be reachable, breaking the workflow.