### PR TITLE
Add a bookmarkManager for listing with multi-select and actions

### DIFF
--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -214,8 +214,8 @@ void BookmarkModel::setHideProjectBookmarks( bool hideProjectBookmarks )
   if ( mHideProjectBookmarks == hideProjectBookmarks )
     return;
 
-  mHideProjectBookmarks = hideProjectBookmarks;
   beginFilterChange();
+  mHideProjectBookmarks = hideProjectBookmarks;
   endFilterChange();
 
   emit hideProjectBookmarksChanged();
@@ -245,11 +245,19 @@ void BookmarkModel::toggleSelected( const QString &id )
     return;
 
   if ( mSelectedIds.contains( id ) )
+  {
     mSelectedIds.remove( id );
+  }
   else
+  {
     mSelectedIds.insert( id );
+  }
 
-  emitSelectionChanged();
+  const int count = rowCount();
+  if ( count > 0 )
+  {
+    emit dataChanged( index( 0, 0 ), index( count - 1, 0 ), { BookmarkModel::BookmarkSelected } );
+  }
   emit selectedCountChanged();
 }
 
@@ -259,7 +267,12 @@ void BookmarkModel::clearSelection()
     return;
 
   mSelectedIds.clear();
-  emitSelectionChanged();
+
+  const int count = rowCount();
+  if ( count > 0 )
+  {
+    emit dataChanged( index( 0, 0 ), index( count - 1, 0 ), { BookmarkModel::BookmarkSelected } );
+  }
   emit selectedCountChanged();
 }
 
@@ -282,13 +295,6 @@ int BookmarkModel::deleteSelected()
   emit selectedCountChanged();
 
   return deleted;
-}
-
-void BookmarkModel::emitSelectionChanged()
-{
-  const int count = rowCount();
-  if ( count > 0 )
-    emit dataChanged( index( 0, 0 ), index( count - 1, 0 ), { BookmarkModel::BookmarkSelected } );
 }
 
 int BookmarkModel::groupRank( const QString &group ) const

--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -62,7 +62,13 @@ QVariant BookmarkModel::data( const QModelIndex &index, int role ) const
 
     case BookmarkModel::BookmarkUser:
     {
-      return mModel->data( mModel->index( sourceIndex.row(), QgsBookmarkManagerModel::ColumnStore ), Qt::CheckStateRole ).value<Qt::CheckState>() != Qt::Checked;
+      return isUserBookmark( sourceIndex.row() );
+    }
+
+    case BookmarkModel::BookmarkSelected:
+    {
+      const QString id = mModel->data( sourceIndex, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Id ) ).toString();
+      return mSelectedIds.contains( id );
     }
   }
 
@@ -78,13 +84,16 @@ QHash<int, QByteArray> BookmarkModel::roleNames() const
   roleNames[BookmarkModel::BookmarkPoint] = "BookmarkPoint";
   roleNames[BookmarkModel::BookmarkCrs] = "BookmarkCrs";
   roleNames[BookmarkModel::BookmarkUser] = "BookmarkUser";
+  roleNames[BookmarkModel::BookmarkSelected] = "BookmarkSelected";
   return roleNames;
 }
 
 void BookmarkModel::setMapSettings( QgsQuickMapSettings *mapSettings )
 {
   if ( mMapSettings == mapSettings )
+  {
     return;
+  }
 
   mMapSettings = mapSettings;
 
@@ -95,7 +104,9 @@ void BookmarkModel::setExtentFromBookmark( const QModelIndex &index )
 {
   QModelIndex sourceIndex = mapToSource( index );
   if ( !sourceIndex.isValid() || !mMapSettings )
+  {
     return;
+  }
 
   const QgsReferencedRectangle rect = mModel->data( sourceIndex, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Extent ) ).value<QgsReferencedRectangle>();
   QgsCoordinateTransform transform( rect.crs(), mMapSettings->destinationCrs(), QgsProject::instance()->transformContext() );
@@ -122,7 +133,9 @@ void BookmarkModel::setExtentFromBookmark( const QModelIndex &index )
 QString BookmarkModel::addBookmarkAtPoint( QgsPoint point, const QString &name, const QString &group )
 {
   if ( !mMapSettings )
+  {
     return QString();
+  }
 
   QgsRectangle extent = mMapSettings->extent();
   const QgsPointXY center = extent.center();
@@ -191,4 +204,166 @@ void BookmarkModel::store()
     doc.save( out, 2 );
     f.close();
   }
+}
+
+void BookmarkModel::setShowProjectOnly( bool showProjectOnly )
+{
+  if ( mShowProjectOnly == showProjectOnly )
+  {
+    return;
+  }
+
+  mShowProjectOnly = showProjectOnly;
+  beginFilterChange();
+  endFilterChange();
+
+  emit showProjectOnlyChanged();
+}
+
+bool BookmarkModel::isUserBookmark( int sourceRow ) const
+{
+  return mModel->data( mModel->index( sourceRow, QgsBookmarkManagerModel::ColumnStore ), Qt::CheckStateRole ).value<Qt::CheckState>() != Qt::Checked;
+}
+
+bool BookmarkModel::filterAcceptsRow( int sourceRow, const QModelIndex & ) const
+{
+  if ( !mShowProjectOnly )
+  {
+    return true;
+  }
+  return isUserBookmark( sourceRow );
+}
+
+void BookmarkModel::toggleSelected( const QString &id )
+{
+  if ( id.isEmpty() )
+  {
+    return;
+  }
+
+  if ( mSelectedIds.contains( id ) )
+  {
+    mSelectedIds.remove( id );
+  }
+  else
+  {
+    mSelectedIds.insert( id );
+  }
+
+  emitSelectionChanged();
+  emit selectedCountChanged();
+}
+
+void BookmarkModel::setSelected( const QString &id, bool selected )
+{
+  if ( id.isEmpty() )
+  {
+    return;
+  }
+
+  if ( selected == mSelectedIds.contains( id ) )
+  {
+    return;
+  }
+
+  if ( selected )
+  {
+    mSelectedIds.insert( id );
+  }
+  else
+  {
+    mSelectedIds.remove( id );
+  }
+
+  emitSelectionChanged();
+  emit selectedCountChanged();
+}
+
+void BookmarkModel::selectAll()
+{
+  const int count = rowCount();
+  bool changed = false;
+  for ( int row = 0; row < count; ++row )
+  {
+    const QString id = data( index( row, 0 ), BookmarkModel::BookmarkId ).toString();
+    if ( !id.isEmpty() && !mSelectedIds.contains( id ) )
+    {
+      mSelectedIds.insert( id );
+      changed = true;
+    }
+  }
+
+  if ( changed )
+  {
+    emitSelectionChanged();
+    emit selectedCountChanged();
+  }
+}
+
+void BookmarkModel::clearSelection()
+{
+  if ( mSelectedIds.isEmpty() )
+  {
+    return;
+  }
+
+  mSelectedIds.clear();
+  emitSelectionChanged();
+  emit selectedCountChanged();
+}
+
+void BookmarkModel::emitSelectionChanged()
+{
+  const int count = rowCount();
+  if ( count > 0 )
+  {
+    emit dataChanged( index( 0, 0 ), index( count - 1, 0 ), { BookmarkModel::BookmarkSelected } );
+  }
+}
+
+void BookmarkModel::setGroupByColor( bool groupByColor )
+{
+  if ( mGroupByColor == groupByColor )
+  {
+    return;
+  }
+
+  mGroupByColor = groupByColor;
+
+  if ( mGroupByColor )
+  {
+    setSortRole( BookmarkModel::BookmarkGroup );
+    sort( 0 );
+  }
+  else
+  {
+    // Restore the source model insertion order
+    sort( -1 );
+  }
+
+  emit groupByColorChanged();
+}
+
+int BookmarkModel::groupRank( const QString &group ) const
+{
+  if ( group == QLatin1String( "orange" ) )
+  {
+    return 1;
+  }
+  else if ( group == QLatin1String( "red" ) )
+  {
+    return 2;
+  }
+  else if ( group == QLatin1String( "blue" ) )
+  {
+    return 3;
+  }
+  return 0;
+}
+
+bool BookmarkModel::lessThan( const QModelIndex &sourceLeft, const QModelIndex &sourceRight ) const
+{
+  const QString leftGroup = mModel->data( sourceLeft, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Group ) ).toString();
+  const QString rightGroup = mModel->data( sourceRight, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Group ) ).toString();
+  return groupRank( leftGroup ) < groupRank( rightGroup );
 }

