### PR TITLE
Parse the plugin translation files with underscore

### DIFF
--- a/src/core/pluginmanager.cpp
+++ b/src/core/pluginmanager.cpp
@@ -86,7 +86,7 @@ void PluginManager::loadPlugin( const QString &pluginPath, const QString &plugin
   QFileInfo pluginFileInfo( pluginPath );
   const QString languageCode = QLocale().name();
   QTranslator *languageTranslator = new QTranslator();
-  if ( languageTranslator->load( QStringLiteral( "%1%2%3" ).arg( pluginFileInfo.fileName().chopped( 4 ), pluginFileInfo.fileName() == QStringLiteral( "main.qml" ) ? "" : QStringLiteral( "-plugin_" ), languageCode ), pluginFileInfo.absolutePath(), "_" ) )
+  if ( languageTranslator->load( QStringLiteral( "%1%2%3" ).arg( pluginFileInfo.fileName().chopped( 4 ), pluginFileInfo.fileName() == QStringLiteral( "main.qml" ) ? QStringLiteral( "_" ) : QStringLiteral( "-plugin_" ), languageCode ), pluginFileInfo.absolutePath(), "_" ) )
   {
     QCoreApplication::installTranslator( languageTranslator );
     mLoadedPluginTranslators.insert( pluginPath, languageTranslator );


### PR DESCRIPTION
Currently, if an app-wide plugin is named `main.qml` QF would consider the `mainfr.qml` file, though we want the `main_fr.qml` file and equivalents to be considered, which is what this PR intends to do.