### PR TITLE
[Backport release-4_2] Fix improper 'file://' prefix added when using the file chooser in the file positioning device configuration popup

### DIFF
--- a/src/qml/FileDeviceChooser.qml
+++ b/src/qml/FileDeviceChooser.qml
@@ -74,6 +74,6 @@ Item {
 
   FileDialog {
     id: fileDialog
-    onAccepted: filePath.text = selectedFile
+    onAccepted: filePath.text = UrlUtils.toLocalFile(selectedFile)
   }
 }


### PR DESCRIPTION
Backport #7681
 **Authored by:** @nirvn