--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -22,6 +22,8 @@
 #include <qgsgeometry.h>
 #include <qgsproject.h>
 
+#include <algorithm>
+
 BookmarkModel::BookmarkModel( QgsBookmarkManager *manager, QgsBookmarkManager *projectManager, QObject *parent )
   : QSortFilterProxyModel( parent )
   , mModel( new QgsBookmarkManagerModel( manager, projectManager, this ) )
@@ -264,15 +266,10 @@ int BookmarkModel::deleteSelected()
     return 0;
   }
 
-  int deleted = 0;
   const QStringList ids( mSelectedIds.constBegin(), mSelectedIds.constEnd() );
-  for ( const QString &id : ids )
-  {
-    if ( mManager->removeBookmark( id ) )
-    {
-      ++deleted;
-    }
-  }
+  const int deleted = static_cast<int>( std::count_if( ids.constBegin(), ids.constEnd(), [this]( const QString &id ) {
+    return mManager->removeBookmark( id );
+  } ) );
 
   // Persist once after all removals rather than on every bookmark.
   store();

--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -283,8 +283,7 @@ int BookmarkModel::deleteSelected()
     return 0;
   }
 
-  const QStringList ids( mSelectedIds.constBegin(), mSelectedIds.constEnd() );
-  const int deleted = static_cast<int>( std::count_if( ids.constBegin(), ids.constEnd(), [this]( const QString &id ) {
+  const int deleted = static_cast<int>( std::count_if( mSelectedIds.constBegin(), mSelectedIds.constEnd(), [this]( const QString &id ) {
     return mManager->removeBookmark( id );
   } ) );
 

--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -209,16 +209,16 @@ void BookmarkModel::store()
   }
 }
 
-void BookmarkModel::setShowProjectOnly( bool showProjectOnly )
+void BookmarkModel::setHideProjectBookmarks( bool hideProjectBookmarks )
 {
-  if ( mShowProjectOnly == showProjectOnly )
+  if ( mHideProjectBookmarks == hideProjectBookmarks )
     return;
 
-  mShowProjectOnly = showProjectOnly;
+  mHideProjectBookmarks = hideProjectBookmarks;
   beginFilterChange();
   endFilterChange();
 
-  emit showProjectOnlyChanged();
+  emit hideProjectBookmarksChanged();
 }
 
 bool BookmarkModel::isUserBookmark( int sourceRow ) const
@@ -228,7 +228,7 @@ bool BookmarkModel::isUserBookmark( int sourceRow ) const
 
 bool BookmarkModel::filterAcceptsRow( int sourceRow, const QModelIndex & ) const
 {
-  if ( !mShowProjectOnly )
+  if ( !mHideProjectBookmarks )
     return true;
 
   // The drawer scopes the list to bookmarks created in QField (user bookmarks).
@@ -238,6 +238,10 @@ bool BookmarkModel::filterAcceptsRow( int sourceRow, const QModelIndex & ) const
 void BookmarkModel::toggleSelected( const QString &id )
 {
   if ( id.isEmpty() )
+    return;
+
+  // Only user bookmarks (those owned by the user manager) can be selected.
+  if ( mManager->bookmarkById( id ).id().isEmpty() )
     return;
 
   if ( mSelectedIds.contains( id ) )

--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -28,6 +28,10 @@ BookmarkModel::BookmarkModel( QgsBookmarkManager *manager, QgsBookmarkManager *p
   , mManager( manager )
 {
   setSourceModel( mModel.get() );
+
+  // Bookmarks are always grouped by color so the list can render color sections.
+  setSortRole( BookmarkModel::BookmarkGroup );
+  sort( 0 );
 }
 
 QVariant BookmarkModel::data( const QModelIndex &index, int role ) const
@@ -45,7 +49,10 @@ QVariant BookmarkModel::data( const QModelIndex &index, int role ) const
       return mModel->data( sourceIndex, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Name ) );
 
     case BookmarkModel::BookmarkGroup:
-      return mModel->data( sourceIndex, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Group ) );
+    {
+      const QString group = mModel->data( sourceIndex, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Group ) ).toString();
+      return group.isEmpty() ? QStringLiteral( "green" ) : group;
+    }
 
     case BookmarkModel::BookmarkPoint:
     {
@@ -91,9 +98,7 @@ QHash<int, QByteArray> BookmarkModel::roleNames() const
 void BookmarkModel::setMapSettings( QgsQuickMapSettings *mapSettings )
 {
   if ( mMapSettings == mapSettings )
-  {
     return;
-  }
 
   mMapSettings = mapSettings;
 
@@ -104,9 +109,7 @@ void BookmarkModel::setExtentFromBookmark( const QModelIndex &index )
 {
   QModelIndex sourceIndex = mapToSource( index );
   if ( !sourceIndex.isValid() || !mMapSettings )
-  {
     return;
-  }
 
   const QgsReferencedRectangle rect = mModel->data( sourceIndex, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Extent ) ).value<QgsReferencedRectangle>();
   QgsCoordinateTransform transform( rect.crs(), mMapSettings->destinationCrs(), QgsProject::instance()->transformContext() );
@@ -133,9 +136,7 @@ void BookmarkModel::setExtentFromBookmark( const QModelIndex &index )
 QString BookmarkModel::addBookmarkAtPoint( QgsPoint point, const QString &name, const QString &group )
 {
   if ( !mMapSettings )
-  {
     return QString();
-  }
 
   QgsRectangle extent = mMapSettings->extent();
   const QgsPointXY center = extent.center();
@@ -209,9 +210,7 @@ void BookmarkModel::store()
 void BookmarkModel::setShowProjectOnly( bool showProjectOnly )
 {
   if ( mShowProjectOnly == showProjectOnly )
-  {
     return;
-  }
 
   mShowProjectOnly = showProjectOnly;
   beginFilterChange();
@@ -228,120 +227,67 @@ bool BookmarkModel::isUserBookmark( int sourceRow ) const
 bool BookmarkModel::filterAcceptsRow( int sourceRow, const QModelIndex & ) const
 {
   if ( !mShowProjectOnly )
-  {
     return true;
-  }
+
+  // The drawer scopes the list to bookmarks created in QField (user bookmarks).
   return isUserBookmark( sourceRow );
 }
 
 void BookmarkModel::toggleSelected( const QString &id )
 {
   if ( id.isEmpty() )
-  {
     return;
-  }
 
   if ( mSelectedIds.contains( id ) )
-  {
     mSelectedIds.remove( id );
-  }
   else
-  {
     mSelectedIds.insert( id );
-  }
 
   emitSelectionChanged();
   emit selectedCountChanged();
-}
-
-void BookmarkModel::setSelected( const QString &id, bool selected )
-{
-  if ( id.isEmpty() )
-  {
-    return;
-  }
-
-  if ( selected == mSelectedIds.contains( id ) )
-  {
-    return;
-  }
-
-  if ( selected )
-  {
-    mSelectedIds.insert( id );
-  }
-  else
-  {
-    mSelectedIds.remove( id );
-  }
-
-  emitSelectionChanged();
-  emit selectedCountChanged();
-}
-
-void BookmarkModel::selectAll()
-{
-  const int count = rowCount();
-  bool changed = false;
-  for ( int row = 0; row < count; ++row )
-  {
-    const QString id = data( index( row, 0 ), BookmarkModel::BookmarkId ).toString();
-    if ( !id.isEmpty() && !mSelectedIds.contains( id ) )
-    {
-      mSelectedIds.insert( id );
-      changed = true;
-    }
-  }
-
-  if ( changed )
-  {
-    emitSelectionChanged();
-    emit selectedCountChanged();
-  }
 }
 
 void BookmarkModel::clearSelection()
 {
   if ( mSelectedIds.isEmpty() )
-  {
     return;
-  }
 
   mSelectedIds.clear();
   emitSelectionChanged();
   emit selectedCountChanged();
 }
 
+int BookmarkModel::deleteSelected()
+{
+  if ( mSelectedIds.isEmpty() )
+  {
+    return 0;
+  }
+
+  int deleted = 0;
+  const QStringList ids( mSelectedIds.constBegin(), mSelectedIds.constEnd() );
+  for ( const QString &id : ids )
+  {
+    if ( mManager->removeBookmark( id ) )
+    {
+      ++deleted;
+    }
+  }
+
+  // Persist once after all removals rather than on every bookmark.
+  store();
+
+  mSelectedIds.clear();
+  emit selectedCountChanged();
+
+  return deleted;
+}
+
 void BookmarkModel::emitSelectionChanged()
 {
   const int count = rowCount();
   if ( count > 0 )
-  {
     emit dataChanged( index( 0, 0 ), index( count - 1, 0 ), { BookmarkModel::BookmarkSelected } );
-  }
-}
-
-void BookmarkModel::setGroupByColor( bool groupByColor )
-{
-  if ( mGroupByColor == groupByColor )
-  {
-    return;
-  }
-
-  mGroupByColor = groupByColor;
-
-  if ( mGroupByColor )
-  {
-    setSortRole( BookmarkModel::BookmarkGroup );
-    sort( 0 );
-  }
-  else
-  {
-    // Restore the source model insertion order
-    sort( -1 );
-  }
-
-  emit groupByColorChanged();
 }
 
 int BookmarkModel::groupRank( const QString &group ) const
@@ -358,6 +304,8 @@ int BookmarkModel::groupRank( const QString &group ) const
   {
     return 3;
   }
+
+  // Default (empty group) comes first.
   return 0;
 }
 

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -20,6 +20,7 @@
 
 #include "qgsquickmapsettings.h"
 
+#include <QSet>
 #include <qgsbookmarkmanager.h>
 #include <qgsbookmarkmodel.h>
 #include <qobjectuniqueptr.h>
@@ -33,6 +34,15 @@ class BookmarkModel : public QSortFilterProxyModel
 
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ setMapSettings READ mapSettings NOTIFY mapSettingsChanged )
 
+    //! When TRUE, only project bookmarks are listed; user bookmarks are hidden.
+    Q_PROPERTY( bool showProjectOnly READ showProjectOnly WRITE setShowProjectOnly NOTIFY showProjectOnlyChanged )
+
+    //! When TRUE, bookmarks are grouped/sorted by their color; insertion order is kept within each color.
+    Q_PROPERTY( bool groupByColor READ groupByColor WRITE setGroupByColor NOTIFY groupByColorChanged )
+
+    //! Number of currently selected bookmarks.
+    Q_PROPERTY( int selectedCount READ selectedCount NOTIFY selectedCountChanged )
+
   public:
     enum Roles
     {
@@ -42,6 +52,7 @@ class BookmarkModel : public QSortFilterProxyModel
       BookmarkPoint,
       BookmarkCrs,
       BookmarkUser,
+      BookmarkSelected,
     };
     Q_ENUM( Roles )
 
@@ -69,14 +80,56 @@ class BookmarkModel : public QSortFilterProxyModel
 
     QgsQuickMapSettings *mapSettings() const { return mMapSettings; }
 
+    bool showProjectOnly() const { return mShowProjectOnly; }
+    void setShowProjectOnly( bool showProjectOnly );
+
+    bool groupByColor() const { return mGroupByColor; }
+    void setGroupByColor( bool groupByColor );
+
+    int selectedCount() const { return mSelectedIds.size(); }
+
+    //! Toggles the selection state of the bookmark identified by \a id.
+    Q_INVOKABLE void toggleSelected( const QString &id );
+
+    //! Sets the selection state of the bookmark identified by \a id to \a selected.
+    Q_INVOKABLE void setSelected( const QString &id, bool selected );
+
+    //! Selects all currently listed bookmarks.
+    Q_INVOKABLE void selectAll();
+
+    //! Clears the current selection.
+    Q_INVOKABLE void clearSelection();
+
+    //! Returns the identifiers of all currently selected bookmarks.
+    Q_INVOKABLE QStringList selectedIds() const { return QStringList( mSelectedIds.constBegin(), mSelectedIds.constEnd() ); }
+
   signals:
     void mapSettingsChanged();
+    void showProjectOnlyChanged();
+    void groupByColorChanged();
+    void selectedCountChanged();
     void requestJumpToPoint( const QgsPoint &center, const double &scale = -1.0, bool handleMargins = false ) const;
 
+  protected:
+    bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const override;
+    bool lessThan( const QModelIndex &sourceLeft, const QModelIndex &sourceRight ) const override;
+
   private:
+    //! Returns TRUE if the source row is a user/global bookmark, FALSE if it is a project bookmark.
+    bool isUserBookmark( int sourceRow ) const;
+
+    //! Emits dataChanged for the BookmarkSelected role across all listed rows.
+    void emitSelectionChanged();
+
+    //! Returns the sort rank for a bookmark group/color ("" first, then orange, red, blue).
+    int groupRank( const QString &group ) const;
+
     QObjectUniquePtr<QgsBookmarkManagerModel> mModel;
     QgsBookmarkManager *mManager = nullptr;
     QgsQuickMapSettings *mMapSettings = nullptr;
+    bool mShowProjectOnly = false;
+    bool mGroupByColor = false;
+    QSet<QString> mSelectedIds;
 };
 
 #endif // BOOKMARKMODEL_H

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -34,11 +34,8 @@ class BookmarkModel : public QSortFilterProxyModel
 
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ setMapSettings READ mapSettings NOTIFY mapSettingsChanged )
 
-    //! When TRUE, only project bookmarks are listed; user bookmarks are hidden.
+    //! When TRUE, the list is scoped to user bookmarks (those created in QField).
     Q_PROPERTY( bool showProjectOnly READ showProjectOnly WRITE setShowProjectOnly NOTIFY showProjectOnlyChanged )
-
-    //! When TRUE, bookmarks are grouped/sorted by their color; insertion order is kept within each color.
-    Q_PROPERTY( bool groupByColor READ groupByColor WRITE setGroupByColor NOTIFY groupByColorChanged )
 
     //! Number of currently selected bookmarks.
     Q_PROPERTY( int selectedCount READ selectedCount NOTIFY selectedCountChanged )
@@ -83,30 +80,22 @@ class BookmarkModel : public QSortFilterProxyModel
     bool showProjectOnly() const { return mShowProjectOnly; }
     void setShowProjectOnly( bool showProjectOnly );
 
-    bool groupByColor() const { return mGroupByColor; }
-    void setGroupByColor( bool groupByColor );
-
     int selectedCount() const { return mSelectedIds.size(); }
 
     //! Toggles the selection state of the bookmark identified by \a id.
     Q_INVOKABLE void toggleSelected( const QString &id );
 
-    //! Sets the selection state of the bookmark identified by \a id to \a selected.
-    Q_INVOKABLE void setSelected( const QString &id, bool selected );
-
-    //! Selects all currently listed bookmarks.
-    Q_INVOKABLE void selectAll();
 
     //! Clears the current selection.
     Q_INVOKABLE void clearSelection();
 
-    //! Returns the identifiers of all currently selected bookmarks.
-    Q_INVOKABLE QStringList selectedIds() const { return QStringList( mSelectedIds.constBegin(), mSelectedIds.constEnd() ); }
+    //! Deletes all currently selected bookmarks, persisting once. Returns the number deleted.
+    Q_INVOKABLE int deleteSelected();
+
 
   signals:
     void mapSettingsChanged();
     void showProjectOnlyChanged();
-    void groupByColorChanged();
     void selectedCountChanged();
     void requestJumpToPoint( const QgsPoint &center, const double &scale = -1.0, bool handleMargins = false ) const;
 
@@ -128,7 +117,6 @@ class BookmarkModel : public QSortFilterProxyModel
     QgsBookmarkManager *mManager = nullptr;
     QgsQuickMapSettings *mMapSettings = nullptr;
     bool mShowProjectOnly = false;
-    bool mGroupByColor = false;
     QSet<QString> mSelectedIds;
 };
 

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -34,11 +34,11 @@ class BookmarkModel : public QSortFilterProxyModel
 
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ setMapSettings READ mapSettings NOTIFY mapSettingsChanged )
 
