### PR TITLE
QfPaneDrawer component shared by the featurelistform and bookmarklist drawers

### DIFF
--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -14,11 +14,6 @@ QfPaneDrawer {
   id: bookmarkList
   property alias model: bookmarksList.model
   property bool multiSelection: false
-  onMultiSelectionChanged: {
-    if (model) {
-      model.hideProjectBookmarks = multiSelection;
-    }
-  }
 
   contentVisible: props.isVisible
   freezeKey: 'bookmarkresize'
@@ -415,6 +410,13 @@ QfPaneDrawer {
   function show() {
     props.isVisible = true;
     focus = true;
+  }
+
+  function setMultiSelection(active) {
+    multiSelection = active;
+    if (model) {
+      model.hideProjectBookmarks = active;
+    }
   }
 
   function hide() {

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -433,7 +433,7 @@ QfPaneDrawer {
   function hide() {
     props.isVisible = false;
     focus = false;
-    fullScreenView = false;
+    isFullscreen = false;
     bookmarkList.setMultiSelection(false);
     if (bookmarkList.model) {
       bookmarkList.model.clearSelection();

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -10,68 +10,22 @@ import Theme
 /**
  * \ingroup qml
  */
-Pane {
+QfPaneDrawer {
   id: bookmarkList
   property alias model: bookmarksList.model
   property bool multiSelection: false
-  property bool fullScreenView: false
-  property bool isVertical: parent.width < parent.height || parent.width < 300
-  property bool isDragging: false
-  property real dragHeightAdjustment: 0
-  property real dragWidthAdjustment: 0
-  property real lastWidth
-
-  width: {
-    if (props.isVisible) {
-      if (dragWidthAdjustment != 0) {
-        return lastWidth - dragWidthAdjustment;
-      } else if (fullScreenView || parent.width <= parent.height || width >= 0.95 * parent.width) {
-        lastWidth = parent.width;
-        return parent.width;
-      } else {
-        const newWidth = Math.min(Math.max(200, parent.width / 2.25), parent.width);
-        lastWidth = newWidth;
-        return newWidth;
-      }
-    } else {
-      lastWidth = 0;
-      return 0;
-    }
-  }
-  property real lastHeight
-
-  height: {
-    if (props.isVisible) {
-      if (dragHeightAdjustment != 0) {
-        return Math.min(lastHeight - dragHeightAdjustment, parent.height - mainWindow.sceneTopMargin);
-      } else if (fullScreenView || parent.width > parent.height || height >= 0.95 * parent.height) {
-        lastHeight = parent.height;
-        return parent.height;
-      } else {
-        const defaultMin = Math.min(Math.max(200, parent.height / 2), parent.height);
-        const minContentHeight = bookmarkListToolBar.height + (bookmarksList.contentHeight + bookmarksList.anchors.bottomMargin) + 25;
-        const newHeight = Math.min(minContentHeight, defaultMin);
-        lastHeight = newHeight;
-        return newHeight;
-      }
-    } else {
-      lastHeight = 0;
-      return 0;
+  onMultiSelectionChanged: {
+    if (model) {
+      model.hideProjectBookmarks = multiSelection;
     }
   }
 
-  topPadding: 0
-  leftPadding: 0
-  rightPadding: 0
-  bottomPadding: 0
+  contentVisible: props.isVisible
+  freezeKey: 'bookmarkresize'
+  headerHeight: bookmarkListToolBar.height
+  minContentHeight: bookmarkListToolBar.height + (bookmarksList.contentHeight + bookmarksList.anchors.bottomMargin) + 25
 
-  visible: props.isVisible
-  clip: true
-
-  WheelHandler {
-    acceptedDevices: PointerDevice.AllDevices
-    onWheel: {}
-  }
+  onCollapsed: bookmarkList.hide()
 
   QtObject {
     id: props
@@ -443,50 +397,6 @@ Pane {
     }
   }
 
-  function setMultiSelection(active) {
-    multiSelection = active;
-    if (model) {
-      model.hideProjectBookmarks = active;
-    }
-  }
-
-  function statusIndicatorDragged(deltaX, deltaY) {
-    fullScreenView = false;
-    if (isVertical) {
-      dragHeightAdjustment += deltaY;
-    } else {
-      dragWidthAdjustment += deltaX;
-    }
-  }
-
-  function statusIndicatorDragReleased() {
-    isDragging = false;
-    if (isVertical) {
-      const minContentHeight = bookmarkListToolBar.height + 48 + 30;
-      if (bookmarkList.height < minContentHeight) {
-        if (fullScreenView) {
-          fullScreenView = false;
-        } else {
-          bookmarkList.hide();
-        }
-      } else if (dragHeightAdjustment < -parent.height * 0.2) {
-        fullScreenView = true;
-      }
-    } else {
-      if (bookmarkList.width < bookmarkList.parent.width * 0.3) {
-        if (fullScreenView) {
-          fullScreenView = false;
-        } else {
-          bookmarkList.hide();
-        }
-      } else if (dragWidthAdjustment < -parent.width * 0.2) {
-        fullScreenView = true;
-      }
-    }
-    dragHeightAdjustment = 0;
-    dragWidthAdjustment = 0;
-  }
-
   Keys.onReleased: event => {
     if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
       if (Overlay.overlay && Overlay.overlay.visibleChildren.length > 1 || (Overlay.overlay.visibleChildren.length === 1 && !toast.visible)) {
@@ -499,36 +409,6 @@ Pane {
         bookmarkList.hide();
       }
       event.accepted = true;
-    }
-  }
-
-  Behavior on width {
-    enabled: !isDragging
-    PropertyAnimation {
-      duration: parent.width > parent.height ? 250 : 0
-      easing.type: Easing.OutQuart
-
-      onRunningChanged: {
-        if (running)
-          mapCanvasMap.freeze('bookmarkresize');
-        else
-          mapCanvasMap.unfreeze('bookmarkresize');
-      }
-    }
-  }
-
-  Behavior on height {
-    enabled: !isDragging
-    PropertyAnimation {
-      duration: parent.width < parent.height ? 250 : 0
-      easing.type: Easing.OutQuart
-
-      onRunningChanged: {
-        if (running)
-          mapCanvasMap.freeze('bookmarkresize');
-        else
-          mapCanvasMap.unfreeze('bookmarkresize');
-      }
     }
   }
 

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -22,6 +22,16 @@ QfPaneDrawer {
 
   onCollapsed: bookmarkList.hide()
 
+  states: [
+    State {
+      name: "Hidden"
+    },
+    State {
+      name: "Visible"
+    }
+  ]
+  state: "Hidden"
+
   QtObject {
     id: props
 
@@ -410,6 +420,7 @@ QfPaneDrawer {
   function show() {
     props.isVisible = true;
     focus = true;
+    state = "Visible";
   }
 
   function setMultiSelection(active) {
@@ -427,5 +438,6 @@ QfPaneDrawer {
     if (bookmarkList.model) {
       bookmarkList.model.clearSelection();
     }
+    state = "Hidden";
   }
 }

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -26,7 +26,7 @@ import Theme
 /**
  * \ingroup qml
  */
-Pane {
+QfPaneDrawer {
   id: featureFormList
 
   property ProcessingAlgorithm algorithm: processingAlgorithm
@@ -49,14 +49,21 @@ Pane {
   property bool allowDelete
 
   property bool multiSelection: false
-  property bool fullScreenView: qfieldSettings.fullScreenIdentifyView
-  property bool isVertical: parent.width < parent.height || parent.width < 300
-
-  property bool isDragging: false
-  property real dragHeightAdjustment: 0
-  property real dragWidthAdjustment: 0
+  fullScreenView: qfieldSettings.fullScreenIdentifyView
 
   property bool canvasOperationRequested: digitizingToolbar.geometryRequested || moveFeaturesToolbar.moveFeaturesRequested || rotateFeaturesToolbar.rotateFeaturesRequested
+
+  contentVisible: props.isVisible || featureFormList.canvasOperationRequested
+  freezeKey: 'formresize'
+  headerHeight: featureListToolBar.height
+  useDefaultMinHeight: featureFormList.state !== "FeatureList"
+  minContentHeight: featureListToolBar.height + (globalFeaturesList.contentHeight + globalFeaturesList.anchors.bottomMargin) + 25
+
+  onCollapsed: {
+    if (featureFormList.state !== 'FeatureFormEdit') {
+      featureFormList.state = 'Hidden';
+    }
+  }
 
   signal showMessage(string message)
   signal editGeometry
@@ -66,58 +73,11 @@ Pane {
     featureForm.requestCancel();
   }
 
-  property real lastWidth
-
-  width: {
-    if (props.isVisible || featureFormList.canvasOperationRequested) {
-      if (dragWidthAdjustment != 0) {
-        return lastWidth - dragWidthAdjustment;
-      } else if (fullScreenView || parent.width <= parent.height || width >= 0.95 * parent.width) {
-        lastWidth = parent.width;
-        return parent.width;
-      } else {
-        const newWidth = Math.min(Math.max(200, parent.width / 2.25), parent.width);
-        lastWidth = newWidth;
-        return newWidth;
-      }
-    } else {
-      lastWidth = 0;
-      return 0;
-    }
-  }
-  property real lastHeight
-
-  height: {
-    if (props.isVisible || featureFormList.canvasOperationRequested) {
-      if (dragHeightAdjustment != 0) {
-        return Math.min(lastHeight - dragHeightAdjustment, parent.height - mainWindow.sceneTopMargin);
-      } else if (fullScreenView || parent.width > parent.height || height >= 0.95 * parent.height) {
-        lastHeight = parent.height;
-        return parent.height;
-      } else {
-        const defaultMin = Math.min(Math.max(200, parent.height / 2), parent.height);
-        var minContentHeight = featureFormList.state !== "FeatureList" ? defaultMin : featureListToolBar.height + (globalFeaturesList.contentHeight + globalFeaturesList.anchors.bottomMargin) + 25;
-        const newHeight = Math.min(minContentHeight, defaultMin);
-        lastHeight = newHeight;
-        return newHeight;
-      }
-    } else {
-      lastHeight = 0;
-      return 0;
-    }
-  }
-
   anchors.bottomMargin: featureFormList.canvasOperationRequested ? featureFormList.height : 0
   anchors.rightMargin: featureFormList.canvasOperationRequested ? -featureFormList.width : 0
   opacity: featureFormList.canvasOperationRequested ? 0.5 : 1
 
-  topPadding: 0
-  leftPadding: 0
-  rightPadding: 0
-  bottomPadding: 0
-
   enabled: !featureFormList.canvasOperationRequested
-  visible: props.isVisible
 
   states: [
     State {
@@ -255,12 +215,6 @@ Pane {
     }
   ]
   state: "Hidden"
-  clip: true
-
-  WheelHandler {
-    acceptedDevices: PointerDevice.AllDevices
-    onWheel: {}
-  }
 
   QtObject {
     id: props
@@ -560,48 +514,15 @@ Pane {
     }
 
     onStatusIndicatorDragged: function (deltaX, deltaY) {
-      fullScreenView = false;
-      if (isVertical) {
-        dragHeightAdjustment += deltaY;
-      } else {
-        dragWidthAdjustment += deltaX;
-      }
+      featureFormList.statusIndicatorDragged(deltaX, deltaY);
     }
 
     onStatusIndicatorDragAcquired: {
-      isDragging = true;
+      featureFormList.isDragging = true;
     }
 
     onStatusIndicatorDragReleased: {
-      isDragging = false;
-      if (isVertical) {
-        const minContentHeight = featureListToolBar.height + 48 + 30;
-        if (featureFormList.height < minContentHeight) {
-          if (fullScreenView) {
-            fullScreenView = false;
-          } else {
-            if (featureFormList.state !== 'FeatureFormEdit') {
-              featureFormList.state = 'Hidden';
-            }
-          }
-        } else if (dragHeightAdjustment < -parent.height * 0.2) {
-          fullScreenView = true;
-        }
-      } else {
-        if (featureFormList.width < featureFormList.parent.width * 0.3) {
-          if (fullScreenView) {
-            fullScreenView = false;
-          } else {
-            if (featureFormList.state != 'FeatureFormEdit') {
-              featureFormList.state = 'Hidden';
-            }
-          }
-        } else if (dragWidthAdjustment < -parent.width * 0.2) {
-          fullScreenView = true;
-        }
-      }
-      dragHeightAdjustment = 0;
-      dragWidthAdjustment = 0;
+      featureFormList.statusIndicatorDragReleased();
     }
 
     onEditAttributesButtonClicked: {
@@ -803,36 +724,6 @@ Pane {
         }
       }
       event.accepted = true;
-    }
-  }
-
-  Behavior on width {
-    enabled: !isDragging
-    PropertyAnimation {
-      duration: parent.width > parent.height ? 250 : 0
-      easing.type: Easing.OutQuart
-
-      onRunningChanged: {
-        if (running)
-          mapCanvasMap.freeze('formresize');
-        else
-          mapCanvasMap.unfreeze('formresize');
-      }
-    }
-  }
-
-  Behavior on height {
-    enabled: !isDragging
-    PropertyAnimation {
-      duration: parent.width < parent.height ? 250 : 0
-      easing.type: Easing.OutQuart
-
-      onRunningChanged: {
-        if (running)
-          mapCanvasMap.freeze('formresize');
-        else
-          mapCanvasMap.unfreeze('formresize');
-      }
     }
   }
 

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -49,7 +49,7 @@ QfPaneDrawer {
   property bool allowDelete
 
   property bool multiSelection: false
-  fullScreenView: qfieldSettings.fullScreenIdentifyView
+  isFullscreen: qfieldSettings.fullScreenIdentifyView
 
   property bool canvasOperationRequested: digitizingToolbar.geometryRequested || moveFeaturesToolbar.moveFeaturesRequested || rotateFeaturesToolbar.rotateFeaturesRequested
 
@@ -790,7 +790,7 @@ QfPaneDrawer {
   function hide() {
     props.isVisible = false;
     focus = false;
-    fullScreenView = qfieldSettings.fullScreenIdentifyView;
+    isFullscreen = qfieldSettings.fullScreenIdentifyView;
     if (!featureFormList.canvasOperationRequested) {
       featureFormList.multiSelection = false;
       featureForm.model.featureModel.modelMode = FeatureModel.SingleFeatureModel;

--- a/src/qml/imports/Theme/QfPaneDrawer.qml
+++ b/src/qml/imports/Theme/QfPaneDrawer.qml
@@ -1,0 +1,149 @@
+import QtQuick
+import QtQuick.Controls
+
+/**
+ * \ingroup qml
+ */
+Pane {
+  id: paneDrawer
+
+  property bool isVertical: parent.width < parent.height || parent.width < 300
+  property bool fullScreenView: false
+  property bool isDragging: false
+  property real dragHeightAdjustment: 0
+  property real dragWidthAdjustment: 0
+  property real lastWidth
+  property real lastHeight
+
+  // When TRUE the pane is laid out at its resting size, when FALSE it collapses to zero
+  property bool contentVisible: false
+  // Content driven minimum height the pane snaps to at rest, clamped to half the available height
+  property real minContentHeight: 0
+  // When TRUE the resting height ignores a minContentHeight and uses the default minimum
+  property bool useDefaultMinHeight: false
+  // Height of the header, used to compute the collapse threshold
+  property real headerHeight: 0
+  // Key passed to mapCanvasMap freeze/unfreeze so concurrent panes does not clear each other
+  property string freezeKey
+  // Emitted when a drag releases below the minimum size without entering fullscreen
+  signal collapsed
+
+  width: {
+    if (contentVisible) {
+      if (dragWidthAdjustment != 0) {
+        return lastWidth - dragWidthAdjustment;
+      } else if (fullScreenView || parent.width <= parent.height || width >= 0.95 * parent.width) {
+        lastWidth = parent.width;
+        return parent.width;
+      } else {
+        const newWidth = Math.min(Math.max(200, parent.width / 2.25), parent.width);
+        lastWidth = newWidth;
+        return newWidth;
+      }
+    } else {
+      lastWidth = 0;
+      return 0;
+    }
+  }
+
+  height: {
+    if (contentVisible) {
+      if (dragHeightAdjustment != 0) {
+        return Math.min(lastHeight - dragHeightAdjustment, parent.height - mainWindow.sceneTopMargin);
+      } else if (fullScreenView || parent.width > parent.height || height >= 0.95 * parent.height) {
+        lastHeight = parent.height;
+        return parent.height;
+      } else {
+        const defaultMin = Math.min(Math.max(200, parent.height / 2), parent.height);
+        const newHeight = useDefaultMinHeight ? defaultMin : Math.min(minContentHeight, defaultMin);
+        lastHeight = newHeight;
+        return newHeight;
+      }
+    } else {
+      lastHeight = 0;
+      return 0;
+    }
+  }
+
+  topPadding: 0
+  leftPadding: 0
+  rightPadding: 0
+  bottomPadding: 0
+
+  visible: contentVisible
+  clip: true
+
+  WheelHandler {
+    acceptedDevices: PointerDevice.AllDevices
+    onWheel: {}
+  }
+
+  function statusIndicatorDragged(deltaX, deltaY) {
+    fullScreenView = false;
+    if (isVertical) {
+      dragHeightAdjustment += deltaY;
+    } else {
+      dragWidthAdjustment += deltaX;
+    }
+  }
+
+  function statusIndicatorDragReleased() {
+    isDragging = false;
+    if (isVertical) {
+      const minHeight = headerHeight + 48 + 30;
+      if (paneDrawer.height < minHeight) {
+        if (fullScreenView) {
+          fullScreenView = false;
+        } else {
+          paneDrawer.collapsed();
+        }
+      } else if (dragHeightAdjustment < -parent.height * 0.2) {
+        fullScreenView = true;
+      }
+    } else {
+      if (paneDrawer.width < paneDrawer.parent.width * 0.3) {
+        if (fullScreenView) {
+          fullScreenView = false;
+        } else {
+          paneDrawer.collapsed();
+        }
+      } else if (dragWidthAdjustment < -parent.width * 0.2) {
+        fullScreenView = true;
+      }
+    }
+    dragHeightAdjustment = 0;
+    dragWidthAdjustment = 0;
+  }
+
+  Behavior on width {
+    enabled: !isDragging
+    PropertyAnimation {
+      duration: paneDrawer.parent.width > paneDrawer.parent.height ? 250 : 0
+      easing.type: Easing.OutQuart
+
+      onRunningChanged: {
+        if (running) {
+          mapCanvasMap.freeze(paneDrawer.freezeKey);
+        } else {
+          mapCanvasMap.unfreeze(paneDrawer.freezeKey);
+        }
+      }
+    }
+  }
+
+  Behavior on height {
+    enabled: !isDragging
+    PropertyAnimation {
+      duration: paneDrawer.parent.width < paneDrawer.parent.height ? 250 : 0
+      easing.type: Easing.OutQuart
+
+      onRunningChanged: {
+        if (running) {
+          mapCanvasMap.freeze(paneDrawer.freezeKey);
+        } else {
+          mapCanvasMap.unfreeze(paneDrawer.freezeKey);
+        }
+      }
+    }
+  }
+}

--- a/src/qml/imports/Theme/QfPaneDrawer.qml
+++ b/src/qml/imports/Theme/QfPaneDrawer.qml
@@ -7,60 +7,69 @@ import QtQuick.Controls
 Pane {
   id: paneDrawer
 
-  property bool isVertical: parent.width < parent.height || parent.width < 300
+  //! TRUE when the pane is laid out vertically (portrait or narrow), driving the drag axis and resize animation direction
+  readonly property bool isVertical: parent.width < parent.height || parent.width < 300
+  //! When TRUE the pane expands to fill the whole available area
   property bool fullScreenView: false
+  //! TRUE while the header is being dragged to resize the pane
   property bool isDragging: false
-  property real dragHeightAdjustment: 0
-  property real dragWidthAdjustment: 0
-  property real lastWidth
-  property real lastHeight
 
-  // When TRUE the pane is laid out at its resting size, when FALSE it collapses to zero
+  //! When TRUE the pane is laid out at its resting size, when FALSE it collapses to zero
   property bool contentVisible: false
-  // Content driven minimum height the pane snaps to at rest, clamped to half the available height
+  //! Content driven minimum height the pane snaps to at rest, clamped to half the available height
   property real minContentHeight: 0
-  // When TRUE the resting height ignores a minContentHeight and uses the default minimum
+  //! When TRUE the resting height ignores a minContentHeight and uses the default minimum
   property bool useDefaultMinHeight: false
-  // Height of the header, used to compute the collapse threshold
+  //! Height of the header, used to compute the collapse threshold
   property real headerHeight: 0
-  // Key passed to mapCanvasMap freeze/unfreeze so concurrent panes does not clear each other
+  //! Key passed to mapCanvasMap freeze/unfreeze so concurrent panes does not clear each other
   property string freezeKey
-  // Emitted when a drag releases below the minimum size without entering fullscreen
+  //! Emitted when a drag releases below the minimum size without entering fullscreen
   signal collapsed
+
+  //! Internal state driving the resize math, kept out of the public interface
+  QtObject {
+    id: props
+
+    property real dragHeightAdjustment: 0
+    property real dragWidthAdjustment: 0
+    property real lastWidth
+    property real lastHeight
+  }
 
   width: {
     if (contentVisible) {
-      if (dragWidthAdjustment != 0) {
-        return lastWidth - dragWidthAdjustment;
+      if (props.dragWidthAdjustment != 0) {
+        return props.lastWidth - props.dragWidthAdjustment;
       } else if (fullScreenView || parent.width <= parent.height || width >= 0.95 * parent.width) {
-        lastWidth = parent.width;
+        props.lastWidth = parent.width;
         return parent.width;
       } else {
         const newWidth = Math.min(Math.max(200, parent.width / 2.25), parent.width);
-        lastWidth = newWidth;
+        props.lastWidth = newWidth;
         return newWidth;
       }
     } else {
-      lastWidth = 0;
+      props.lastWidth = 0;
       return 0;
     }
   }
 
   height: {
     if (contentVisible) {
-      if (dragHeightAdjustment != 0) {
-        return Math.min(lastHeight - dragHeightAdjustment, parent.height - mainWindow.sceneTopMargin);
+      if (props.dragHeightAdjustment != 0) {
+        return Math.min(props.lastHeight - props.dragHeightAdjustment, parent.height - mainWindow.sceneTopMargin);
       } else if (fullScreenView || parent.width > parent.height || height >= 0.95 * parent.height) {
-        lastHeight = parent.height;
+        props.lastHeight = parent.height;
         return parent.height;
       } else {
         const defaultMin = Math.min(Math.max(200, parent.height / 2), parent.height);
         const newHeight = useDefaultMinHeight ? defaultMin : Math.min(minContentHeight, defaultMin);
-        lastHeight = newHeight;
+        props.lastHeight = newHeight;
         return newHeight;
       }
     } else {
-      lastHeight = 0;
+      props.lastHeight = 0;
       return 0;
     }
   }
@@ -81,9 +90,9 @@ Pane {
   function statusIndicatorDragged(deltaX, deltaY) {
     fullScreenView = false;
     if (isVertical) {
-      dragHeightAdjustment += deltaY;
+      props.dragHeightAdjustment += deltaY;
     } else {
-      dragWidthAdjustment += deltaX;
+      props.dragWidthAdjustment += deltaX;
     }
   }
 
@@ -97,7 +106,7 @@ Pane {
         } else {
           paneDrawer.collapsed();
         }
-      } else if (dragHeightAdjustment < -parent.height * 0.2) {
+      } else if (props.dragHeightAdjustment < -parent.height * 0.2) {
         fullScreenView = true;
       }
     } else {
@@ -107,12 +116,12 @@ Pane {
         } else {
           paneDrawer.collapsed();
         }
-      } else if (dragWidthAdjustment < -parent.width * 0.2) {
+      } else if (props.dragWidthAdjustment < -parent.width * 0.2) {
         fullScreenView = true;
       }
     }
-    dragHeightAdjustment = 0;
-    dragWidthAdjustment = 0;
+    props.dragHeightAdjustment = 0;
+    props.dragWidthAdjustment = 0;
   }
 
   Behavior on width {

--- a/src/qml/imports/Theme/QfPaneDrawer.qml
+++ b/src/qml/imports/Theme/QfPaneDrawer.qml
@@ -10,7 +10,7 @@ Pane {
   //! TRUE when the pane is laid out vertically (portrait or narrow), driving the drag axis and resize animation direction
   readonly property bool isVertical: parent.width < parent.height || parent.width < 300
   //! When TRUE the pane expands to fill the whole available area
-  property bool fullScreenView: false
+  property bool isFullscreen: false
   //! TRUE while the header is being dragged to resize the pane
   property bool isDragging: false
 
@@ -41,7 +41,7 @@ Pane {
     if (contentVisible) {
       if (props.dragWidthAdjustment != 0) {
         return props.lastWidth - props.dragWidthAdjustment;
-      } else if (fullScreenView || parent.width <= parent.height || width >= 0.95 * parent.width) {
+      } else if (isFullscreen || parent.width <= parent.height || width >= 0.95 * parent.width) {
         props.lastWidth = parent.width;
         return parent.width;
       } else {
@@ -59,7 +59,7 @@ Pane {
     if (contentVisible) {
       if (props.dragHeightAdjustment != 0) {
         return Math.min(props.lastHeight - props.dragHeightAdjustment, parent.height - mainWindow.sceneTopMargin);
-      } else if (fullScreenView || parent.width > parent.height || height >= 0.95 * parent.height) {
+      } else if (isFullscreen || parent.width > parent.height || height >= 0.95 * parent.height) {
         props.lastHeight = parent.height;
         return parent.height;
       } else {
@@ -88,7 +88,7 @@ Pane {
   }
 
   function statusIndicatorDragged(deltaX, deltaY) {
-    fullScreenView = false;
+    isFullscreen = false;
     if (isVertical) {
       props.dragHeightAdjustment += deltaY;
     } else {
@@ -101,23 +101,23 @@ Pane {
     if (isVertical) {
       const minHeight = headerHeight + 48 + 30;
       if (paneDrawer.height < minHeight) {
-        if (fullScreenView) {
-          fullScreenView = false;
+        if (isFullscreen) {
+          isFullscreen = false;
         } else {
           paneDrawer.collapsed();
         }
       } else if (props.dragHeightAdjustment < -parent.height * 0.2) {
-        fullScreenView = true;
+        isFullscreen = true;
       }
     } else {
       if (paneDrawer.width < paneDrawer.parent.width * 0.3) {
-        if (fullScreenView) {
-          fullScreenView = false;
+        if (isFullscreen) {
+          isFullscreen = false;
         } else {
           paneDrawer.collapsed();
         }
       } else if (props.dragWidthAdjustment < -parent.width * 0.2) {
-        fullScreenView = true;
+        isFullscreen = true;
       }
     }
     props.dragHeightAdjustment = 0;

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -13,6 +13,7 @@ QfMeterBar 1.0 QfMeterBar.qml
 QfOpacityMask 1.0 QfOpacityMask.qml
 QfOverlayContainer 1.0 QfOverlayContainer.qml
 QfPageHeader 1.0 QfPageHeader.qml
+QfPaneDrawer 1.0 QfPaneDrawer.qml
 QfPopup 1.0 QfPopup.qml
 QfProgressRing 1.0 QfProgressRing.qml
 QfProjectThumbnail 1.0 QfProjectThumbnail.qml

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -847,8 +847,8 @@ ApplicationWindow {
       freehandDigitizing: freehandButton.freehandDigitizing && freehandHandler.active
 
       property bool allowMargins: !gnssButton.followActive || !gnssButton.followOrientationActive
-      rightMargin: allowMargins ? !featureListForm.fullScreenView && !featureListForm.canvasOperationRequested && featureListForm.x > 0 ? featureListForm.width : 0 : 0
-      bottomMargin: allowMargins ? Math.max(informationDrawer.height > mainWindow.sceneBottomMargin ? informationDrawer.height : 0, !featureListForm.fullScreenView && !featureListForm.canvasOperationRequested && featureListForm.y > 0 ? featureListForm.height : 0) : 0
+      rightMargin: allowMargins ? !featureListForm.isFullscreen && !featureListForm.canvasOperationRequested && featureListForm.x > 0 ? featureListForm.width : 0 : 0
+      bottomMargin: allowMargins ? Math.max(informationDrawer.height > mainWindow.sceneBottomMargin ? informationDrawer.height : 0, !featureListForm.isFullscreen && !featureListForm.canvasOperationRequested && featureListForm.y > 0 ? featureListForm.height : 0) : 0
 
       anchors.fill: parent
 
@@ -5441,7 +5441,7 @@ ApplicationWindow {
 
   Toast {
     id: toast
-    bottomSpacing: Math.max(60, mainWindow.sceneBottomMargin, informationDrawer.height, overlayFeatureFormDrawer.opened && !overlayFeatureFormDrawer.fullScreenView && overlayFeatureFormDrawer.y > 0 ? overlayFeatureFormDrawer.height : 0, !featureListForm.fullScreenView && !featureListForm.canvasOperationRequested && featureListForm.y > 0 ? featureListForm.height : 0)
+    bottomSpacing: Math.max(60, mainWindow.sceneBottomMargin, informationDrawer.height, overlayFeatureFormDrawer.opened && !overlayFeatureFormDrawer.fullScreenView && overlayFeatureFormDrawer.y > 0 ? overlayFeatureFormDrawer.height : 0, !featureListForm.isFullscreen && !featureListForm.canvasOperationRequested && featureListForm.y > 0 ? featureListForm.height : 0)
   }
 
   MouseArea {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4659,8 +4659,8 @@ ApplicationWindow {
       bottom: parent.bottom
     }
 
-    onVisibleChanged: {
-      if (visible && featureListForm.visible) {
+    onStateChanged: {
+      if (state !== "Hidden" && featureListForm.visible) {
         featureListForm.hide();
       }
     }

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -109,19 +109,20 @@
         <file>Nyuki.qml</file>
         <file>LayerLoginDialog.qml</file>
         <file>imports/Theme/QfActionButton.qml</file>
+        <file>imports/Theme/QfButton.qml</file>
         <file>imports/Theme/QfComboBox.qml</file>
         <file>imports/Theme/QfDropShadow.qml</file>
         <file>imports/Theme/QfExpandableGroupBox.qml</file>
         <file>imports/Theme/QfOpacityMask.qml</file>
         <file>imports/Theme/QfToolButton.qml</file>
         <file>imports/Theme/QfToolButtonDrawer.qml</file>
-        <file>imports/Theme/QfButton.qml</file>
         <file>imports/Theme/QfSwitch.qml</file>
         <file>imports/Theme/QfTextField.qml</file>
         <file>imports/Theme/QfCollapsibleMessage.qml</file>
         <file>imports/Theme/QfSlider.qml</file>
         <file>imports/Theme/QfCalendarPanel.qml</file>
         <file>imports/Theme/QfPageHeader.qml</file>
+        <file>imports/Theme/QfPaneDrawer.qml</file>
         <file>imports/Theme/QfOverlayContainer.qml</file>
         <file>imports/Theme/QfTabBar.qml</file>
         <file>imports/Theme/qmldir</file>


### PR DESCRIPTION
The featurelistform and bookmark listdrawer had duplicated pane sizing, drag-to-resize, fullscreen and resize-animation logic. This extracts that into a shared QfPaneDrawer and migrates both onto it

Each components keeps its own header, content and behaviour, configuring the shell via contentVisible, minContentHeight, headerHeight and freezeKey, and reacting to collapsed() for below-minimum drags. NavigationBar is unchanged, hence no behavioural change intended for either drawer