### PR TITLE
[Backport release-4_2] Fix out-of-sync delta file wrapper pointer when users delete a currently opened cloud project and re-download it immediately

### DIFF
--- a/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfieldcloudprojectsmodel.cpp
@@ -858,6 +858,17 @@ void QFieldCloudProjectsModel::setupProjectConnections( QFieldCloudProject *proj
     emit dataChanged( idx, idx, QVector<int>() << LastLocalPushDeltasRole );
   } );
 
+  connect( project, &QFieldCloudProject::deltaFileWrapperChanged, this, [this] {
+    const QFieldCloudProject *p = static_cast<QFieldCloudProject *>( sender() );
+    if ( mCurrentProjectId == p->id() )
+    {
+      if ( mLayerObserver )
+      {
+        mLayerObserver->setDeltaFileWrapper( p->deltaFileWrapper() );
+      }
+    }
+  } );
+
   connect( project, &QFieldCloudProject::deltasCountChanged, this, [this] {
     const QFieldCloudProject *p = static_cast<QFieldCloudProject *>( sender() );
     const QModelIndex idx = findProjectIndex( p->id() );


### PR DESCRIPTION
Backport #7674
 **Authored by:** @nirvn