-    //! When TRUE, the list is scoped to user bookmarks (those created in QField).
-    Q_PROPERTY( bool showProjectOnly READ showProjectOnly WRITE setShowProjectOnly NOTIFY showProjectOnlyChanged )
+    //! When TRUE, project bookmarks are hidden so only user bookmarks (those created in QField) are listed.
+    Q_PROPERTY( bool hideProjectBookmarks READ hideProjectBookmarks WRITE setHideProjectBookmarks NOTIFY hideProjectBookmarksChanged )
 
     //! Number of currently selected bookmarks.
-    Q_PROPERTY( int selectedCount READ selectedCount NOTIFY selectedCountChanged )
+    Q_PROPERTY( qsizetype selectedCount READ selectedCount NOTIFY selectedCountChanged )
 
   public:
     enum Roles
@@ -77,14 +77,13 @@ class BookmarkModel : public QSortFilterProxyModel
 
     QgsQuickMapSettings *mapSettings() const { return mMapSettings; }
 
-    bool showProjectOnly() const { return mShowProjectOnly; }
-    void setShowProjectOnly( bool showProjectOnly );
+    bool hideProjectBookmarks() const { return mHideProjectBookmarks; }
+    void setHideProjectBookmarks( bool hideProjectBookmarks );
 
-    int selectedCount() const { return mSelectedIds.size(); }
+    qsizetype selectedCount() const { return mSelectedIds.size(); }
 
     //! Toggles the selection state of the bookmark identified by \a id.
     Q_INVOKABLE void toggleSelected( const QString &id );
