### PR TITLE
Bookmark export, quick properties access, and cleaner grouping

### DIFF
--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -35,8 +35,8 @@ BookmarkModel::BookmarkModel( QgsBookmarkManager *manager, QgsBookmarkManager *p
 {
   setSourceModel( mModel.get() );
 
-  // Bookmarks are always grouped by color so the list can render color sections.
-  setSortRole( BookmarkModel::BookmarkGroup );
+  // Bookmarks are always grouped by section so the list can render color sections.
+  setSortRole( BookmarkModel::BookmarkSection );
   sort( 0 );
 }
 
@@ -83,6 +83,16 @@ QVariant BookmarkModel::data( const QModelIndex &index, int role ) const
       const QString id = mModel->data( sourceIndex, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Id ) ).toString();
       return mSelectedIds.contains( id );
     }
+
+    case BookmarkModel::BookmarkSection:
+    {
+      if ( !isUserBookmark( sourceIndex.row() ) )
+      {
+        return QStringLiteral( "project" );
+      }
+      const QString group = mModel->data( sourceIndex, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Group ) ).toString();
+      return group.isEmpty() ? QStringLiteral( "green" ) : group;
+    }
   }
 
   return QVariant();
@@ -98,6 +108,7 @@ QHash<int, QByteArray> BookmarkModel::roleNames() const
   roleNames[BookmarkModel::BookmarkCrs] = "BookmarkCrs";
   roleNames[BookmarkModel::BookmarkUser] = "BookmarkUser";
   roleNames[BookmarkModel::BookmarkSelected] = "BookmarkSelected";
+  roleNames[BookmarkModel::BookmarkSection] = "BookmarkSection";
   return roleNames;
 }
 
@@ -379,7 +390,15 @@ int BookmarkModel::groupRank( const QString &group ) const
 
 bool BookmarkModel::lessThan( const QModelIndex &sourceLeft, const QModelIndex &sourceRight ) const
 {
-  const QString leftGroup = mModel->data( sourceLeft, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Group ) ).toString();
-  const QString rightGroup = mModel->data( sourceRight, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Group ) ).toString();
-  return groupRank( leftGroup ) < groupRank( rightGroup );
+  // Project bookmarks form their own section, listed before the user bookmark color groups.
+  const int leftRank = isUserBookmark( sourceLeft.row() ) ? groupRank( mModel->data( sourceLeft, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Group ) ).toString() ) : -1;
+  const int rightRank = isUserBookmark( sourceRight.row() ) ? groupRank( mModel->data( sourceRight, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Group ) ).toString() ) : -1;
+
+  if ( leftRank != rightRank )
+  {
+    return leftRank < rightRank;
+  }
+
+  // Within a section, preserve creation order (source row order).
+  return sourceLeft.row() < sourceRight.row();
 }

--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -16,11 +16,15 @@
  ***************************************************************************/
 
 #include "bookmarkmodel.h"
+#include "layerutils.h"
+#include "platformutilities.h"
 
 #include <qgsapplication.h>
 #include <qgscoordinatetransform.h>
 #include <qgsgeometry.h>
+#include <qgsmemoryproviderutils.h>
 #include <qgsproject.h>
+#include <qgsvectorlayer.h>
 
 #include <algorithm>
 
@@ -294,6 +298,64 @@ int BookmarkModel::deleteSelected()
   emit selectedCountChanged();
 
   return deleted;
