### PR TITLE
Use lowerCamelCase for objectName values

### DIFF
--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -125,7 +125,7 @@ Drawer {
 
           QfToolButton {
             id: measurementButton
-            objectName: "MeasurementButton"
+            objectName: "measurementButton"
             anchors.verticalCenter: parent.verticalCenter
             round: true
             iconSource: Theme.getThemeVectorIcon("ic_measurement_black_24dp")
@@ -139,7 +139,7 @@ Drawer {
 
           QfToolButton {
             id: view3DButton
-            objectName: "View3DButton"
+            objectName: "view3DButton"
             anchors.verticalCenter: parent.verticalCenter
             round: true
             iconSource: Theme.getThemeVectorIcon("ic_3d_white_24dp")
@@ -153,7 +153,7 @@ Drawer {
 
           QfToolButton {
             id: printItemButton
-            objectName: "PrintItemButton"
+            objectName: "printItemButton"
             anchors.verticalCenter: parent.verticalCenter
             round: true
             iconSource: Theme.getThemeVectorIcon("ic_print_black_24dp")
@@ -167,7 +167,7 @@ Drawer {
 
           QfToolButton {
             id: cloudButton
-            objectName: "CloudButton"
+            objectName: "cloudButton"
             anchors.verticalCenter: parent.verticalCenter
             iconSource: {
               if (cloudConnection.status === QFieldCloudConnection.LoggedIn && cloudProjectsModel.currentProject) {
@@ -254,7 +254,7 @@ Drawer {
 
           QfToolButton {
             id: projectFolderButton
-            objectName: "ProjectFolderButton"
+            objectName: "projectFolderButton"
             anchors.verticalCenter: parent.verticalCenter
             font: Theme.defaultFont
             iconSource: Theme.getThemeVectorIcon("ic_project_folder_black_24dp")
@@ -512,7 +512,7 @@ Drawer {
 
       Legend {
         id: legend
-        objectName: "Legend"
+        objectName: "legend"
         isVisible: dashBoard.position > 0
         anchors.fill: parent
         anchors.leftMargin: mainWindow.sceneLeftMargin + 5
@@ -551,7 +551,7 @@ Drawer {
 
       QfSwitch {
         id: modeSwitch
-        objectName: "ModeSwitch"
+        objectName: "modeSwitch"
         width: 56 + 36
         height: 48
         anchors.right: parent.right

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -238,7 +238,7 @@ Item {
 
     QfComboBox {
       id: comboBox
-      objectName: "RelationComboBox"
+      objectName: "relationComboBox"
       visible: !enabled || (!useSearch && !useCompleter && (relation !== undefined ? relation.isValid : true))
       Layout.fillWidth: true
 
@@ -563,7 +563,7 @@ Item {
 
     QfToolButton {
       id: searchButton
-      objectName: "OpenSearchFeaturePopupButton"
+      objectName: "openSearchFeaturePopupButton"
 
       Layout.preferredWidth: enabled ? 48 : 0
       Layout.preferredHeight: 48
@@ -581,7 +581,7 @@ Item {
 
     QfToolButton {
       id: addFeatureButton
-      objectName: "AddFeatureButton"
+      objectName: "addFeatureButton"
 
       Layout.preferredWidth: comboBox.enabled ? 48 : 0
       Layout.preferredHeight: 48

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -171,7 +171,7 @@ EditorWidgetBase {
 
     QfSearchBar {
       id: searchBar
-      objectName: "ValueRelationSearchBar"
+      objectName: "valueRelationSearchBar"
       width: parent.width
       height: searchHeight
       visible: enabled
@@ -206,7 +206,7 @@ EditorWidgetBase {
 
         GridLayout {
           id: valueGridView
-          objectName: "ValueRelationGridView"
+          objectName: "valueRelationGridView"
           anchors.left: parent.left
           anchors.right: parent.right
           anchors.top: parent.top
@@ -217,7 +217,7 @@ EditorWidgetBase {
           Repeater {
             id: repeater
             model: listModel.allowMulti ? listModel : 0
-            objectName: "ValueRelationRepeater"
+            objectName: "valueRelationRepeater"
 
             delegate: Item {
               id: listItem

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -5693,37 +5693,37 @@ ApplicationWindow {
         "type": "information",
         "title": qsTr("Digitizing toggle"),
         "description": qsTr("Switch between browse and digitize modes. Browse mode focuses on delivering the best experience viewing the map and its features, while digitize mode enables you to create features and edit geometries."),
-        "target": () => [iface.findItemByObjectName('ModeSwitch')]
+        "target": () => [iface.findItemByObjectName('modeSwitch')]
       },
       {
         "type": "information",
         "title": qsTr("Legend"),
         "description": qsTr("The legend shows map layers and allows you to toggle visibility and opacity properties by <b>long-pressing on a layer to open a properties popup</b>. The popup offers additional functionalities such as zooming to layer extent and displaying features contained within vector layers."),
-        "target": () => [iface.findItemByObjectName('Legend')]
+        "target": () => [iface.findItemByObjectName('legend')]
       },
       {
         "type": "information",
         "title": qsTr("Measurement"),
         "description": qsTr("Toggle the measurement tool to calculate distances and areas on the map."),
-        "target": () => [iface.findItemByObjectName('MeasurementButton')]
+        "target": () => [iface.findItemByObjectName('measurementButton')]
       },
       {
         "type": "information",
         "title": qsTr("Print"),
         "description": qsTr("Export the map canvas to PDF using configured project print and atlas layouts."),
-        "target": () => [iface.findItemByObjectName('PrintItemButton')]
+        "target": () => [iface.findItemByObjectName('printItemButton')]
       },
       {
         "type": "information",
         "title": qsTr("QFieldCloud"),
         "description": qsTr("Push changes, synchronize or revert changes to and from QFieldCloud when a cloud project is opened."),
-        "target": () => [iface.findItemByObjectName('CloudButton')]
+        "target": () => [iface.findItemByObjectName('cloudButton')]
       },
       {
         "type": "information",
         "title": qsTr("Project folder"),
         "description": qsTr("Open the project folder to access project files, data sources, and related documents. Useful for managing project resources, manually uploading data to QFieldCloud, and sharing datasets, attachments, and layouts."),
-        "target": () => [iface.findItemByObjectName('ProjectFolderButton')]
+        "target": () => [iface.findItemByObjectName('projectFolderButton')]
       }
     ]
 

--- a/test/qml/tst_editorwidgets.qml
+++ b/test/qml/tst_editorwidgets.qml
@@ -528,10 +528,10 @@ TestCase {
     };
     setupValueRelationInReadonlyMode();
     const relationComboBoxParent = valueRelation.children[1];
-    const comboBoxItem = Utils.findChildren(relationComboBoxParent, "RelationComboBox");
-    const addFeatureButton = Utils.findChildren(relationComboBoxParent, "AddFeatureButton");
+    const comboBoxItem = Utils.findChildren(relationComboBoxParent, "relationComboBox");
+    const addFeatureButton = Utils.findChildren(relationComboBoxParent, "addFeatureButton");
     const valueRelationListComponentParent = valueRelation.children[2];
-    const valueRelationRepeater = Utils.findChildren(valueRelationListComponentParent, "ValueRelationRepeater");
+    const valueRelationRepeater = Utils.findChildren(valueRelationListComponentParent, "valueRelationRepeater");
 
     // check ui in readonly mode
     compare(relationComboBoxParent.enabled, false);
@@ -578,7 +578,7 @@ TestCase {
     };
     setupValueRelationInReadonlyMode();
     const relationComboBoxParent = valueRelation.children[1];
-    const comboBoxItem = Utils.findChildren(relationComboBoxParent, "RelationComboBox");
+    const comboBoxItem = Utils.findChildren(relationComboBoxParent, "relationComboBox");
     const featureListModel = comboBoxItem.model;
     const expectedOrderedData = {
       "name": ["Ethan", "Liam", "Olivia", "Sophia", "Noah", "Ava", "Mathieu", "Mason"]
@@ -621,7 +621,7 @@ TestCase {
     };
     setupValueRelationInReadonlyMode();
     const relationComboBoxParent = valueRelation.children[1];
-    const comboBoxItem = Utils.findChildren(relationComboBoxParent, "RelationComboBox");
+    const comboBoxItem = Utils.findChildren(relationComboBoxParent, "relationComboBox");
     const featureListModel = comboBoxItem.model;
     const expectedOrderedData = {
       "name": ["Ava", "Ethan", "Liam", "Mason", "Mathieu", "Noah", "Olivia", "Sophia"]
@@ -664,7 +664,7 @@ TestCase {
     };
     setupValueRelationInReadonlyMode();
     const relationComboBoxParent = valueRelation.children[1];
-    const addFeatureButton = Utils.findChildren(relationComboBoxParent, "AddFeatureButton");
+    const addFeatureButton = Utils.findChildren(relationComboBoxParent, "addFeatureButton");
     valueRelation.isEnabled = true;
     waitForRendering(valueRelation);
     verify(relationComboBoxParent.embeddedFeatureForm === null);
@@ -704,7 +704,7 @@ TestCase {
     };
     setupValueRelationInReadonlyMode();
     const relationComboBoxParent = valueRelation.children[1];
-    const comboBoxItem = Utils.findChildren(relationComboBoxParent, "RelationComboBox");
+    const comboBoxItem = Utils.findChildren(relationComboBoxParent, "relationComboBox");
     const featureListModel = comboBoxItem.model;
     const expectedOrderedData = {
       "name": ["Ava", "Ethan", "Liam", "Mason", "Mathieu", "Noah", "Olivia", "Sophia"]
@@ -753,12 +753,12 @@ TestCase {
     };
     setupValueRelationInReadonlyMode();
     const relationComboBoxParent = valueRelation2.children[1];
-    const comboBoxItem = Utils.findChildren(relationComboBoxParent, "RelationComboBox");
-    const addFeatureButton = Utils.findChildren(relationComboBoxParent, "AddFeatureButton");
+    const comboBoxItem = Utils.findChildren(relationComboBoxParent, "relationComboBox");
+    const addFeatureButton = Utils.findChildren(relationComboBoxParent, "addFeatureButton");
     const valueRelationListComponentParent = valueRelation2.children[2];
-    const valueRelationGridView = Utils.findChildren(valueRelationListComponentParent, "ValueRelationGridView");
-    const valueRelationRepeater = Utils.findChildren(valueRelationListComponentParent, "ValueRelationRepeater");
-    const valueRelationSearchBar = Utils.findChildren(valueRelationListComponentParent, "ValueRelationSearchBar");
+    const valueRelationGridView = Utils.findChildren(valueRelationListComponentParent, "valueRelationGridView");
+    const valueRelationRepeater = Utils.findChildren(valueRelationListComponentParent, "valueRelationRepeater");
+    const valueRelationSearchBar = Utils.findChildren(valueRelationListComponentParent, "valueRelationSearchBar");
     const featureListModel = valueRelationRepeater.model;
 
     // check ui in readonly mode
@@ -806,7 +806,7 @@ TestCase {
     };
     setupValueRelationInReadonlyMode();
     const valueRelationListComponentParent = valueRelation.children[2];
-    const valueRelationRepeater = Utils.findChildren(valueRelationListComponentParent, "ValueRelationRepeater");
+    const valueRelationRepeater = Utils.findChildren(valueRelationListComponentParent, "valueRelationRepeater");
     const featureListModel = valueRelationRepeater.model;
     const expectedOrderedData = {
       "name": ["<i>NULL</i>", "Ethan", "Olivia", "Mason", "Liam", "Mathieu", "Sophia", "Noah", "Ava"]
@@ -846,7 +846,7 @@ TestCase {
     };
     setupValueRelationInReadonlyMode();
     const valueRelationListComponentParent = valueRelation.children[2];
-    const valueRelationRepeater = Utils.findChildren(valueRelationListComponentParent, "ValueRelationRepeater");
+    const valueRelationRepeater = Utils.findChildren(valueRelationListComponentParent, "valueRelationRepeater");
     const featureListModel = valueRelationRepeater.model;
     const expectedOrderedData = {
       "name": ["Ethan", "Mason", "Olivia", "Liam", "Mathieu", "Ava", "Noah", "Sophia"]
@@ -886,8 +886,8 @@ TestCase {
     };
     setupValueRelationInReadonlyMode();
     const valueRelationListComponentParent = valueRelation.children[2];
-    const valueRelationRepeater = Utils.findChildren(valueRelationListComponentParent, "ValueRelationRepeater");
-    const valueRelationSearchBar = Utils.findChildren(valueRelationListComponentParent, "ValueRelationSearchBar");
+    const valueRelationRepeater = Utils.findChildren(valueRelationListComponentParent, "valueRelationRepeater");
+    const valueRelationSearchBar = Utils.findChildren(valueRelationListComponentParent, "valueRelationSearchBar");
     const searchTextField = valueRelationSearchBar.children[0].children[3];
 
     // turn on editable mode
@@ -942,9 +942,9 @@ TestCase {
     };
     setupValueRelationInReadonlyMode();
     const relationComboBoxParent = valueRelation.children[1];
-    const comboBoxItem = Utils.findChildren(relationComboBoxParent, "RelationComboBox");
-    const addFeatureButton = Utils.findChildren(relationComboBoxParent, "AddFeatureButton");
-    const openSearchFeaturePopupButton = Utils.findChildren(relationComboBoxParent, "OpenSearchFeaturePopupButton");
+    const comboBoxItem = Utils.findChildren(relationComboBoxParent, "relationComboBox");
+    const addFeatureButton = Utils.findChildren(relationComboBoxParent, "addFeatureButton");
+    const openSearchFeaturePopupButton = Utils.findChildren(relationComboBoxParent, "openSearchFeaturePopupButton");
 
     // Initially, the combobox should not select any item because the value is undefined
     compare(comboBoxItem.displayText, "NULL");
@@ -1075,7 +1075,7 @@ TestCase {
     };
     setupValueRelationInReadonlyMode();
     const relationComboBoxParent = valueRelation.children[1];
-    const comboBoxItem = Utils.findChildren(relationComboBoxParent, "RelationComboBox");
+    const comboBoxItem = Utils.findChildren(relationComboBoxParent, "relationComboBox");
     const featureListModel = comboBoxItem.model;
     const expectedOrderedData = {
       "name": ["Ava", "Ethan", "Liam", "Mason", "Mathieu", "Noah", "Olivia", "Sophia"]


### PR DESCRIPTION
### 🚀 Description

Follow-up to align `objectName` values with our `lowerLetterForFirstWord` standard. Some were introduced in PascalCase.