-
 
     //! Clears the current selection.
     Q_INVOKABLE void clearSelection();
@@ -92,10 +91,9 @@ class BookmarkModel : public QSortFilterProxyModel
     //! Deletes all currently selected bookmarks, persisting once. Returns the number deleted.
     Q_INVOKABLE int deleteSelected();
 
-
   signals:
     void mapSettingsChanged();
-    void showProjectOnlyChanged();
+    void hideProjectBookmarksChanged();
     void selectedCountChanged();
     void requestJumpToPoint( const QgsPoint &center, const double &scale = -1.0, bool handleMargins = false ) const;
 
@@ -116,7 +114,7 @@ class BookmarkModel : public QSortFilterProxyModel
     QObjectUniquePtr<QgsBookmarkManagerModel> mModel;
     QgsBookmarkManager *mManager = nullptr;
     QgsQuickMapSettings *mMapSettings = nullptr;
-    bool mShowProjectOnly = false;
+    bool mHideProjectBookmarks = false;
     QSet<QString> mSelectedIds;
 };
 

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -105,9 +105,6 @@ class BookmarkModel : public QSortFilterProxyModel
     //! Returns TRUE if the source row is a user/global bookmark, FALSE if it is a project bookmark.
     bool isUserBookmark( int sourceRow ) const;
 
