### PR TITLE
Add admonition md extensions for plugins doc

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,4 +42,7 @@ nav:
   - QML Items: QField/group__qml.md
 
 markdown_extensions:
+  - admonition
   - attr_list
+  - pymdownx.details
+  - pymdownx.superfences


### PR DESCRIPTION
Follow-up of #7658 -> adding the missing admonitions markdown extensions for the Plugins API doc,  
See https://squidfunk.github.io/mkdocs-material/reference/admonitions/#configuration

| Before | After |
| --- | --- |
| <img width="794" height="519" alt="image" src="https://github.com/user-attachments/assets/297c1575-87f9-4c27-add8-a9da8f19d325" /> | <img width="785" height="601" alt="image" src="https://github.com/user-attachments/assets/932e2936-3ec4-4a40-b23e-23263cbfb88f" /> |
| <img width="791" height="459" alt="image" src="https://github.com/user-attachments/assets/60a8b187-7014-4023-94bd-8da12c7b6e26" /> | <img width="794" height="592" alt="image" src="https://github.com/user-attachments/assets/c808c890-b10a-4277-b49c-79a421ea04a5" /> |