### PR TITLE
Use QV4_FORCE_INTERPRETER to bypass JIT

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -114,6 +114,7 @@ void initAuthManager( QgsAuthManager *authManager )
 int main( int argc, char **argv )
 {
   qputenv( "QT_ANDROID_DISABLE_ACCESSIBILITY", "1" );
+  qputenv( "QV4_FORCE_INTERPRETER", "1" );
 
   QCoreApplication::setOrganizationName( "OPENGIS.ch" );
   QCoreApplication::setOrganizationDomain( "opengis.ch" );


### PR DESCRIPTION
OK, it appears this (https://qt-project.atlassian.net/browse/QTBUG-147153) is the culprit for our increased crash rate in QField 4.2. As the issue suggests, it'd be worth seeing if bypassing the JIT compiler helps. 

This does that by adding an environment variable (https://doc.qt.io/qt-6/qtqml-javascript-finetuning.html). 

This will require us to release another patch release for 4.2 and keep track of incoming crash reports on the play store and sentry.

A bit of additional background here. We've been hit by this issue for a long, long time. But something spiked when we published 4.2. We can see the increase in this 90 day crash graph from sentry:

<img width="1000" height="400" alt="image" src="https://github.com/user-attachments/assets/6faef2a5-4a87-4281-a9c4-03b690604073" />

We've tried quite a few fixes in 4.2.3, 4.2.4 and 4.2.5 like changing Q_PROPERTY QList<T> to Q_PROPERTY QVariantList, insuring newly introduced arrays are copied, etc. to essentially no great result on our crash vitals. We still need ~72 hours to get us enough data for 4.2.5 to see if anything we did there helped, but I'm not super confident looking at the initial crash reports we're getting on that version.

If it's not a change in the code we introduced in 4.2, it must be having to do with Qt itself, which we _did_ update to 6.10.3 for QField 4.2.