### PR TITLE
Fix UDP receiver failing to reflect bound state

### DIFF
--- a/src/core/positioning/udpreceiver.cpp
+++ b/src/core/positioning/udpreceiver.cpp
@@ -128,6 +128,8 @@ void UdpReceiver::handleStateChanged( QAbstractSocket::SocketState state )
     case QAbstractSocket::ListeningState:
       break;
   }
+
+  setSocketState( state );
 }
 
 void UdpReceiver::handleError( QAbstractSocket::SocketError error )

--- a/test/qml/tst_positioning.qml
+++ b/test/qml/tst_positioning.qml
@@ -152,6 +152,7 @@ TestCase {
     coordinateTransformer.verticalGrid = '';
     // wait a few seconds so positioning can catch some NMEA strings
     wait(2500);
+    compare(positioning.deviceSocketState, QAbstractSocket.ConnectedState);
     compare(Math.floor(positioning.positionInformation.latitude), 46);
     compare(Math.floor(positioning.positionInformation.longitude), 9);
     compare(Math.floor(positioning.positionInformation.elevation / 10), 110);
@@ -166,9 +167,10 @@ TestCase {
     coordinateTransformer.verticalGrid = '';
 
     // wait a few seconds so positioning can catch some NMEA strings
+    wait(1000);
+    compare(positioning.deviceSocketState, QAbstractSocket.BoundState);
     let compared = false;
     for (let i = 0; i < 10; i++) {
-      wait(500);
       if (positioning.positionInformation.qualityDescription === "Float RTK + IMU") {
         compare(positioning.positionInformation.qualityDescription, "Float RTK + IMU");
         compare(positioning.positionInformation.imuCorrection, true);
@@ -179,6 +181,7 @@ TestCase {
         compared = true;
         break;
       }
+      wait(500);
     }
     compare(compared, true);
   }


### PR DESCRIPTION
Fix regression from https://github.com/opengisch/QField/commit/656e6c8ce8d5912603aaa19898d64c39d2941e0a and updated our UDP receiver test case to insure we never regress on this front again.

Fixes https://github.com/opengisch/QField/issues/7594