### PR TITLE
Handle empty result when conducting permission requests on Android

### DIFF
--- a/src/core/platforms/android/androidplatformutilities.cpp
+++ b/src/core/platforms/android/androidplatformutilities.cpp
@@ -644,8 +644,8 @@ bool AndroidPlatformUtilities::checkAndAcquirePermissions( QStringList permissio
   {
     for ( const QString &permission : permissions )
     {
-      auto r = QtAndroidPrivate::requestPermission( permission ).result();
-      if ( r == QtAndroidPrivate::Denied )
+      auto results = QtAndroidPrivate::requestPermission( permission ).results();
+      if ( results.isEmpty() || results.at( 0 ) == QtAndroidPrivate::Denied )
       {
         if ( !forceAsk )
         {

--- a/src/core/positioning/internalgnssreceiver.cpp
+++ b/src/core/positioning/internalgnssreceiver.cpp
@@ -218,18 +218,51 @@ void InternalGnssReceiver::handleSatellitesInViewUpdated( const QList<QGeoSatell
 
 void InternalGnssReceiver::handleError( QGeoPositionInfoSource::Error positioningError )
 {
-  qDebug() << positioningError;
+  switch ( positioningError )
+  {
+    case QGeoPositionInfoSource::AccessError:
+    case QGeoPositionInfoSource::ClosedError:
+    {
+      qDebug() << positioningError;
+      break;
+    }
+
+    case QGeoPositionInfoSource::UnknownSourceError:
+    case QGeoPositionInfoSource::UpdateTimeoutError:
+    case QGeoPositionInfoSource::NoError:
+    {
+      break;
+    }
+  }
+
   return;
 }
 
 void InternalGnssReceiver::handleSatelliteError( QGeoSatelliteInfoSource::Error satelliteError )
 {
-  qDebug() << satelliteError;
-  if ( satelliteError == QGeoSatelliteInfoSource::ClosedError )
+  switch ( satelliteError )
   {
-    mSatelliteInformationValid = false;
-    mSatellitesID.clear();
-    mSatellitesInfo.clear();
+    case QGeoSatelliteInfoSource::AccessError:
+    {
+      qDebug() << satelliteError;
+      break;
+    }
+
+    case QGeoSatelliteInfoSource::ClosedError:
+    {
+      qDebug() << satelliteError;
+      mSatelliteInformationValid = false;
+      mSatellitesID.clear();
+      mSatellitesInfo.clear();
+    }
+
+    case QGeoSatelliteInfoSource::UnknownSourceError:
+    case QGeoSatelliteInfoSource::UpdateTimeoutError:
+    case QGeoSatelliteInfoSource::NoError:
+    {
+      break;
+    }
   }
+
   return;
 }


### PR DESCRIPTION
Now that we've fixed the V4 engine crasher (I still can't believe we nailed this one :partying_face: ), this crasher around permission handling is the #1 crasher (much, much smaller crash rates though).

We assume there will be a result item returned, but in fact it is possible to have an empty array that means user or OS has cancelled the request (i.e. permission never accepted or declined).