### PR TITLE
 Handle scenario in which we pass on an invalid QDateTime() value for datetime attributes

### DIFF
--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -116,26 +116,8 @@ EditorWidgetBase {
         enabled: config['calendar_popup'] === undefined || config['calendar_popup']
         anchors.fill: parent
         onClicked: {
-          let usedDate = new Date();
-          if (value !== undefined && value != '') {
-            usedDate = value;
-          }
-
-          if (usedDate instanceof Date) {
-            // Deal with invalid (i.e. null) QDateTime
-            if (isNaN(usedDate.getTime())) {
-              usedDate = new Date();
-            }
-          } else {
-            let dateFormat = config['field_format'] !== undefined ? config['field_format'] : 'yyyy-MM-dd';
-            if (!!config['field_format_overwrite']) {
-              dateFormat = !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['field_format'];
-            }
-            usedDate = Date.fromLocaleString(Qt.locale(), value, dateFormat);
-          }
-
           todayButton.forceActiveFocus();
-          calendarPanel.selectedDate = usedDate;
+          calendarPanel.selectedDate = convertValueToDate(value);
           calendarPanel.open();
         }
       }
@@ -255,5 +237,27 @@ EditorWidgetBase {
       dateFormat = !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['field_format'];
     }
     return Qt.formatDateTime(date, dateFormat);
+  }
+
+  function convertValueToDate(value) {
+    let usedDate = new Date();
+    if (value !== undefined && value != '') {
+      usedDate = value;
+    }
+
+    if (usedDate instanceof Date) {
+      // Deal with invalid (i.e. null) QDateTime
+      if (isNaN(usedDate.getTime())) {
+        usedDate = new Date();
+      }
+    } else {
+      let dateFormat = config['field_format'] !== undefined ? config['field_format'] : 'yyyy-MM-dd';
+      if (!!config['field_format_overwrite']) {
+        dateFormat = !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['field_format'];
+      }
+      usedDate = Date.fromLocaleString(Qt.locale(), value, dateFormat);
+    }
+
+    return usedDate;
   }
 }

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -120,13 +120,20 @@ EditorWidgetBase {
           if (value !== undefined && value != '') {
             usedDate = value;
           }
-          if (!(usedDate instanceof Date)) {
+
+          if (usedDate instanceof Date) {
+            // Deal with invalid (i.e. null) QDateTime
+            if (isNaN(usedDate.getTime())) {
+              usedDate = new Date();
+            }
+          } else {
             let dateFormat = config['field_format'] !== undefined ? config['field_format'] : 'yyyy-MM-dd';
             if (!!config['field_format_overwrite']) {
               dateFormat = !!config['field_iso_format'] ? 'yyyy-MM-dd HH:mm:ss+t' : config['field_format'];
             }
             usedDate = Date.fromLocaleString(Qt.locale(), value, dateFormat);
           }
+
           todayButton.forceActiveFocus();
           calendarPanel.selectedDate = usedDate;
           calendarPanel.open();

--- a/test/qml/tst_editorwidgets.qml
+++ b/test/qml/tst_editorwidgets.qml
@@ -335,6 +335,11 @@ TestCase {
         compare(label.text, results[resultIdx++]);
       }
     }
+
+    // Simulate an empty QDateTime() value and insure we get a valid date to be used with the calendar popup in return
+    const invalidDatetimeValue = new Date("-");
+    const date = dateTime.convertValueToDate(invalidDatetimeValue);
+    verify(!isNaN(date.getTime()));
   }
 
   /**


### PR DESCRIPTION
Prevents this horrific scenario:

<img width="510" height="802" alt="image" src="https://github.com/user-attachments/assets/a5796b85-dafc-4753-bddd-0d5c31cd1214" />
