### PR TITLE
Add required entitlements file to support NFC tag reading

### DIFF
--- a/platform/ios/qfield.entitlements
+++ b/platform/ios/qfield.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://apple.com">
+<plist version="1.0">
+<dict>
+    <key>com.apple.developer.nfc.readersession.formats</key>
+    <array>
+        <string>NDEF</string>
+        <string>TAG</string>
+    </array>
+</dict>
+</plist>

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -204,6 +204,7 @@ if(IOS)
   # _beta
 
   include("${CMAKE_SOURCE_DIR}/cmake/AddQtIosApp.cmake")
+
   add_qt_ios_app(
     qfield
     NAME "QField"
@@ -226,4 +227,8 @@ if(IOS)
     IPA
     UPLOAD_SYMBOL
     VERBOSE)
+
+  set_target_properties(
+    qfield PROPERTIES XCODE_ATTRIBUTE_CODE_SIGN_ENTITLEMENTS
+                      "${PROJECT_SOURCE_DIR}/platform/ios/qfield.entitlements")
 endif()


### PR DESCRIPTION
The good old stack overflow resource tells us we were lacking a file here.