+}
+
+bool BookmarkModel::exportBookmarks( bool selectedOnly )
+{
+  QgsFields fields;
+  fields.append( QgsField( QStringLiteral( "title" ), QMetaType::QString ) );
+  fields.append( QgsField( QStringLiteral( "color" ), QMetaType::QString ) );
+
+  const QgsCoordinateReferenceSystem exportCrs( QStringLiteral( "EPSG:4326" ) );
+  std::unique_ptr<QgsVectorLayer> layer( QgsMemoryProviderUtils::createMemoryLayer( QStringLiteral( "bookmarks" ), fields, Qgis::WkbType::Point, exportCrs ) );
+
+  QgsFeatureList features;
+  const QList<QgsBookmark> bookmarks = mManager->bookmarks();
+  for ( const QgsBookmark &bookmark : bookmarks )
+  {
+    if ( selectedOnly && !mSelectedIds.contains( bookmark.id() ) )
+    {
+      continue;
+    }
+
+    const QgsReferencedRectangle extent = bookmark.extent();
+    QgsPointXY center = extent.center();
+    if ( extent.crs() != exportCrs )
+    {
+      QgsCoordinateTransform transform( extent.crs(), exportCrs, QgsProject::instance()->transformContext() );
+      try
+      {
+        center = transform.transform( center );
+      }
+      catch ( const QgsException & )
+      {
+        continue;
+      }
+    }
+
+    QgsFeature feature( layer->fields() );
+    feature.setGeometry( QgsGeometry::fromPointXY( center ) );
+    feature.setAttribute( QStringLiteral( "title" ), bookmark.name() );
+    feature.setAttribute( QStringLiteral( "color" ), bookmark.group() );
+    features << feature;
+  }
+
+  if ( features.isEmpty() )
+  {
+    return false;
+  }
+
+  layer->dataProvider()->addFeatures( features );
+
+  const QString filePath = QStringLiteral( "%1/bookmarks_%2.gpkg" ).arg( QDir::tempPath(), QString::number( QDateTime::currentMSecsSinceEpoch() ) );
+  const QString exportedPath = LayerUtils::saveVectorLayerAs( layer.get(), filePath );
+  if ( exportedPath.isEmpty() )
+  {
+    return false;
+  }
+
+  PlatformUtilities::instance()->sendDatasetTo( exportedPath );
+  return true;
 }
 
 int BookmarkModel::groupRank( const QString &group ) const

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -50,6 +50,7 @@ class BookmarkModel : public QSortFilterProxyModel
       BookmarkCrs,
       BookmarkUser,
       BookmarkSelected,
+      BookmarkSection,
     };
     Q_ENUM( Roles )
 

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -91,6 +91,9 @@ class BookmarkModel : public QSortFilterProxyModel
     //! Deletes all currently selected bookmarks, persisting once. Returns the number deleted.
     Q_INVOKABLE int deleteSelected();
 