-    //! Emits dataChanged for the BookmarkSelected role across all listed rows.
-    void emitSelectionChanged();
-
     //! Returns the sort rank for a bookmark group/color ("" first, then orange, red, blue).
     int groupRank( const QString &group ) const;
 

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -14,6 +14,11 @@ Pane {
   id: bookmarkList
   property alias model: bookmarksList.model
   property bool multiSelection: false
+  onMultiSelectionChanged: {
+    if (model) {
+      model.hideProjectBookmarks = multiSelection;
+    }
+  }
   property bool fullScreenView: false
   property bool isVertical: parent.width < parent.height || parent.width < 300
   property bool isDragging: false
@@ -372,7 +377,7 @@ Pane {
           verticalCenter: parent.verticalCenter
         }
         checked: BookmarkSelected
-        visible: bookmarkList.multiSelection
+        visible: bookmarkList.multiSelection && BookmarkUser
 
         onClicked: {
           bookmarkList.model.toggleSelected(BookmarkId);
@@ -409,6 +414,9 @@ Pane {
         }
 
         onPressAndHold: {
+          if (!BookmarkUser) {
+            return;
+          }
           bookmarkList.multiSelection = true;
           bookmarkList.model.toggleSelected(BookmarkId);
         }
@@ -534,7 +542,7 @@ Pane {
     bookmarkList.multiSelection = false;
     if (bookmarkList.model) {
       bookmarkList.model.clearSelection();
-      bookmarkList.model.showProjectOnly = false;
+      bookmarkList.model.hideProjectBookmarks = false;
     }
   }
 }

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -13,17 +13,12 @@ import Theme
 Pane {
   id: bookmarkList
   property alias model: bookmarksList.model
-
   property bool multiSelection: false
   property bool fullScreenView: false
   property bool isVertical: parent.width < parent.height || parent.width < 300
-
   property bool isDragging: false
   property real dragHeightAdjustment: 0
   property real dragWidthAdjustment: 0
-
-  signal requestJumpToPoint(var center, real scale, bool handleMargins)
-
   property real lastWidth
 
   width: {
@@ -54,8 +49,8 @@ Pane {
         return parent.height;
       } else {
         const defaultMin = Math.min(Math.max(200, parent.height / 2), parent.height);
-        const contentHeight = bookmarkListToolBar.height + (bookmarksList.contentHeight + bookmarksList.anchors.bottomMargin) + 25;
-        const newHeight = Math.max(Math.min(contentHeight, defaultMin), Math.min(defaultMin, bookmarkListToolBar.height + 120));
+        const minContentHeight = bookmarkListToolBar.height + (bookmarksList.contentHeight + bookmarksList.anchors.bottomMargin) + 25;
+        const newHeight = Math.min(minContentHeight, defaultMin);
         lastHeight = newHeight;
         return newHeight;
       }
@@ -84,67 +79,47 @@ Pane {
     property bool isVisible: false
   }
 
-  ToolBar {
+  Rectangle {
     id: bookmarkListToolBar
 
     anchors.top: parent.top
+    anchors.topMargin: topMargin
     anchors.left: parent.left
     anchors.right: parent.right
-    height: 48 + mainWindow.sceneTopMargin
+    height: topMargin + 58
+    color: Theme.mainBackgroundColor
+    clip: true
 
-    background: Rectangle {
-      color: Theme.mainBackgroundColor
+    property double topMargin: bookmarkList.y == 0 ? mainWindow.sceneTopMargin : 0.0
+    property double leftMargin: bookmarkList.x == 0 ? mainWindow.sceneLeftMargin : 0.0
+    property double rightMargin: mainWindow.sceneRightMargin
+
+    Rectangle {
+      width: parent.width * 0.3
+      height: 5
+      radius: 10
+
+      anchors.horizontalCenter: parent.horizontalCenter
+      anchors.top: parent.top
+      anchors.topMargin: bookmarkListToolBar.topMargin + 1
+
+      color: Theme.controlBorderColor
     }
 
     Item {
-      anchors.fill: parent
-      anchors.topMargin: mainWindow.sceneTopMargin
-      anchors.leftMargin: bookmarkList.x == 0 ? mainWindow.sceneLeftMargin : 0
-      anchors.rightMargin: mainWindow.sceneRightMargin
-
-      QfToolButton {
-        id: backButton
-        anchors.left: parent.left
-        anchors.verticalCenter: parent.verticalCenter
-        width: 48
-        height: 48
-        iconSource: bookmarkList.multiSelection ? Theme.getThemeVectorIcon("ic_clear_white_24dp") : Theme.getThemeVectorIcon("ic_arrow_left_white_24dp")
-        iconColor: Theme.mainTextColor
-        bgcolor: "transparent"
-
-        onClicked: {
-          if (bookmarkList.multiSelection) {
-            bookmarkList.model.clearSelection();
-            bookmarkList.multiSelection = false;
-          } else {
-            bookmarkList.hide();
-          }
-        }
+      anchors {
+        fill: parent
+        topMargin: bookmarkListToolBar.topMargin + 5
       }
-
-      Text {
-        id: selectionCount
-        anchors.left: backButton.right
-        anchors.verticalCenter: parent.verticalCenter
-        width: bookmarkList.multiSelection ? 48 : 0
-        visible: width > 0
-        height: 48
-        verticalAlignment: Text.AlignVCenter
-        font: Theme.strongFont
-        color: Theme.mainTextColor
-        text: {
-          const count = bookmarkList.model ? bookmarkList.model.selectedCount : 0;
-          return count < 100 ? count : '99+';
-        }
-      }
+      clip: true
 
       Text {
         property double balancedMargin: Math.max(backButton.width + selectionCount.width, menuButton.width)
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.leftMargin: balancedMargin
-        anchors.rightMargin: balancedMargin
+        anchors.top: parent.top
+        anchors.leftMargin: balancedMargin + bookmarkListToolBar.leftMargin
+        anchors.rightMargin: balancedMargin + bookmarkListToolBar.rightMargin
         height: 48
 
         font: Theme.strongFont
@@ -155,21 +130,96 @@ Pane {
         fontSizeMode: Text.Fit
         wrapMode: Text.Wrap
         elide: Text.ElideRight
-      }
 
-      QfToolButton {
-        id: menuButton
-        anchors.right: parent.right
-        anchors.verticalCenter: parent.verticalCenter
-        width: 48
-        height: 48
-        iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")
-        iconColor: Theme.mainTextColor
-        bgcolor: "transparent"
+        DragHandler {
+          enabled: true
+          target: null
+          acceptedButtons: Qt.LeftButton
+          grabPermissions: PointerHandler.CanTakeOverFromAnything
+          dragThreshold: 5
 
-        onClicked: {
-          bookmarkListMenu.popup(menuButton.x + menuButton.width - bookmarkListMenu.width, menuButton.y);
+          property var oldPos
+
+          onActiveChanged: {
+            if (active) {
+              bookmarkList.isDragging = true;
+              oldPos = centroid.scenePosition;
+            } else {
+              bookmarkList.statusIndicatorDragReleased();
+            }
+          }
+
+          onCentroidChanged: {
+            if (active) {
+              const dx = centroid.scenePosition.x - oldPos.x;
+              const dy = centroid.scenePosition.y - oldPos.y;
+              if (dx !== 0 || dy !== 0) {
+                bookmarkList.statusIndicatorDragged(dx, dy);
+                oldPos = centroid.scenePosition;
+              }
+            }
+          }
         }
+      }
+    }
+
+    QfToolButton {
+      id: backButton
+      anchors.left: parent.left
+      anchors.leftMargin: bookmarkListToolBar.leftMargin
+      anchors.top: parent.top
+      anchors.topMargin: bookmarkListToolBar.topMargin + 5
+      width: 48
+      height: 48
+      clip: true
+      iconSource: bookmarkList.multiSelection ? Theme.getThemeVectorIcon("ic_clear_white_24dp") : Theme.getThemeVectorIcon("ic_arrow_left_white_24dp")
+      iconColor: Theme.mainTextColor
+
+      onClicked: {
+        if (bookmarkList.multiSelection) {
+          bookmarkList.model.clearSelection();
+          bookmarkList.multiSelection = false;
+        } else {
+          bookmarkList.hide();
+        }
+      }
+    }
+
+    Text {
+      id: selectionCount
+
+      anchors.left: backButton.right
+      anchors.top: parent.top
+      anchors.topMargin: bookmarkListToolBar.topMargin + 5
+
+      width: (bookmarkList.multiSelection && bookmarkList.model ? 48 : 0)
+      visible: width > 0
+      height: 48
+      verticalAlignment: Text.AlignVCenter
+      font: Theme.strongFont
+      color: Theme.mainTextColor
+
+      text: {
+        const count = bookmarkList.model ? bookmarkList.model.selectedCount : 0;
+        return count < 100 ? count : '99+';
+      }
+    }
+
+    QfToolButton {
+      id: menuButton
+      anchors.right: parent.right
+      anchors.rightMargin: bookmarkListToolBar.rightMargin
+      anchors.top: parent.top
+      anchors.topMargin: bookmarkListToolBar.topMargin + 5
+      width: 48
+      height: 48
+      clip: true
+
+      iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")
+      iconColor: Theme.mainTextColor
+
+      onClicked: {
+        bookmarkListMenu.popup(menuButton.x + menuButton.width - bookmarkListMenu.width, menuButton.y);
       }
     }
   }
@@ -204,19 +254,6 @@ Pane {
     }
 
     MenuItem {
-      id: moveSelectedBookmarksBtn
-      text: qsTr('Move Selected Bookmark(s)')
-      icon.source: Theme.getThemeVectorIcon("ic_move_white_24dp")
-      enabled: bookmarkList.multiSelection && bookmarkList.model && bookmarkList.model.selectedCount > 0
-
-      font: Theme.defaultFont
-      height: 48
-      leftPadding: Theme.menuItemLeftPadding
-
-      onTriggered: {}
-    }
-
-    MenuItem {
       id: deleteSelectedBookmarksBtn
       text: qsTr('Delete Selected Bookmark(s)')
       icon.source: Theme.getThemeVectorIcon("ic_delete_forever_white_24dp")
@@ -226,25 +263,40 @@ Pane {
       height: 48
       leftPadding: Theme.menuItemLeftPadding
 
-      onTriggered: {}
+      onTriggered: {
+        bookmarkListMenu.close();
+        deleteBookmarksDialog.selectedCount = bookmarkList.model ? bookmarkList.model.selectedCount : 0;
+        deleteBookmarksDialog.open();
+      }
+    }
+  }
+
+  QfDialog {
+    id: deleteBookmarksDialog
+    parent: mainWindow.contentItem
+
+    property int selectedCount: 0
+
+    title: qsTr("Delete bookmark(s)")
+    Label {
+      width: mainWindow.width - 60
+      wrapMode: Text.WordWrap
+      font: Theme.defaultFont
+      color: Theme.mainTextColor
+      text: qsTr("Should the %n selected bookmark(s) really be deleted?", "", deleteBookmarksDialog.selectedCount)
     }
 
-    MenuItem {
-      id: groupBookmarksBtn
-      text: qsTr('Group Bookmarks')
-      checkable: true
-      checked: bookmarkList.model ? bookmarkList.model.groupByColor : false
-      enabled: bookmarksList.count > 0
-
-      font: Theme.defaultFont
-      height: 48
-      leftPadding: Theme.menuItemCheckLeftPadding
-
-      onTriggered: {
-        if (bookmarkList.model) {
-          bookmarkList.model.groupByColor = !bookmarkList.model.groupByColor;
-        }
+    onAccepted: {
+      if (bookmarkList.model) {
+        const deleted = bookmarkList.model.deleteSelected();
+        displayToast(qsTr("Deleted %n bookmark(s)", "", deleted));
       }
+      bookmarkList.multiSelection = false;
+      bookmarkList.focus = true;
+    }
+
+    onRejected: {
+      bookmarkList.focus = true;
     }
   }
 
@@ -259,13 +311,46 @@ Pane {
     anchors.rightMargin: mainWindow.sceneRightMargin
     anchors.bottom: parent.bottom
     anchors.bottomMargin: mainWindow.sceneBottomMargin
-
+    height: parent.height - bookmarkListToolBar.height
     ScrollBar.vertical: QfScrollBar {}
+
+    section.property: "BookmarkGroup"
+    section.labelPositioning: ViewSection.InlineLabels
+    section.delegate: Component {
+      Rectangle {
+        width: parent.width
+        height: 30
+        color: Theme.controlBorderColor
+
+        Text {
+          anchors {
+            horizontalCenter: parent.horizontalCenter
+            verticalCenter: parent.verticalCenter
+          }
+          font.bold: true
+          font.pointSize: Theme.resultFont.pointSize
+          color: Theme.mainTextColor
+          text: {
+            switch (section) {
+            case "orange":
+              return qsTr("Orange");
+            case "red":
+              return qsTr("Red");
+            case "blue":
+              return qsTr("Blue");
+            }
+            return qsTr("Green");
+          }
+        }
+      }
+    }
 
     delegate: Rectangle {
       id: itemBackground
-      anchors.left: parent ? parent.left : undefined
-      anchors.right: parent ? parent.right : undefined
+      anchors {
+        left: parent ? parent.left : undefined
+        right: parent ? parent.right : undefined
+      }
       height: Math.max(48, bookmarkLabel.height)
       color: "transparent"
 
@@ -279,28 +364,10 @@ Pane {
         color: Material.rippleColor
       }
 
-      Rectangle {
-        id: groupAccent
-        anchors.left: parent.left
-        height: parent.height
-        width: 6
-        color: {
-          switch (BookmarkGroup) {
-          case "orange":
-            return Theme.bookmarkOrange;
-          case "red":
-            return Theme.bookmarkRed;
-          case "blue":
-            return Theme.bookmarkBlue;
-          }
-          return Theme.bookmarkDefault;
-        }
-      }
-
       CheckBox {
         id: selectionCheckBox
         anchors {
-          leftMargin: 11
+          leftMargin: 5
           left: parent.left
           verticalCenter: parent.verticalCenter
         }
@@ -312,10 +379,10 @@ Pane {
         }
       }
 
-      Label {
+      Text {
         id: bookmarkLabel
         anchors {
-          leftMargin: bookmarkList.multiSelection ? 56 : 16
+          leftMargin: bookmarkList.multiSelection ? 50 : 10
           rightMargin: 10
           left: parent.left
           right: parent.right
@@ -373,6 +440,43 @@ Pane {
     }
   }
 
+  function statusIndicatorDragged(deltaX, deltaY) {
+    fullScreenView = false;
+    if (isVertical) {
+      dragHeightAdjustment += deltaY;
+    } else {
+      dragWidthAdjustment += deltaX;
+    }
+  }
+
+  function statusIndicatorDragReleased() {
+    isDragging = false;
+    if (isVertical) {
+      const minContentHeight = bookmarkListToolBar.height + 48 + 30;
+      if (bookmarkList.height < minContentHeight) {
+        if (fullScreenView) {
+          fullScreenView = false;
+        } else {
+          bookmarkList.hide();
+        }
+      } else if (dragHeightAdjustment < -parent.height * 0.2) {
+        fullScreenView = true;
+      }
+    } else {
+      if (bookmarkList.width < bookmarkList.parent.width * 0.3) {
+        if (fullScreenView) {
+          fullScreenView = false;
+        } else {
+          bookmarkList.hide();
+        }
+      } else if (dragWidthAdjustment < -parent.width * 0.2) {
+        fullScreenView = true;
+      }
+    }
+    dragHeightAdjustment = 0;
+    dragWidthAdjustment = 0;
+  }
+
   Keys.onReleased: event => {
     if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
       if (Overlay.overlay && Overlay.overlay.visibleChildren.length > 1 || (Overlay.overlay.visibleChildren.length === 1 && !toast.visible)) {
@@ -395,11 +499,10 @@ Pane {
       easing.type: Easing.OutQuart
 
       onRunningChanged: {
-        if (running) {
+        if (running)
           mapCanvasMap.freeze('bookmarkresize');
-        } else {
+        else
           mapCanvasMap.unfreeze('bookmarkresize');
-        }
       }
     }
   }
@@ -411,11 +514,10 @@ Pane {
       easing.type: Easing.OutQuart
 
       onRunningChanged: {
-        if (running) {
+        if (running)
           mapCanvasMap.freeze('bookmarkresize');
-        } else {
+        else
           mapCanvasMap.unfreeze('bookmarkresize');
-        }
       }
     }
   }
@@ -428,11 +530,11 @@ Pane {
   function hide() {
     props.isVisible = false;
     focus = false;
+    fullScreenView = false;
     bookmarkList.multiSelection = false;
     if (bookmarkList.model) {
       bookmarkList.model.clearSelection();
       bookmarkList.model.showProjectOnly = false;
-      bookmarkList.model.groupByColor = false;
     }
   }
 }

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -14,11 +14,6 @@ Pane {
   id: bookmarkList
   property alias model: bookmarksList.model
   property bool multiSelection: false
-  onMultiSelectionChanged: {
-    if (model) {
-      model.hideProjectBookmarks = multiSelection;
-    }
-  }
   property bool fullScreenView: false
   property bool isVertical: parent.width < parent.height || parent.width < 300
   property bool isDragging: false
@@ -183,7 +178,7 @@ Pane {
       onClicked: {
         if (bookmarkList.multiSelection) {
           bookmarkList.model.clearSelection();
-          bookmarkList.multiSelection = false;
+          bookmarkList.setMultiSelection(false);
         } else {
           bookmarkList.hide();
         }
@@ -247,7 +242,7 @@ Pane {
       leftPadding: Theme.menuItemCheckLeftPadding
 
       onTriggered: {
-        bookmarkList.multiSelection = !bookmarkList.multiSelection;
+        bookmarkList.setMultiSelection(!bookmarkList.multiSelection);
         if (!bookmarkList.multiSelection) {
           bookmarkList.model.clearSelection();
         }
@@ -296,7 +291,7 @@ Pane {
         const deleted = bookmarkList.model.deleteSelected();
         displayToast(qsTr("Deleted %n bookmark(s)", "", deleted));
       }
-      bookmarkList.multiSelection = false;
+      bookmarkList.setMultiSelection(false);
       bookmarkList.focus = true;
     }
 
@@ -417,7 +412,7 @@ Pane {
           if (!BookmarkUser) {
             return;
           }
-          bookmarkList.multiSelection = true;
+          bookmarkList.setMultiSelection(true);
           bookmarkList.model.toggleSelected(BookmarkId);
         }
       }
@@ -445,6 +440,13 @@ Pane {
       PropertyAnimation {
         easing.type: Easing.OutQuart
       }
+    }
+  }
+
+  function setMultiSelection(active) {
+    multiSelection = active;
+    if (model) {
+      model.hideProjectBookmarks = active;
     }
   }
 
@@ -492,7 +494,7 @@ Pane {
       }
       if (bookmarkList.multiSelection) {
         bookmarkList.model.clearSelection();
-        bookmarkList.multiSelection = false;
+        bookmarkList.setMultiSelection(false);
       } else {
         bookmarkList.hide();
       }
@@ -539,10 +541,9 @@ Pane {
     props.isVisible = false;
     focus = false;
     fullScreenView = false;
-    bookmarkList.multiSelection = false;
+    bookmarkList.setMultiSelection(false);
     if (bookmarkList.model) {
       bookmarkList.model.clearSelection();
-      bookmarkList.model.hideProjectBookmarks = false;
     }
   }
 }

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -1,0 +1,438 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Controls.Material
+import QtQuick.Controls.Material.impl
+import org.qgis
+import org.qfield
+import Theme
+
+/**
+ * \ingroup qml
+ */
+Pane {
+  id: bookmarkList
+  property alias model: bookmarksList.model
+
+  property bool multiSelection: false
+  property bool fullScreenView: false
+  property bool isVertical: parent.width < parent.height || parent.width < 300
+
+  property bool isDragging: false
+  property real dragHeightAdjustment: 0
+  property real dragWidthAdjustment: 0
+
+  signal requestJumpToPoint(var center, real scale, bool handleMargins)
+
+  property real lastWidth
+
+  width: {
+    if (props.isVisible) {
+      if (dragWidthAdjustment != 0) {
+        return lastWidth - dragWidthAdjustment;
+      } else if (fullScreenView || parent.width <= parent.height || width >= 0.95 * parent.width) {
+        lastWidth = parent.width;
+        return parent.width;
+      } else {
+        const newWidth = Math.min(Math.max(200, parent.width / 2.25), parent.width);
+        lastWidth = newWidth;
+        return newWidth;
+      }
+    } else {
+      lastWidth = 0;
+      return 0;
+    }
+  }
+  property real lastHeight
+
+  height: {
+    if (props.isVisible) {
+      if (dragHeightAdjustment != 0) {
+        return Math.min(lastHeight - dragHeightAdjustment, parent.height - mainWindow.sceneTopMargin);
+      } else if (fullScreenView || parent.width > parent.height || height >= 0.95 * parent.height) {
+        lastHeight = parent.height;
+        return parent.height;
+      } else {
+        const defaultMin = Math.min(Math.max(200, parent.height / 2), parent.height);
+        const contentHeight = bookmarkListToolBar.height + (bookmarksList.contentHeight + bookmarksList.anchors.bottomMargin) + 25;
+        const newHeight = Math.max(Math.min(contentHeight, defaultMin), Math.min(defaultMin, bookmarkListToolBar.height + 120));
+        lastHeight = newHeight;
+        return newHeight;
+      }
+    } else {
+      lastHeight = 0;
+      return 0;
+    }
+  }
+
+  topPadding: 0
+  leftPadding: 0
+  rightPadding: 0
+  bottomPadding: 0
+
+  visible: props.isVisible
+  clip: true
+
+  WheelHandler {
+    acceptedDevices: PointerDevice.AllDevices
+    onWheel: {}
+  }
+
+  QtObject {
+    id: props
+
+    property bool isVisible: false
+  }
+
+  ToolBar {
+    id: bookmarkListToolBar
+
+    anchors.top: parent.top
+    anchors.left: parent.left
+    anchors.right: parent.right
+    height: 48 + mainWindow.sceneTopMargin
+
+    background: Rectangle {
+      color: Theme.mainBackgroundColor
+    }
+
+    Item {
+      anchors.fill: parent
+      anchors.topMargin: mainWindow.sceneTopMargin
+      anchors.leftMargin: bookmarkList.x == 0 ? mainWindow.sceneLeftMargin : 0
+      anchors.rightMargin: mainWindow.sceneRightMargin
+
+      QfToolButton {
+        id: backButton
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        width: 48
+        height: 48
+        iconSource: bookmarkList.multiSelection ? Theme.getThemeVectorIcon("ic_clear_white_24dp") : Theme.getThemeVectorIcon("ic_arrow_left_white_24dp")
+        iconColor: Theme.mainTextColor
+        bgcolor: "transparent"
+
+        onClicked: {
+          if (bookmarkList.multiSelection) {
+            bookmarkList.model.clearSelection();
+            bookmarkList.multiSelection = false;
+          } else {
+            bookmarkList.hide();
+          }
+        }
+      }
+
+      Text {
+        id: selectionCount
+        anchors.left: backButton.right
+        anchors.verticalCenter: parent.verticalCenter
+        width: bookmarkList.multiSelection ? 48 : 0
+        visible: width > 0
+        height: 48
+        verticalAlignment: Text.AlignVCenter
+        font: Theme.strongFont
+        color: Theme.mainTextColor
+        text: {
+          const count = bookmarkList.model ? bookmarkList.model.selectedCount : 0;
+          return count < 100 ? count : '99+';
+        }
+      }
+
+      Text {
+        property double balancedMargin: Math.max(backButton.width + selectionCount.width, menuButton.width)
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.leftMargin: balancedMargin
+        anchors.rightMargin: balancedMargin
+        height: 48
+
+        font: Theme.strongFont
+        color: Theme.mainTextColor
+        text: qsTr("Bookmarks")
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        fontSizeMode: Text.Fit
+        wrapMode: Text.Wrap
+        elide: Text.ElideRight
+      }
+
+      QfToolButton {
+        id: menuButton
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        width: 48
+        height: 48
+        iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")
+        iconColor: Theme.mainTextColor
+        bgcolor: "transparent"
+
+        onClicked: {
+          bookmarkListMenu.popup(menuButton.x + menuButton.width - bookmarkListMenu.width, menuButton.y);
+        }
+      }
+    }
+  }
+
+  QfMenu {
+    id: bookmarkListMenu
+    title: qsTr("Bookmark List Menu")
+
+    topMargin: mainWindow.sceneTopMargin
+    bottomMargin: mainWindow.sceneBottomMargin
+
+    MenuItem {
+      text: qsTr('Toggle Bookmark Selection')
+
+      checkable: true
+      checked: bookmarkList.multiSelection
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: Theme.menuItemCheckLeftPadding
+
+      onTriggered: {
+        bookmarkList.multiSelection = !bookmarkList.multiSelection;
+        if (!bookmarkList.multiSelection) {
+          bookmarkList.model.clearSelection();
+        }
+      }
+    }
+
+    MenuSeparator {
+      width: parent.width
+    }
+
+    MenuItem {
+      id: moveSelectedBookmarksBtn
+      text: qsTr('Move Selected Bookmark(s)')
+      icon.source: Theme.getThemeVectorIcon("ic_move_white_24dp")
+      enabled: bookmarkList.multiSelection && bookmarkList.model && bookmarkList.model.selectedCount > 0
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: Theme.menuItemLeftPadding
+
+      onTriggered: {}
+    }
+
+    MenuItem {
+      id: deleteSelectedBookmarksBtn
+      text: qsTr('Delete Selected Bookmark(s)')
+      icon.source: Theme.getThemeVectorIcon("ic_delete_forever_white_24dp")
+      enabled: bookmarkList.multiSelection && bookmarkList.model && bookmarkList.model.selectedCount > 0
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: Theme.menuItemLeftPadding
+
+      onTriggered: {}
+    }
+
+    MenuItem {
+      id: groupBookmarksBtn
+      text: qsTr('Group Bookmarks')
+      checkable: true
+      checked: bookmarkList.model ? bookmarkList.model.groupByColor : false
+      enabled: bookmarksList.count > 0
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: Theme.menuItemCheckLeftPadding
+
+      onTriggered: {
+        if (bookmarkList.model) {
+          bookmarkList.model.groupByColor = !bookmarkList.model.groupByColor;
+        }
+      }
+    }
+  }
+
+  ListView {
+    id: bookmarksList
+
+    clip: true
+    anchors.top: bookmarkListToolBar.bottom
+    anchors.left: parent.left
+    anchors.leftMargin: bookmarkList.x == 0 ? mainWindow.sceneLeftMargin : 0
+    anchors.right: parent.right
+    anchors.rightMargin: mainWindow.sceneRightMargin
+    anchors.bottom: parent.bottom
+    anchors.bottomMargin: mainWindow.sceneBottomMargin
+
+    ScrollBar.vertical: QfScrollBar {}
+
+    delegate: Rectangle {
+      id: itemBackground
+      anchors.left: parent ? parent.left : undefined
+      anchors.right: parent ? parent.right : undefined
+      height: Math.max(48, bookmarkLabel.height)
+      color: "transparent"
+
+      Ripple {
+        clip: true
+        width: parent.width
+        height: parent.height
+        pressed: mouseArea.pressed
+        anchor: itemBackground
+        active: mouseArea.pressed
+        color: Material.rippleColor
+      }
+
+      Rectangle {
+        id: groupAccent
+        anchors.left: parent.left
+        height: parent.height
+        width: 6
+        color: {
+          switch (BookmarkGroup) {
+          case "orange":
+            return Theme.bookmarkOrange;
+          case "red":
+            return Theme.bookmarkRed;
+          case "blue":
+            return Theme.bookmarkBlue;
+          }
+          return Theme.bookmarkDefault;
+        }
+      }
+
+      CheckBox {
+        id: selectionCheckBox
+        anchors {
+          leftMargin: 11
+          left: parent.left
+          verticalCenter: parent.verticalCenter
+        }
+        checked: BookmarkSelected
+        visible: bookmarkList.multiSelection
+
+        onClicked: {
+          bookmarkList.model.toggleSelected(BookmarkId);
+        }
+      }
+
+      Label {
+        id: bookmarkLabel
+        anchors {
+          leftMargin: bookmarkList.multiSelection ? 56 : 16
+          rightMargin: 10
+          left: parent.left
+          right: parent.right
+          verticalCenter: parent.verticalCenter
+        }
+        font.bold: true
+        font.pointSize: Theme.resultFont.pointSize
+        color: Theme.mainTextColor
+        text: BookmarkName !== '' ? BookmarkName : qsTr("Untitled bookmark")
+        wrapMode: Text.WordWrap
+      }
+
+      MouseArea {
+        id: mouseArea
+        anchors.fill: parent
+
+        onClicked: {
+          if (bookmarkList.multiSelection) {
+            bookmarkList.model.toggleSelected(BookmarkId);
+          } else {
+            bookmarkList.model.setExtentFromBookmark(bookmarkList.model.index(index, 0));
+            bookmarkList.hide();
+          }
+        }
+
+        onPressAndHold: {
+          bookmarkList.multiSelection = true;
+          bookmarkList.model.toggleSelected(BookmarkId);
+        }
+      }
+
+      Rectangle {
+        anchors.bottom: parent.bottom
+        height: 1
+        color: Theme.controlBorderColor
+        width: parent.width
+      }
+    }
+
+    Label {
+      anchors.centerIn: parent
+      width: parent.width - 40
+      visible: bookmarksList.count === 0
+      horizontalAlignment: Text.AlignHCenter
+      wrapMode: Text.WordWrap
+      font: Theme.defaultFont
+      color: Theme.secondaryTextColor
+      text: qsTr("No bookmarks yet")
+    }
+
+    Behavior on height {
+      PropertyAnimation {
+        easing.type: Easing.OutQuart
+      }
+    }
+  }
+
+  Keys.onReleased: event => {
+    if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+      if (Overlay.overlay && Overlay.overlay.visibleChildren.length > 1 || (Overlay.overlay.visibleChildren.length === 1 && !toast.visible)) {
+        return;
+      }
+      if (bookmarkList.multiSelection) {
+        bookmarkList.model.clearSelection();
+        bookmarkList.multiSelection = false;
+      } else {
+        bookmarkList.hide();
+      }
+      event.accepted = true;
+    }
+  }
+
+  Behavior on width {
+    enabled: !isDragging
+    PropertyAnimation {
+      duration: parent.width > parent.height ? 250 : 0
+      easing.type: Easing.OutQuart
+
+      onRunningChanged: {
+        if (running) {
+          mapCanvasMap.freeze('bookmarkresize');
+        } else {
+          mapCanvasMap.unfreeze('bookmarkresize');
+        }
+      }
+    }
+  }
+
+  Behavior on height {
+    enabled: !isDragging
+    PropertyAnimation {
+      duration: parent.width < parent.height ? 250 : 0
+      easing.type: Easing.OutQuart
+
+      onRunningChanged: {
+        if (running) {
+          mapCanvasMap.freeze('bookmarkresize');
+        } else {
+          mapCanvasMap.unfreeze('bookmarkresize');
+        }
+      }
+    }
+  }
+
+  function show() {
+    props.isVisible = true;
+    focus = true;
+  }
+
+  function hide() {
+    props.isVisible = false;
+    focus = false;
+    bookmarkList.multiSelection = false;
+    if (bookmarkList.model) {
+      bookmarkList.model.clearSelection();
+      bookmarkList.model.showProjectOnly = false;
+      bookmarkList.model.groupByColor = false;
+    }
+  }
+}

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -17,7 +17,6 @@ Drawer {
   signal showPrintLayouts(point p)
   signal showCloudPopup
   signal showProjectFolder
-  signal showBookmarks
   signal toggleMeasurementTool
   signal toggle3DView
   signal returnHome
@@ -263,20 +262,6 @@ Drawer {
             round: true
             onClicked: {
               showProjectFolder();
-            }
-          }
-
-          QfToolButton {
-            id: bookmarksButton
-            objectName: "BookmarksButton"
-            anchors.verticalCenter: parent.verticalCenter
-            round: true
-            iconSource: Theme.getThemeVectorIcon("ic_bookmark_black_24dp")
-            iconColor: Theme.mainTextColor
-            bgcolor: "transparent"
-            onClicked: {
-              showBookmarks();
-              highlighted = false;
             }
           }
         }

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -17,6 +17,7 @@ Drawer {
   signal showPrintLayouts(point p)
   signal showCloudPopup
   signal showProjectFolder
+  signal showBookmarks
   signal toggleMeasurementTool
   signal toggle3DView
   signal returnHome
@@ -262,6 +263,20 @@ Drawer {
             round: true
             onClicked: {
               showProjectFolder();
+            }
+          }
+
+          QfToolButton {
+            id: bookmarksButton
+            objectName: "BookmarksButton"
+            anchors.verticalCenter: parent.verticalCenter
+            round: true
+            iconSource: Theme.getThemeVectorIcon("ic_bookmark_black_24dp")
+            iconColor: Theme.mainTextColor
+            bgcolor: "transparent"
+            onClicked: {
+              showBookmarks();
+              highlighted = false;
             }
           }
         }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3810,7 +3810,7 @@ ApplicationWindow {
         if (featureListForm.visible) {
           featureListForm.hide();
         }
-        bookmarkModel.showProjectOnly = true;
+        bookmarkModel.hideProjectBookmarks = false;
         bookmarkList.show();
         highlighted = false;
       }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3807,10 +3807,6 @@ ApplicationWindow {
       onTriggered: {
         mainMenu.close();
         dashBoard.close();
-        if (featureListForm.visible) {
-          featureListForm.hide();
-        }
-        bookmarkModel.hideProjectBookmarks = false;
         bookmarkList.show();
         highlighted = false;
       }
@@ -4661,6 +4657,12 @@ ApplicationWindow {
     anchors {
       right: parent.right
       bottom: parent.bottom
+    }
+
+    onVisibleChanged: {
+      if (visible && featureListForm.visible) {
+        featureListForm.hide();
+      }
     }
 
     Component.onCompleted: focusstack.addFocusTaker(this)

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3580,15 +3580,6 @@ ApplicationWindow {
       qfieldLocalDataPickerScreen.visible = true;
     }
 
-    onShowBookmarks: {
-      dashBoard.close();
-      if (featureListForm.visible) {
-        featureListForm.hide();
-      }
-      bookmarkModel.showProjectOnly = true;
-      bookmarkList.show();
-    }
-
     // If the user clicks the "Return home" button in the middle of digitizing, we will ask if they want to discard their changes.
     // If they press cancel, nothing will happen, but if they press discard, we will discard their digitizing.
     // We will also use `shouldReturnHome` to know that we need to return home as well or not.
@@ -3802,6 +3793,26 @@ ApplicationWindow {
       onTriggered: {
         dashBoard.close();
         pluginManagerSettings.open();
+      }
+    }
+
+    MenuItem {
+      text: qsTr("Bookmarks")
+
+      font: Theme.defaultFont
+      icon.source: Theme.getThemeVectorIcon("ic_bookmark_black_24dp")
+      height: 48
+      leftPadding: Theme.menuItemLeftPadding
+
+      onTriggered: {
+        mainMenu.close();
+        dashBoard.close();
+        if (featureListForm.visible) {
+          featureListForm.hide();
+        }
+        bookmarkModel.showProjectOnly = true;
+        bookmarkList.show();
+        highlighted = false;
       }
     }
 
@@ -4646,9 +4657,7 @@ ApplicationWindow {
     objectName: "bookmarkList"
 
     model: bookmarkModel
-
     focus: visible
-
     anchors {
       right: parent.right
       bottom: parent.bottom

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -3580,6 +3580,15 @@ ApplicationWindow {
       qfieldLocalDataPickerScreen.visible = true;
     }
 
+    onShowBookmarks: {
+      dashBoard.close();
+      if (featureListForm.visible) {
+        featureListForm.hide();
+      }
+      bookmarkModel.showProjectOnly = true;
+      bookmarkList.show();
+    }
+
     // If the user clicks the "Return home" button in the middle of digitizing, we will ask if they want to discard their changes.
     // If they press cancel, nothing will happen, but if they press discard, we will discard their digitizing.
     // We will also use `shouldReturnHome` to know that we need to return home as well or not.
@@ -4615,6 +4624,9 @@ ApplicationWindow {
 
     onStateChanged: {
       platformUtilities.setHandleVolumeKeys(qfieldSettings.digitizingVolumeKeys && state === "Hidden");
+      if (state !== "Hidden" && bookmarkList.visible) {
+        bookmarkList.hide();
+      }
     }
 
     Component.onCompleted: focusstack.addFocusTaker(this)
@@ -4627,6 +4639,31 @@ ApplicationWindow {
     radius: 6.0
     color: "#80000000"
     source: featureListForm
+  }
+
+  BookmarkList {
+    id: bookmarkList
+    objectName: "bookmarkList"
+
+    model: bookmarkModel
+
+    focus: visible
+
+    anchors {
+      right: parent.right
+      bottom: parent.bottom
+    }
+
+    Component.onCompleted: focusstack.addFocusTaker(this)
+  }
+
+  QfDropShadow {
+    anchors.fill: bookmarkList
+    horizontalOffset: mainWindow.width >= mainWindow.height ? -2 : 0
+    verticalOffset: mainWindow.width < mainWindow.height ? -2 : 0
+    radius: 6.0
+    color: "#80000000"
+    source: bookmarkList
   }
 
   OverlayFeatureFormDrawer {

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -166,5 +166,6 @@
         <file>3d/TerrainMesh.qml</file>
         <file>3d/Rubberband3D.qml</file>
         <file>3d/FeatureListSelectionHighlight3D.qml</file>
+        <file>BookmarkList.qml</file>
     </qresource>
 </RCC>

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -4,6 +4,7 @@
         <file>BadLayerItem.qml</file>
         <file>BluetoothDeviceChooser.qml</file>
         <file>BookmarkHighlight.qml</file>
+        <file>BookmarkList.qml</file>
         <file>BookmarkProperties.qml</file>
         <file>BookmarkRenderer.qml</file>
         <file>BrowserPanel.qml</file>
@@ -166,6 +167,5 @@
         <file>3d/TerrainMesh.qml</file>
         <file>3d/Rubberband3D.qml</file>
         <file>3d/FeatureListSelectionHighlight3D.qml</file>
-        <file>BookmarkList.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
This adds a bookmark drawer for browsing and managing user bookmarks, opened from the main menu

Whats included:
- A bottom drawer listing user bookmarks, opened from the main 3-dot menu
- Tap a bookmark to zoom the map to it
- Multi-select mode (long-press or the menu toggle) with multi selection and perform actions on bookmarks (ex. batch delete)
- Bookmarks are grouped into color sections (Green, Orange, Red, Blue), which was pre-existing visual guide in bookmark property

The UI mirrors the existing Features drawer for consistency in look and behavior


##Demo


https://github.com/user-attachments/assets/c7dc3556-efcd-42d8-a124-d10c53c0d105

