### PR TITLE
Fix handling of current_parent* driven default value expression when editing a child feature

### DIFF
--- a/src/core/attributeformmodelbase.cpp
+++ b/src/core/attributeformmodelbase.cpp
@@ -311,9 +311,11 @@ void AttributeFormModelBase::applyParentDefaultValues()
       if ( !fields.at( fidx ).defaultValueDefinition().isValid() || ( !fields.at( fidx ).defaultValueDefinition().applyOnUpdate() && !featureIsNew ) )
         continue;
 
-      if ( fields.at( fidx ).defaultValueDefinition().expression().indexOf( "@current_parent_" ) > -1 )
+      QgsExpression exp( fields.at( fidx ).defaultValueDefinition().expression() );
+      const QSet<QString> referencedFunctions = exp.referencedFunctions();
+      const QSet<QString> referencedVariables = exp.referencedVariables();
+      if ( referencedFunctions.contains( QStringLiteral( "current_parent_value" ) ) || referencedVariables.contains( QStringLiteral( "current_parent_feature" ) ) || referencedVariables.contains( QStringLiteral( "current_parent_geometry" ) ) )
       {
-        QgsExpression exp( fields.at( fidx ).defaultValueDefinition().expression() );
         exp.prepare( &mExpressionContext );
         const QVariant defaultValue = exp.evaluate( &mExpressionContext );
         const bool success = mFeatureModel->setData( mFeatureModel->index( fidx ), defaultValue, FeatureModel::AttributeValue );

--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -290,13 +290,7 @@ EditorWidgetBase {
 
       text: qsTr("Open Form")
       onTriggered: {
-        ensureEmbeddedFormLoaded();
-        embeddedPopup.state = isEnabled ? 'Edit' : 'ReadOnly';
-        embeddedPopup.currentLayer = nmRelationId ? relationEditorModel.nmRelation.referencedLayer : relationEditorModel.relation.referencingLayer;
-        embeddedPopup.linkedRelation = relationEditorModel.relation;
-        embeddedPopup.linkedParentFeature = relationEditorModel.feature;
-        embeddedPopup.feature = nmRelationId ? childMenu.entryNmReferencedFeature : childMenu.entryReferencingFeature;
-        embeddedPopup.open();
+        showViewFeaturePopup(nmRelationId ? childMenu.entryNmReferencedFeature : childMenu.entryReferencingFeature);
       }
     }
 
@@ -457,6 +451,20 @@ EditorWidgetBase {
 
   function requestedGeometryReceived(geometry) {
     showAddFeaturePopup(geometry);
+  }
+
+  function showViewFeaturePopup(feature) {
+    ensureEmbeddedFormLoaded();
+    embeddedPopup.state = isEnabled ? 'Edit' : 'ReadOnly';
+    embeddedPopup.currentLayer = nmRelationId ? relationEditorModel.nmRelation.referencedLayer : relationEditorModel.relation.referencingLayer;
+    embeddedPopup.linkedParentFeature = relationEditorModel.feature;
+    embeddedPopup.linkedRelation = relationEditorModel.relation;
+    embeddedPopup.linkedRelationOrderingField = relationEditorModel.orderingField !== undefined ? relationEditorModel.orderingField : "";
+    embeddedPopup.feature = feature;
+    embeddedPopup.open();
+    if (isEnabled) {
+      embeddedPopup.attributeFormModel.applyParentDefaultValues();
+    }
   }
 
   function showAddFeaturePopup(geometry) {

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -489,13 +489,7 @@ RelationEditorBase {
 
   function openFeatureForm(feature, nmFeature) {
     stopAllMedia();
-    ensureEmbeddedFormLoaded();
-    embeddedPopup.state = isEnabled ? 'Edit' : 'ReadOnly';
-    embeddedPopup.currentLayer = nmRelationId ? referencingFeatureListModel.nmRelation.referencedLayer : referencingFeatureListModel.relation.referencingLayer;
-    embeddedPopup.linkedRelation = referencingFeatureListModel.relation;
-    embeddedPopup.linkedParentFeature = referencingFeatureListModel.feature;
-    embeddedPopup.feature = nmRelationId ? nmFeature : feature;
-    embeddedPopup.open();
+    showViewFeaturePopup(nmRelationId ? nmFeature : feature);
   }
 
   function resolveAttachmentPath(path) {

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -165,14 +165,7 @@ RelationEditorBase {
             bgcolor: 'transparent'
 
             onClicked: {
-              ensureEmbeddedFormLoaded();
-              embeddedPopup.state = isEnabled ? 'Edit' : 'ReadOnly';
-              embeddedPopup.currentLayer = orderedRelationModel.relation.referencingLayer;
-              embeddedPopup.linkedRelation = orderedRelationModel.relation;
-              embeddedPopup.linkedRelationOrderingField = orderedRelationModel.orderingField;
-              embeddedPopup.linkedParentFeature = orderedRelationModel.feature;
-              embeddedPopup.feature = model.referencingFeature;
-              embeddedPopup.open();
+              showViewFeaturePopup(model.referencingFeature);
             }
           }
 

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -112,13 +112,7 @@ RelationEditorBase {
           bgcolor: 'transparent'
 
           onClicked: {
-            ensureEmbeddedFormLoaded();
-            embeddedPopup.state = isEnabled ? 'Edit' : 'ReadOnly';
-            embeddedPopup.currentLayer = nmRelationId ? referencingFeatureListModel.nmRelation.referencedLayer : referencingFeatureListModel.relation.referencingLayer;
-            embeddedPopup.linkedRelation = referencingFeatureListModel.relation;
-            embeddedPopup.linkedParentFeature = referencingFeatureListModel.feature;
-            embeddedPopup.feature = nmRelationId ? model.nmReferencedFeature : model.referencingFeature;
-            embeddedPopup.open();
+            showViewFeaturePopup(nmRelationId ? model.nmReferencedFeature : model.referencingFeature);
           }
         }
 


### PR DESCRIPTION
This PR fixes https://github.com/opengisch/QField/issues/7668

Looking into the issue revealed a couple of issues this PR addresses:
- we had a poorly designed method to check for the usage of a parent feature driving default value expressions; and
- we did not refresh parent feature driven default value expressions when opening a child feature _in editing mode_.

I've also taken the time to deduplicate code here to ease maintenance and improvements to child editing.