### PR TITLE
Clean up layer observer's handling of listeners, log information on which layer has been plugged in

### DIFF
--- a/src/core/qfieldcloud/deltafilewrapper.cpp
+++ b/src/core/qfieldcloud/deltafilewrapper.cpp
@@ -69,9 +69,9 @@ DeltaFileWrapper::DeltaFileWrapper( const QString &projectId, const QString &fil
 
   if ( mErrorType == DeltaFileWrapper::ErrorType::NoError && QFileInfo::exists( mFileName ) )
   {
-    QJsonParseError jsonError;
+    qInfo() << QStringLiteral( "Loading deltas from file at %1" ).arg( mFileName );
 
-    QgsLogger::debug( QStringLiteral( "Loading deltas from %1" ).arg( mFileName ) );
+    QJsonParseError jsonError;
 
     if ( !deltaFile.open( QIODevice::ReadWrite ) )
     {
@@ -141,6 +141,8 @@ DeltaFileWrapper::DeltaFileWrapper( const QString &projectId, const QString &fil
   }
   else if ( mErrorType == DeltaFileWrapper::ErrorType::NoError )
   {
+    qInfo() << QStringLiteral( "Creating deltas file at %1" ).arg( mFileName );
+
     mJsonRoot = QJsonObject( { { "version", DeltaFormatVersion },
                                { "id", QUuid::createUuid().toString( QUuid::WithoutBraces ) },
                                { "project", mCloudProjectId },

--- a/src/core/qfieldcloud/layerobserver.cpp
+++ b/src/core/qfieldcloud/layerobserver.cpp
@@ -32,29 +32,12 @@
 LayerObserver::LayerObserver( const QgsProject *project )
   : mProject( project )
 {
-  connect( mProject, &QgsProject::homePathChanged, this, &LayerObserver::onHomePathChanged );
-  connect( mProject, &QgsProject::layersAdded, this, &LayerObserver::onLayersAdded );
+  connect( mProject, &QgsProject::readProject, this, &LayerObserver::onReadProject );
 
   if ( !project->fileName().isEmpty() )
   {
-    onHomePathChanged();
+    onReadProject();
   }
-}
-
-
-void LayerObserver::reset( bool isHardReset ) const
-{
-  if ( !mDeltaFileWrapper )
-  {
-    return;
-  }
-
-  if ( isHardReset )
-  {
-    mDeltaFileWrapper->resetId();
-  }
-
-  mDeltaFileWrapper->reset();
 }
 
 
@@ -76,7 +59,7 @@ void LayerObserver::setDeltaFileWrapper( DeltaFileWrapper *wrapper )
 }
 
 
-void LayerObserver::onHomePathChanged()
+void LayerObserver::onReadProject()
 {
   if ( mProject->fileName().isEmpty() )
   {
@@ -89,12 +72,6 @@ void LayerObserver::onHomePathChanged()
   {
     addLayerListeners();
   }
-}
-
-void LayerObserver::onLayersAdded( const QList<QgsMapLayer *> &layers )
-{
-  Q_UNUSED( layers );
-  addLayerListeners();
 }
 
 
@@ -305,6 +282,7 @@ void LayerObserver::onEditingStopped()
 
 void LayerObserver::addLayerListeners()
 {
+  qInfo() << "Add layer listeners";
   const QList<QgsMapLayer *> layers = mProject->mapLayers().values();
 
   // we should keep track only of the layers on cloud projects
@@ -357,6 +335,7 @@ void LayerObserver::addLayerListeners()
         connect( vl, &QgsVectorLayer::editingStopped, this, &LayerObserver::onEditingStopped );
 
         mObservedLayerIds.insert( vl->id() );
+        qInfo() << QStringLiteral( "Listener added on layer \"%1\"" ).arg( vl->name() );
       }
     }
   }

--- a/src/core/qfieldcloud/layerobserver.h
+++ b/src/core/qfieldcloud/layerobserver.h
@@ -51,12 +51,6 @@ class LayerObserver : public QObject
 
 
     /**
-     * Clears the current delta file changes
-     */
-    Q_INVOKABLE void reset( bool isHardReset = false ) const;
-
-
-    /**
      * Gets the current delta file
      *
      * @return current delta file
@@ -70,6 +64,13 @@ class LayerObserver : public QObject
      */
     void setDeltaFileWrapper( DeltaFileWrapper *wrapper );
 
+    /**
+     * Add the needed event listeners to monitor for changes.
+     * Assigns listeners only for layer actions of `cloud` and `offline`.
+     */
+    void addLayerListeners();
+
+
   signals:
     void layerEdited( const QString &layerId );
     void deltaFileWrapperChanged();
@@ -77,18 +78,10 @@ class LayerObserver : public QObject
 
   private slots:
     /**
-     * Monitors the current project for new layers.
-     *
-     * @param layers layers added
-     */
-    void onLayersAdded( const QList<QgsMapLayer *> &layers );
-
-
-    /**
-     * Commit the changes of the current delta file and
+     * Reacts to project read event
      *
      */
-    void onHomePathChanged();
+    void onReadProject();
 
 
     /**
@@ -179,12 +172,6 @@ class LayerObserver : public QObject
      */
     QSet<QString> mObservedLayerIds;
 
-
-    /**
-     * Add the needed event listeners to monitor for changes.
-     * Assigns listeners only for layer actions of `cloud` and `offline`.
-     */
-    void addLayerListeners();
 
     bool mLocalAndSourcePkAttrAreEqual = false;
 };

--- a/src/core/qfieldcloud/qfieldcloudproject.cpp
+++ b/src/core/qfieldcloud/qfieldcloudproject.cpp
@@ -2318,7 +2318,13 @@ void QFieldCloudProject::restoreLocalSettings( QFieldCloudProject *project, cons
 void QFieldCloudProject::setupDeltaFileWrapper()
 {
   const QDir localPath( QStringLiteral( "%1/%2/%3" ).arg( QFieldCloudUtils::localCloudDirectory(), mUsername, mId ) );
-  mDeltaFileWrapper.reset( new DeltaFileWrapper( mId, QStringLiteral( "%1/deltafile.json" ).arg( localPath.absolutePath() ) ) );
+  const QString deltaFilePath = QStringLiteral( "%1/deltafile.json" ).arg( localPath.absolutePath() );
+
+  mDeltaFileWrapper.reset( new DeltaFileWrapper( mId, deltaFilePath ) );
+  if ( mDeltaFileWrapper->hasError() )
+  {
+    qInfo() << QStringLiteral( "Error setting up the delta file wrapper: %1" ).arg( mDeltaFileWrapper->errorString() );
+  }
 
   connect( mDeltaFileWrapper.get(), &DeltaFileWrapper::countChanged, this, [this]() {
     refreshModification();

--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -682,11 +682,9 @@ QHash<int, QByteArray> QFieldCloudProjectsModel::roleNames() const
 void QFieldCloudProjectsModel::insertProjects( const QList<QFieldCloudProject *> &projects )
 {
   int currentCount = static_cast<int>( mProjects.size() );
-  int newProjectsCount = 0;
+  QList<QFieldCloudProject *> newProjects;
   for ( QFieldCloudProject *project : projects )
   {
-    setupProjectConnections( project );
-
     bool found = false;
     for ( int i = 0; i < mProjects.count(); ++i )
     {
@@ -721,13 +719,20 @@ void QFieldCloudProjectsModel::insertProjects( const QList<QFieldCloudProject *>
     }
     if ( !found )
     {
-      newProjectsCount++;
-      mProjects.append( project );
+      newProjects.append( project );
     }
   }
 
-  beginInsertRows( QModelIndex(), currentCount, currentCount + newProjectsCount - 1 );
-  endInsertRows();
+  if ( !newProjects.isEmpty() )
+  {
+    beginInsertRows( QModelIndex(), currentCount, currentCount + newProjects.size() - 1 );
+    for ( QFieldCloudProject *newProject : newProjects ) // cppcheck-suppress constVariablePointer
+    {
+      mProjects.append( newProject );
+      setupProjectConnections( newProject );
+    }
+    endInsertRows();
+  }
 }
 
 void QFieldCloudProjectsModel::setupProjectConnections( QFieldCloudProject *project )

--- a/src/qml/WelcomeScreen.qml
+++ b/src/qml/WelcomeScreen.qml
@@ -568,16 +568,22 @@ Page {
                 property string path: ProjectPath
                 property var type: ProjectType
                 property int changesCount: {
-                  const project = cloudProjectsModel.findProject(QFieldCloudUtils.getProjectId(ProjectPath));
-                  if (project) {
-                    return project.deltasCount;
+                  const cloudProjectId = QFieldCloudUtils.getProjectId(ProjectPath);
+                  if (cloudProjectId !== "") {
+                    const project = cloudProjectsModel.findProject(cloudProjectId);
+                    if (project) {
+                      return project.deltasCount;
+                    }
                   }
                   return 0;
                 }
                 property bool isOutdated: {
-                  const project = cloudProjectsModel.findProject(QFieldCloudUtils.getProjectId(ProjectPath));
-                  if (project) {
-                    return project.isOutdated;
+                  const cloudProjectId = QFieldCloudUtils.getProjectId(ProjectPath);
+                  if (cloudProjectId !== "") {
+                    const project = cloudProjectsModel.findProject(cloudProjectId);
+                    if (project) {
+                      return project.isOutdated;
+                    }
                   }
                   return 0;
                 }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -5139,7 +5139,7 @@ ApplicationWindow {
           // Go ahead and upload pending attachments in the background
           platformUtilities.uploadPendingAttachments(cloudConnection);
         }
-        var cloudProjectId = QFieldCloudUtils.getProjectId(qgisProject.fileName);
+        const cloudProjectId = QFieldCloudUtils.getProjectId(qgisProject.fileName);
         if (cloudProjectId) {
           projectInfo.cloudUserInformation = userInformation;
           // Refresh cloud project details

--- a/test/test_layerobserver.cpp
+++ b/test/test_layerobserver.cpp
@@ -104,6 +104,7 @@ TEST_CASE( "LayerObserver" )
   mLayerObserver->setDeltaFileWrapper( mDeltaFileWrapper.get() );
 
   REQUIRE( QgsProject::instance()->addMapLayer( mLayer.get(), false, false ) );
+  mLayerObserver->addLayerListeners();
   REQUIRE( !mLayerObserver->deltaFileWrapper()->hasError() );
 
 #if 0
@@ -138,7 +139,7 @@ TEST_CASE( "LayerObserver" )
     REQUIRE( mLayer->commitChanges() );
     REQUIRE( getDeltaOperations( mLayerObserver->deltaFileWrapper()->fileName() ).size() == 2 );
 
-    mLayerObserver->reset();
+    mLayerObserver->deltaFileWrapper()->reset();
     REQUIRE( mLayer->startEditing() );
     REQUIRE( mLayer->commitChanges() );
 


### PR DESCRIPTION
The PR also avoids adding listener every time a layer is added. It creates a situation where we keep adding layers multiple times, and isn't as good as simply adding once the project is read.

Information logged will hopefully help us debug issues with delta file wrapper.