### PR TITLE
Make value relation search accent-insensitive

### DIFF
--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -359,14 +359,14 @@ void FeatureListModel::gatherFeatureList()
   if ( !mSearchTerm.isEmpty() )
   {
     QString escapedSearchTerm = QgsExpression::quotedValue( mSearchTerm ).replace( QRegularExpression( QStringLiteral( "^'|'$" ) ), QString( "" ) );
-    searchTermExpression = QStringLiteral( " %1 ILIKE '%%2%' " ).arg( fieldDisplayString, escapedSearchTerm );
+    searchTermExpression = QStringLiteral( " unaccent( %1 ) ILIKE unaccent( '%%2%' ) " ).arg( fieldDisplayString, escapedSearchTerm );
 
     QStringList searchTermParts = escapedSearchTerm.split( QRegularExpression( QStringLiteral( "\\s+" ) ), Qt::SkipEmptyParts );
     if ( !searchTermParts.isEmpty() )
     {
       for ( QString &searchTermPart : searchTermParts )
       {
-        searchTermPart = QStringLiteral( "%1 ILIKE '%%2%' " ).arg( fieldDisplayString, searchTermPart );
+        searchTermPart = QStringLiteral( "unaccent( %1 ) ILIKE unaccent( '%%2%' ) " ).arg( fieldDisplayString, searchTermPart );
       }
       searchTermExpression += QStringLiteral( "OR (%2) " ).arg( searchTermParts.join( QStringLiteral( " AND " ) ) );
     }

--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -22,6 +22,7 @@
 #include <QRegularExpression>
 #include <qgsexpressioncontextutils.h>
 #include <qgsproject.h>
+#include <qgsstringutils.h>
 #include <qgsvaluerelationfieldformatter.h>
 
 
@@ -358,15 +359,15 @@ void FeatureListModel::gatherFeatureList()
   QString searchTermExpression;
   if ( !mSearchTerm.isEmpty() )
   {
-    QString escapedSearchTerm = QgsExpression::quotedValue( mSearchTerm ).replace( QRegularExpression( QStringLiteral( "^'|'$" ) ), QString( "" ) );
-    searchTermExpression = QStringLiteral( " unaccent( %1 ) ILIKE unaccent( '%%2%' ) " ).arg( fieldDisplayString, escapedSearchTerm );
+    QString escapedSearchTerm = QgsExpression::quotedValue( QgsStringUtils::unaccent( mSearchTerm ) ).replace( QRegularExpression( QStringLiteral( "^'|'$" ) ), QString( "" ) );
+    searchTermExpression = QStringLiteral( " unaccent( %1 ) ILIKE '%%2%' " ).arg( fieldDisplayString, escapedSearchTerm );
 
     QStringList searchTermParts = escapedSearchTerm.split( QRegularExpression( QStringLiteral( "\\s+" ) ), Qt::SkipEmptyParts );
     if ( !searchTermParts.isEmpty() )
     {
       for ( QString &searchTermPart : searchTermParts )
       {
-        searchTermPart = QStringLiteral( "unaccent( %1 ) ILIKE unaccent( '%%2%' ) " ).arg( fieldDisplayString, searchTermPart );
+        searchTermPart = QStringLiteral( "unaccent( %1 ) ILIKE '%%2%' " ).arg( fieldDisplayString, searchTermPart );
       }
       searchTermExpression += QStringLiteral( "OR (%2) " ).arg( searchTermParts.join( QStringLiteral( " AND " ) ) );
     }

--- a/src/core/utils/stringutils.cpp
+++ b/src/core/utils/stringutils.cpp
@@ -49,16 +49,20 @@ QString StringUtils::createUuid()
 
 double StringUtils::calcFuzzyScore( const QString &string, const QString &searchTerm )
 {
+  // Match accent-insensitively (e.g. "bez" matches "Béziers"), like the callers' search filter.
+  const QString unaccentedString = QgsStringUtils::unaccent( string );
+  const QString unaccentedSearchTerm = QgsStringUtils::unaccent( searchTerm );
+
   double fuzzyScore = 0.0;
-  if ( string.startsWith( searchTerm, Qt::CaseInsensitive ) )
+  if ( unaccentedString.startsWith( unaccentedSearchTerm, Qt::CaseInsensitive ) )
   {
     fuzzyScore += 0.5;
   }
   else
   {
     static QRegularExpression whitespaceRegex( QStringLiteral( "\\W+" ) );
-    const QStringList parts = string.split( whitespaceRegex );
-    const QStringList termParts = searchTerm.split( whitespaceRegex );
+    const QStringList parts = unaccentedString.split( whitespaceRegex );
+    const QStringList termParts = unaccentedSearchTerm.split( whitespaceRegex );
     const qsizetype termPartsCount = termParts.size();
 
     qsizetype lastMatchedTermPartIdx = -1;
@@ -82,7 +86,7 @@ double StringUtils::calcFuzzyScore( const QString &string, const QString &search
     }
   }
 
-  fuzzyScore += QgsStringUtils::fuzzyScore( string, searchTerm ) * 0.5;
+  fuzzyScore += QgsStringUtils::fuzzyScore( unaccentedString, unaccentedSearchTerm ) * 0.5;
   return fuzzyScore;
 };
 
@@ -197,31 +201,46 @@ QString StringUtils::replaceFilenameTags( const QString &string, const QString &
 
 QString StringUtils::highlightText( const QString &string, const QString &highlightText, const QColor &highlightColor )
 {
-  QString formattedString = string.toHtmlEscaped();
-  if ( !highlightText.isEmpty() )
+  if ( highlightText.isEmpty() )
   {
-    const QString formattedHighlightText = highlightText.toHtmlEscaped();
-    const QRegularExpression formattedHighlightExpression( QStringLiteral( "(?!=&[a-z]*)(%1)(?![a-z]*;)" ).arg( formattedHighlightText ), QRegularExpression::CaseInsensitiveOption );
-    if ( formattedString.contains( formattedHighlightExpression ) )
+    return string.toHtmlEscaped();
+  }
+
+  const QString unaccentedString = QgsStringUtils::unaccent( string );
+  const QString unaccentedHighlight = QgsStringUtils::unaccent( highlightText );
+  if ( unaccentedString.length() != string.length() )
+  {
+    return string.toHtmlEscaped();
+  }
+
+  QStringList patterns { QRegularExpression::escape( unaccentedHighlight ) };
+  if ( !unaccentedString.contains( QRegularExpression( patterns.constFirst(), QRegularExpression::CaseInsensitiveOption ) ) )
+  {
+    patterns = unaccentedHighlight.split( ' ', Qt::SkipEmptyParts );
+    patterns.removeDuplicates();
+    for ( QString &part : patterns )
     {
-      formattedString.replace( formattedHighlightExpression, QStringLiteral( "<span style=\"text-decoration:underline;%1\">\\1</span>" ).arg( highlightColor.isValid() ? QStringLiteral( "color:%1" ).arg( highlightColor.name() ) : QString() ) );
-    }
-    else
-    {
-      QStringList highlightParts = highlightText.toLower().split( ' ', Qt::SkipEmptyParts );
-      highlightParts.removeDuplicates();
-      std::sort( highlightParts.begin(), highlightParts.end(), []( const QString &s1, const QString &s2 ) { return s1.size() < s2.size(); } );
-      for ( QString &highlightPart : highlightParts )
-      {
-        highlightPart = highlightPart.toHtmlEscaped();
-      }
-      const QRegularExpression formattedHighlightPartsExpression( QStringLiteral( "(?!=&[a-z]*)(%1)(?![a-z]*;)" ).arg( highlightParts.join( '|' ) ), QRegularExpression::CaseInsensitiveOption );
-      if ( formattedString.contains( formattedHighlightPartsExpression ) )
-      {
-        formattedString.replace( formattedHighlightPartsExpression, QStringLiteral( "<span style=\"text-decoration:underline;%1\">\\1</span>" ).arg( highlightColor.isValid() ? QStringLiteral( "color:%1" ).arg( highlightColor.name() ) : QString() ) );
-      }
+      part = QRegularExpression::escape( part );
     }
   }
+  if ( patterns.isEmpty() )
+  {
+    return string.toHtmlEscaped();
+  }
+
+  const QRegularExpression expression( patterns.join( '|' ), QRegularExpression::CaseInsensitiveOption );
+  const QString spanStyle = highlightColor.isValid() ? QStringLiteral( "color:%1" ).arg( highlightColor.name() ) : QString();
+  QString formattedString;
+  qsizetype cursor = 0;
+  QRegularExpressionMatchIterator matchIterator = expression.globalMatch( unaccentedString );
+  while ( matchIterator.hasNext() )
+  {
+    const QRegularExpressionMatch match = matchIterator.next();
+    formattedString += string.mid( cursor, match.capturedStart() - cursor ).toHtmlEscaped();
+    formattedString += QStringLiteral( "<span style=\"text-decoration:underline;%1\">%2</span>" ).arg( spanStyle, string.mid( match.capturedStart(), match.capturedLength() ).toHtmlEscaped() );
+    cursor = match.capturedEnd();
+  }
+  formattedString += string.mid( cursor ).toHtmlEscaped();
 
   return formattedString;
 }

--- a/test/test_featurelistmodel.cpp
+++ b/test/test_featurelistmodel.cpp
@@ -40,6 +40,75 @@ TEST_CASE( "FeatureListModel validation checks" )
   REQUIRE( featureListModel.findDisplayValueMatches( QStringLiteral( "t" ) ).isEmpty() );
 }
 
+TEST_CASE( "FeatureListModel accent-insensitive search" )
+{
+  if ( !QCoreApplication::instance() )
+  {
+    static int applicationArgumentCount = 1;
+    static char applicationArgumentZero[] = "qfield-tests";
+    static char *applicationArgumentValues[] = { applicationArgumentZero, nullptr };
+    static QCoreApplication coreApplication( applicationArgumentCount, applicationArgumentValues );
+    Q_UNUSED( coreApplication );
+  }
+
+  static const int maximumWaitTimeMilliseconds = 5000;
+
+  std::unique_ptr<QgsVectorLayer> vectorLayerDummy(
+    new QgsVectorLayer(
+      "Point?crs=epsg:4326&field=key:integer&field=name:string",
+      "test",
+      "memory" ) );
+
+  REQUIRE( vectorLayerDummy->isValid() );
+
+  QgsFeature accentedFeature( vectorLayerDummy->fields() );
+  accentedFeature.setAttribute( "key", 1 );
+  accentedFeature.setAttribute( "name", QString::fromUtf8( "Béziers" ) );
+  accentedFeature.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( 0, 0 ) ) );
+
+  QgsFeature otherFeature( vectorLayerDummy->fields() );
+  otherFeature.setAttribute( "key", 2 );
+  otherFeature.setAttribute( "name", QStringLiteral( "Bricks" ) );
+  otherFeature.setGeometry( QgsGeometry::fromPointXY( QgsPointXY( 1, 1 ) ) );
+
+  vectorLayerDummy->startEditing();
+  vectorLayerDummy->addFeature( accentedFeature );
+  vectorLayerDummy->addFeature( otherFeature );
+  vectorLayerDummy->commitChanges();
+
+  FeatureListModel featureListModel;
+  featureListModel.setKeyField( QStringLiteral( "key" ) );
+  featureListModel.setDisplayValueField( QStringLiteral( "name" ) );
+  featureListModel.setCurrentLayer( vectorLayerDummy.get() );
+
+  // Wait for initial population (timer and gatherer thread)
+  {
+    QElapsedTimer waitForPopulationTimer;
+    waitForPopulationTimer.start();
+    while ( featureListModel.rowCount() != 2 && waitForPopulationTimer.elapsed() < maximumWaitTimeMilliseconds )
+    {
+      QCoreApplication::processEvents( QEventLoop::AllEvents, 50 );
+    }
+    REQUIRE( featureListModel.rowCount() == 2 );
+  }
+
+  // Searching without the accent still matches the accented value ("bez" -> "Béziers")
+  {
+    featureListModel.setSearchTerm( QStringLiteral( "bez" ) );
+
+    QElapsedTimer waitForSearchTimer;
+    waitForSearchTimer.start();
+    while ( featureListModel.rowCount() != 1 && waitForSearchTimer.elapsed() < maximumWaitTimeMilliseconds )
+    {
+      QCoreApplication::processEvents( QEventLoop::AllEvents, 50 );
+    }
+
+    REQUIRE( featureListModel.rowCount() == 1 );
+    REQUIRE( featureListModel.dataFromRowIndex( 0, FeatureListModel::DisplayStringRole ).toString() == QString::fromUtf8( "Béziers" ) );
+    REQUIRE( featureListModel.findKey( QVariant( 1 ) ) >= 0 );
+  }
+}
+
 TEST_CASE( "FeatureListModel behaviours" )
 {
   if ( !QCoreApplication::instance() )

--- a/test/test_stringutils.cpp
+++ b/test/test_stringutils.cpp
@@ -36,5 +36,9 @@ TEST_CASE( "StringUtils" )
     REQUIRE( StringUtils::highlightText( "QField roxx", "doxx", QColor( Qt::black ) ) == "QField roxx" );
     REQUIRE( StringUtils::highlightText( "QField <roxx>", "rox", QColor( Qt::black ) ) == "QField &lt;<span style=\"text-decoration:underline;color:#000000\">rox</span>x&gt;" );
     REQUIRE( StringUtils::highlightText( "QField rox - rox", "rox", QColor( Qt::black ) ) == "QField <span style=\"text-decoration:underline;color:#000000\">rox</span> - <span style=\"text-decoration:underline;color:#000000\">rox</span>" );
+
+    REQUIRE( StringUtils::highlightText( "Béziers", "bez", QColor( Qt::black ) ) == "<span style=\"text-decoration:underline;color:#000000\">Béz</span>iers" );
+    REQUIRE( StringUtils::highlightText( "Crème brûlée", "creme", QColor( Qt::black ) ) == "<span style=\"text-decoration:underline;color:#000000\">Crème</span> brûlée" );
+    REQUIRE( StringUtils::highlightText( "beziers", "béz", QColor( Qt::black ) ) == "<span style=\"text-decoration:underline;color:#000000\">bez</span>iers" );
   }
 }


### PR DESCRIPTION
### 🚀 Description
The search field in the value relation widget now matches accent-insensitively, so users can find entries without typing diacritics — e.g. typing `bez` matches `Béziers`, `creme` matches `Crème brûlée`, and `munch` matches `München`.\

### ✨ Key Changes
- `FeatureListModel::gatherFeatureList()`: the `ILIKE` search expression now wraps both the field and the search term with the QGIS `unaccent()` expression function.

- `StringUtils::highlightText()`: the result highlighting is now accent-insensitive too, so the matched portion of an accented entry (e.g. Béz in Béziers) is underlined.

### Demo   



<img width="524" height="317" alt="Screenshot From 2026-07-01 01-49-50" src="https://github.com/user-attachments/assets/ae9fe2fe-3b95-44b1-99b6-f074d0d0f615" />
