### PR TITLE
[Backport release-4_2]  Insure that when a given parent feature being is saved through relation editor widgets the digitizing logger still works

### DIFF
--- a/src/qml/EmbeddedFeatureForm.qml
+++ b/src/qml/EmbeddedFeatureForm.qml
@@ -77,6 +77,10 @@ QfPopup {
 
     anchors.fill: parent
 
+    onCreated: {
+      digitizingToolbar.digitizingLogger.writeCoordinates();
+    }
+
     onConfirmed: {
       form.resetTabs();
       formPopup.featureSaved(formFeatureModel.feature.id);
@@ -107,13 +111,14 @@ QfPopup {
     if (form.state === "ReadOnly") {
       return;
     }
+
     if (!form.isSaved) {
       form.confirm();
-      digitizingToolbar.digitizingLogger.writeCoordinates();
     } else {
       form.isSaved = false;
-      digitizingToolbar.digitizingLogger.clearCoordinates();
     }
+
+    digitizingToolbar.digitizingLogger.clearCoordinates();
   }
 
   function applyGeometry(geometry) {

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -20,6 +20,8 @@ Page {
   signal cancelled
   signal temporaryStored
   signal valueChanged(var field, var oldValue, var newValue)
+  signal created
+  signal saved
   signal aboutToSave
 
   signal toolbarDragged(var deltaX, var deltaY)
@@ -907,6 +909,9 @@ Page {
       if (!model.featureModel.featureAdditionLocked) {
         isSuccess = model.create();
         featureCreated = isSuccess;
+        if (isSuccess) {
+          created();
+        }
       } else {
         isSuccess = false;
         errorPushed = true;
@@ -914,6 +919,9 @@ Page {
       }
     } else {
       isSuccess = model.save();
+      if (isSuccess) {
+        saved();
+      }
     }
     master.ignoreChanges = false;
     if (!isSuccess && !errorPushed) {

--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -126,6 +126,10 @@ Drawer {
 
     state: "Add"
 
+    onCreated: {
+      digitizingToolbar.digitizingLogger.writeCoordinates();
+    }
+
     onConfirmed: {
       displayToast(qsTr("Changes saved"));
       //close drawer if still open
@@ -135,7 +139,6 @@ Drawer {
       } else {
         overlayFeatureForm.isSaved = false; //reset
       }
-      digitizingToolbar.digitizingLogger.writeCoordinates();
       resetTabs();
     }
 


### PR DESCRIPTION
Backport #7696
 **Authored by:** @nirvn