+    //! Exports user bookmarks to a temporary GeoPackage and sends it via the platform's native sharing. When \a selectedOnly is TRUE, only selected bookmarks are exported.
+    Q_INVOKABLE bool exportBookmarks( bool selectedOnly );
+
   signals:
     void mapSettingsChanged();
     void hideProjectBookmarksChanged();

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -292,13 +292,25 @@ QfPaneDrawer {
     height: parent.height - bookmarkListToolBar.height
     ScrollBar.vertical: QfScrollBar {}
 
-    section.property: "BookmarkGroup"
+    section.property: "BookmarkSection"
     section.labelPositioning: ViewSection.InlineLabels
     section.delegate: Component {
       Rectangle {
         width: parent.width
         height: 30
-        color: Theme.controlBorderColor
+        color: {
+          switch (section) {
+          case "orange":
+            return Theme.bookmarkOrange;
+          case "red":
+            return Theme.bookmarkRed;
+          case "blue":
+            return Theme.bookmarkBlue;
+          case "project":
+            return Theme.controlBorderColor;
+          }
+          return Theme.bookmarkDefault;
+        }
 
         Text {
           anchors {
@@ -307,7 +319,7 @@ QfPaneDrawer {
           }
           font.bold: true
           font.pointSize: Theme.resultFont.pointSize
-          color: Theme.mainTextColor
+          color: section === "project" ? Theme.mainTextColor : "white"
           text: {
             switch (section) {
             case "orange":
@@ -316,6 +328,8 @@ QfPaneDrawer {
               return qsTr("Red");
             case "blue":
               return qsTr("Blue");
+            case "project":
+              return qsTr("Project bookmarks");
             }
             return qsTr("Green");
           }

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -249,6 +249,88 @@ QfPaneDrawer {
     }
   }
 
+  QfMenu {
+    id: itemMenu
+    title: qsTr("Bookmark Actions")
+
+    property string itemId: ''
+    property string itemName: ''
+    property string itemGroup: ''
+
+    topMargin: mainWindow.sceneTopMargin
+    bottomMargin: mainWindow.sceneBottomMargin
+
+    MenuItem {
+      text: qsTr("Edit Bookmark")
+      icon.source: Theme.getThemeVectorIcon("ic_edit_attributes_white_24dp")
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: Theme.menuItemLeftPadding
+
+      onTriggered: {
+        bookmarkList.requestBookmarkProperties(itemMenu.itemId, itemMenu.itemName, itemMenu.itemGroup);
+      }
+    }
+
+    MenuItem {
+      text: qsTr("Copy Bookmark Details")
+      icon.source: Theme.getThemeVectorIcon("ic_copy_black_24dp")
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: Theme.menuItemLeftPadding
+
+      onTriggered: {
+        const point = bookmarkList.model.getBookmarkPoint(itemMenu.itemId);
+        const crs = bookmarkList.model.getBookmarkCrs(itemMenu.itemId);
+        const coordinates = StringUtils.pointInformation(point, crs);
+        platformUtilities.copyTextToClipboard(itemMenu.itemName + '\n' + coordinates);
+        displayToast(qsTr('Bookmark details copied to clipboard'));
+      }
+    }
+
+    MenuSeparator {
+      width: parent.width
+    }
+
+    MenuItem {
+      text: qsTr("Delete Bookmark")
+      icon.source: Theme.getThemeVectorIcon("ic_delete_forever_white_24dp")
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: Theme.menuItemLeftPadding
+
+      onTriggered: {
+        removeBookmarkDialog.open();
+      }
+    }
+  }
+
+  QfDialog {
+    id: removeBookmarkDialog
+    parent: mainWindow.contentItem
+
+    title: qsTr("Remove bookmark")
+    Label {
+      width: mainWindow.width - 60
+      wrapMode: Text.WordWrap
+      font: Theme.defaultFont
+      color: Theme.mainTextColor
+      text: qsTr("You are about to remove a bookmark, proceed?")
+    }
+
+    onAccepted: {
+      bookmarkList.model.removeBookmark(itemMenu.itemId);
+      bookmarkList.focus = true;
+    }
+
+    onRejected: {
+      bookmarkList.focus = true;
+    }
+  }
+
   QfDialog {
     id: deleteBookmarksDialog
     parent: mainWindow.contentItem
@@ -298,19 +380,7 @@ QfPaneDrawer {
       Rectangle {
         width: parent.width
         height: 30
-        color: {
-          switch (section) {
-          case "orange":
-            return Theme.bookmarkOrange;
-          case "red":
-            return Theme.bookmarkRed;
-          case "blue":
-            return Theme.bookmarkBlue;
-          case "project":
-            return Theme.controlBorderColor;
-          }
-          return Theme.bookmarkDefault;
-        }
+        color: Theme.controlBorderColor
 
         Text {
           anchors {
@@ -319,7 +389,7 @@ QfPaneDrawer {
           }
           font.bold: true
           font.pointSize: Theme.resultFont.pointSize
-          color: section === "project" ? Theme.mainTextColor : "white"
+          color: Theme.mainTextColor
           text: {
             switch (section) {
             case "orange":
@@ -388,7 +458,7 @@ QfPaneDrawer {
       }
 
       QfToolButton {
-        id: bookmarkPropertiesButton
+        id: itemMenuButton
         anchors {
           right: parent.right
           rightMargin: 5
@@ -396,21 +466,27 @@ QfPaneDrawer {
         }
         width: 48
         height: 48
-        visible: bookmarkList.multiSelection && BookmarkUser
-        round: false
-        iconSource: Theme.getThemeVectorIcon('ic_edit_attributes_white_24dp')
+        visible: !bookmarkList.multiSelection && BookmarkUser
+        round: true
+        opacity: 0.5
+        bgcolor: "transparent"
+        iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")
         iconColor: Theme.mainTextColor
-        bgcolor: 'transparent'
 
         onClicked: {
-          bookmarkList.requestBookmarkProperties(BookmarkId, BookmarkName, BookmarkGroup === 'green' ? '' : BookmarkGroup);
+          const gc = mapToItem(bookmarkList, 0, 0);
+          itemMenu.itemId = BookmarkId;
+          itemMenu.itemName = BookmarkName;
+          // BookmarkGroup surfaces empty groups as "green"; restore empty so edits don't persist a color onto an ungrouped bookmark.
+          itemMenu.itemGroup = BookmarkGroup === 'green' ? '' : BookmarkGroup;
+          itemMenu.popup(gc.x + width - itemMenu.width, gc.y - height);
         }
       }
 
       MouseArea {
         id: mouseArea
         anchors.fill: parent
-        anchors.rightMargin: bookmarkPropertiesButton.visible ? bookmarkPropertiesButton.width : 0
+        anchors.rightMargin: itemMenuButton.visible ? itemMenuButton.width : 0
 
         onClicked: {
           if (bookmarkList.multiSelection) {

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -213,6 +213,23 @@ QfPaneDrawer {
     }
 
     MenuItem {
+      text: bookmarkList.multiSelection ? qsTr('Export Selected Bookmark(s)') : qsTr('Export All Bookmarks')
+      icon.source: Theme.getThemeVectorIcon("ic_download_white_24dp")
+      enabled: !bookmarkList.multiSelection || (bookmarkList.model && bookmarkList.model.selectedCount > 0)
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: Theme.menuItemLeftPadding
+
+      onTriggered: {
+        bookmarkListMenu.close();
+        if (bookmarkList.model.exportBookmarks(bookmarkList.multiSelection)) {
+          displayToast(qsTr("Bookmarks exported"));
+        }
+      }
+    }
+
+    MenuItem {
       id: deleteSelectedBookmarksBtn
       text: qsTr('Delete Selected Bookmark(s)')
       icon.source: Theme.getThemeVectorIcon("ic_delete_forever_white_24dp")

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -215,7 +215,7 @@ QfPaneDrawer {
     }
 
     MenuItem {
-      text: bookmarkList.multiSelection ? qsTr('Export Selected Bookmark(s)') : qsTr('Export All Bookmarks')
+      text: bookmarkList.multiSelection ? qsTr('Export Selected Bookmark(s)') : qsTr('Export All User Bookmarks')
       icon.source: Theme.getThemeVectorIcon("ic_download_white_24dp")
       enabled: !bookmarkList.multiSelection || (bookmarkList.model && bookmarkList.model.selectedCount > 0)
 

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -15,6 +15,8 @@ QfPaneDrawer {
   property alias model: bookmarksList.model
   property bool multiSelection: false
 
+  signal requestBookmarkProperties(string bookmarkId, string bookmarkName, string bookmarkGroup)
+
   contentVisible: props.isVisible
   freezeKey: 'bookmarkresize'
   headerHeight: bookmarkListToolBar.height
@@ -371,9 +373,30 @@ QfPaneDrawer {
         wrapMode: Text.WordWrap
       }
 
+      QfToolButton {
+        id: bookmarkPropertiesButton
+        anchors {
+          right: parent.right
+          rightMargin: 5
+          verticalCenter: parent.verticalCenter
+        }
+        width: 48
+        height: 48
+        visible: bookmarkList.multiSelection && BookmarkUser
+        round: false
+        iconSource: Theme.getThemeVectorIcon('ic_edit_attributes_white_24dp')
+        iconColor: Theme.mainTextColor
+        bgcolor: 'transparent'
+
+        onClicked: {
+          bookmarkList.requestBookmarkProperties(BookmarkId, BookmarkName, BookmarkGroup === 'green' ? '' : BookmarkGroup);
+        }
+      }
+
       MouseArea {
         id: mouseArea
         anchors.fill: parent
+        anchors.rightMargin: bookmarkPropertiesButton.visible ? bookmarkPropertiesButton.width : 0
 
         onClicked: {
           if (bookmarkList.multiSelection) {

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -213,9 +213,9 @@ QfPopup {
           bgcolor: "transparent"
 
           onClicked: {
-            var point = bookmarkModel.getBookmarkPoint(bookmarkProperties.bookmarkId);
-            var crs = bookmarkModel.getBookmarkCrs(bookmarkProperties.bookmarkId);
-            var coordinates = StringUtils.pointInformation(point, crs);
+            const point = bookmarkModel.getBookmarkPoint(bookmarkProperties.bookmarkId);
+            const crs = bookmarkModel.getBookmarkCrs(bookmarkProperties.bookmarkId);
+            const coordinates = StringUtils.pointInformation(point, crs);
             platformUtilities.copyTextToClipboard(nameField.text + '\n' + coordinates);
             displayToast(qsTr('Bookmark details copied to clipboard'));
           }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -4659,6 +4659,13 @@ ApplicationWindow {
       bottom: parent.bottom
     }
 
+    onRequestBookmarkProperties: (bookmarkId, bookmarkName, bookmarkGroup) => {
+      bookmarkProperties.bookmarkId = bookmarkId;
+      bookmarkProperties.bookmarkName = bookmarkName;
+      bookmarkProperties.bookmarkGroup = bookmarkGroup;
+      bookmarkProperties.open();
+    }
+
     onStateChanged: {
       if (state !== "Hidden" && featureListForm.visible) {
         featureListForm.hide();


### PR DESCRIPTION
This pr adds a few improvements to the bookmarks drawer

**Export bookmarks**: From the drawer's menu you can now export your bookmarks to share them. "Export All Bookmarks" sends everything, or switch to selection mode and pick specific ones to get "Export Selected Bookmarks". on desktop it asks you to pick a folder to save into. The bookmarks are saved as a GeoPackage with their name and color.

**Open properties from the list**: In selection mode, each bookmark now has a button to open its properties directly from the list, so you don't have to find it on the map and long-press anymore, ease of use

**Cleaner grouping**: Bookmarks are now grouped under colored section headers matching their color "visibility clue as per existed ideation". Project bookmarks sit in their own section with a regular gray header, ui ux friendly.


https://github.com/user-attachments/assets/be8744eb-3d27-4708-b5f0-fdfe7466c35e
