### PR TITLE
[Backport release-4_2] Fix feature form not properly initiating constraints and visibility when opening from a single-feature identification tap

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -171,6 +171,7 @@ void FeatureModel::setCurrentLayer( QgsVectorLayer *layer )
     if ( sRememberings->contains( mLayer ) )
     {
       mFeature = sRememberings->value( mLayer ).rememberedFeature;
+      mFeature.setId( FID_NULL );
     }
     else
     {

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1038,8 +1038,8 @@ ApplicationWindow {
           canvasMenuFeatureListInstantiator.active = true;
         } else {
           if (qfieldSettings.autoOpenFormSingleIdentify && !featureListForm.multiSelection && featureListForm.model.count === 1) {
-            featureListForm.selection.focusedItem = 0;
             featureListForm.state = "FeatureForm";
+            featureListForm.selection.focusedItem = 0;
           }
           if (qfieldSettings.autoZoomToIdentifiedFeature && featureListForm.model.count > 0) {
             featureListForm.extentController.zoomToAllFeatures();


### PR DESCRIPTION
Backport #7678
 **Authored by:** @nirvn