### PR TITLE
Fix out-of-sync delta file wrapper pointer when users delete a currently opened cloud project and re-download it immediately

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -858,6 +858,17 @@ void QFieldCloudProjectsModel::setupProjectConnections( QFieldCloudProject *proj
     emit dataChanged( idx, idx, QVector<int>() << LastLocalPushDeltasRole );
   } );
 
+  connect( project, &QFieldCloudProject::deltaFileWrapperChanged, this, [this] {
+    const QFieldCloudProject *p = static_cast<QFieldCloudProject *>( sender() );
+    if ( mCurrentProjectId == p->id() )
+    {
+      if ( mLayerObserver )
+      {
+        mLayerObserver->setDeltaFileWrapper( p->deltaFileWrapper() );
+      }
+    }
+  } );
+
   connect( project, &QFieldCloudProject::deltasCountChanged, this, [this] {
     const QFieldCloudProject *p = static_cast<QFieldCloudProject *>( sender() );
     const QModelIndex idx = findProjectIndex( p->id() );


### PR DESCRIPTION
The following steps would lead to an out-of-sync cloud project delta file wrapper:

1/ download a cloud project
2/ open that cloud project
3/ _without closing the cloud project_, go in the cloud projects list and delete the cloud project that is currently opened
4/ re-download the cloud project you just deleted
5/ re-open the cloud project by tapping on it in the cloud projects' list

:boom: out-of-sync delta file wrapper.

Thanks to @ckuipersatkb for providing steps to reproduce which led me on the right track.

Fixes https://github.com/opengisch/QField/issues/7479