### PR TITLE
Reduce long-press start delay on numeric stepper +/- buttons

### DIFF
--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -133,7 +133,8 @@ EditorWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = false;
-        changeValueTimer.interval = 300;
+        changeValueTimer.interval = changeValueTimer.initialInterval;
+        changeValueTimer.triggered();
         changeValueTimer.restart();
       }
       onReleased: {
@@ -164,7 +165,8 @@ EditorWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = true;
-        changeValueTimer.interval = 300;
+        changeValueTimer.interval = changeValueTimer.initialInterval;
+        changeValueTimer.triggered();
         changeValueTimer.restart();
       }
       onReleased: {
@@ -178,7 +180,8 @@ EditorWidgetBase {
 
   Timer {
     id: changeValueTimer
-    interval: 300
+    property int initialInterval: 500
+    interval: initialInterval
     repeat: true
 
     property bool increase: true

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -133,7 +133,7 @@ EditorWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = false;
-        changeValueTimer.interval = 700;
+        changeValueTimer.interval = 300;
         changeValueTimer.restart();
       }
       onReleased: {
@@ -164,7 +164,7 @@ EditorWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = true;
-        changeValueTimer.interval = 700;
+        changeValueTimer.interval = 300;
         changeValueTimer.restart();
       }
       onReleased: {
@@ -178,7 +178,7 @@ EditorWidgetBase {
 
   Timer {
     id: changeValueTimer
-    interval: 700
+    interval: 300
     repeat: true
 
     property bool increase: true

--- a/src/qml/processingparameterwidgets/area.qml
+++ b/src/qml/processingparameterwidgets/area.qml
@@ -151,7 +151,7 @@ ProcessingParameterWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = false;
-        changeValueTimer.interval = 700;
+        changeValueTimer.interval = 300;
         changeValueTimer.restart();
       }
       onReleased: {
@@ -182,7 +182,7 @@ ProcessingParameterWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = true;
-        changeValueTimer.interval = 700;
+        changeValueTimer.interval = 300;
         changeValueTimer.restart();
       }
       onReleased: {
@@ -196,7 +196,7 @@ ProcessingParameterWidgetBase {
 
   Timer {
     id: changeValueTimer
-    interval: 700
+    interval: 300
     repeat: true
 
     property bool increase: true

--- a/src/qml/processingparameterwidgets/area.qml
+++ b/src/qml/processingparameterwidgets/area.qml
@@ -151,7 +151,8 @@ ProcessingParameterWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = false;
-        changeValueTimer.interval = 300;
+        changeValueTimer.interval = changeValueTimer.initialInterval;
+        changeValueTimer.triggered();
         changeValueTimer.restart();
       }
       onReleased: {
@@ -182,7 +183,8 @@ ProcessingParameterWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = true;
-        changeValueTimer.interval = 300;
+        changeValueTimer.interval = changeValueTimer.initialInterval;
+        changeValueTimer.triggered();
         changeValueTimer.restart();
       }
       onReleased: {
@@ -196,7 +198,8 @@ ProcessingParameterWidgetBase {
 
   Timer {
     id: changeValueTimer
-    interval: 300
+    property int initialInterval: 500
+    interval: initialInterval
     repeat: true
 
     property bool increase: true

--- a/src/qml/processingparameterwidgets/distance.qml
+++ b/src/qml/processingparameterwidgets/distance.qml
@@ -143,7 +143,7 @@ ProcessingParameterWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = false;
-        changeValueTimer.interval = 700;
+        changeValueTimer.interval = 300;
         changeValueTimer.restart();
       }
       onReleased: {
@@ -174,7 +174,7 @@ ProcessingParameterWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = true;
-        changeValueTimer.interval = 700;
+        changeValueTimer.interval = 300;
         changeValueTimer.restart();
       }
       onReleased: {
@@ -188,7 +188,7 @@ ProcessingParameterWidgetBase {
 
   Timer {
     id: changeValueTimer
-    interval: 700
+    interval: 300
     repeat: true
 
     property bool increase: true

--- a/src/qml/processingparameterwidgets/distance.qml
+++ b/src/qml/processingparameterwidgets/distance.qml
@@ -143,7 +143,8 @@ ProcessingParameterWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = false;
-        changeValueTimer.interval = 300;
+        changeValueTimer.interval = changeValueTimer.initialInterval;
+        changeValueTimer.triggered();
         changeValueTimer.restart();
       }
       onReleased: {
@@ -174,7 +175,8 @@ ProcessingParameterWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = true;
-        changeValueTimer.interval = 300;
+        changeValueTimer.interval = changeValueTimer.initialInterval;
+        changeValueTimer.triggered();
         changeValueTimer.restart();
       }
       onReleased: {
@@ -188,7 +190,8 @@ ProcessingParameterWidgetBase {
 
   Timer {
     id: changeValueTimer
-    interval: 300
+    property int initialInterval: 500
+    interval: initialInterval
     repeat: true
 
     property bool increase: true

--- a/src/qml/processingparameterwidgets/number.qml
+++ b/src/qml/processingparameterwidgets/number.qml
@@ -70,7 +70,7 @@ ProcessingParameterWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = false;
-        changeValueTimer.interval = 700;
+        changeValueTimer.interval = 300;
         changeValueTimer.restart();
       }
       onReleased: {
@@ -101,7 +101,7 @@ ProcessingParameterWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = true;
-        changeValueTimer.interval = 700;
+        changeValueTimer.interval = 300;
         changeValueTimer.restart();
       }
       onReleased: {
@@ -115,7 +115,7 @@ ProcessingParameterWidgetBase {
 
   Timer {
     id: changeValueTimer
-    interval: 700
+    interval: 300
     repeat: true
 
     property bool increase: true

--- a/src/qml/processingparameterwidgets/number.qml
+++ b/src/qml/processingparameterwidgets/number.qml
@@ -70,7 +70,8 @@ ProcessingParameterWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = false;
-        changeValueTimer.interval = 300;
+        changeValueTimer.interval = changeValueTimer.initialInterval;
+        changeValueTimer.triggered();
         changeValueTimer.restart();
       }
       onReleased: {
@@ -101,7 +102,8 @@ ProcessingParameterWidgetBase {
       }
       onPressAndHold: {
         changeValueTimer.increase = true;
-        changeValueTimer.interval = 300;
+        changeValueTimer.interval = changeValueTimer.initialInterval;
+        changeValueTimer.triggered();
         changeValueTimer.restart();
       }
       onReleased: {
@@ -115,7 +117,8 @@ ProcessingParameterWidgetBase {
 
   Timer {
     id: changeValueTimer
-    interval: 300
+    property int initialInterval: 500
+    interval: initialInterval
     repeat: true
 
     property bool increase: true


### PR DESCRIPTION
### 🚀 Description
Holding the `+`/`-` buttons on the numeric stepper widgets feels unresponsive today: there is a long pause before the value starts repeating.  This PR lowers the initial repeat interval from `700 ms` to `300 ms`, so a held +/- button starts changing the value much sooner. 
