### PR TITLE
Introduce a themeable tool button size

### DIFF
--- a/src/core/theme.cpp
+++ b/src/core/theme.cpp
@@ -491,6 +491,17 @@ void Theme::setFontScale( qreal scale )
   emit fontScaleChanged();
 }
 
+void Theme::setToolButtonSize( int size )
+{
+  if ( mToolButtonSize == size )
+  {
+    return;
+  }
+
+  mToolButtonSize = size;
+  emit toolButtonSizeChanged();
+}
+
 QFont Theme::makeFont( qreal scaleFactor, bool bold ) const
 {
   QFont font;

--- a/src/core/theme.h
+++ b/src/core/theme.h
@@ -113,6 +113,8 @@ class QFIELD_CORE_EXPORT Theme final : public QObject
     Q_PROPERTY( QFont titleFont READ titleFont NOTIFY fontScaleChanged )
     Q_PROPERTY( QFont strongTitleFont READ strongTitleFont NOTIFY fontScaleChanged )
 
+    Q_PROPERTY( int toolButtonSize READ toolButtonSize WRITE setToolButtonSize NOTIFY toolButtonSizeChanged )
+
     Q_PROPERTY( int popupScreenEdgeVerticalMargin READ popupScreenEdgeVerticalMargin CONSTANT )
     Q_PROPERTY( int popupScreenEdgeHorizontalMargin READ popupScreenEdgeHorizontalMargin CONSTANT )
     Q_PROPERTY( int menuItemIconlessLeftPadding READ menuItemIconlessLeftPadding CONSTANT )
@@ -302,6 +304,9 @@ class QFIELD_CORE_EXPORT Theme final : public QObject
     QFont titleFont() const { return makeFont( 1.25, false ); }
     QFont strongTitleFont() const { return makeFont( 1.25, true ); }
 
+    int toolButtonSize() const { return mToolButtonSize; }
+    void setToolButtonSize( int size );
+
     int popupScreenEdgeVerticalMargin() const { return 40; }
     int popupScreenEdgeHorizontalMargin() const { return 20; }
     int menuItemIconlessLeftPadding() const { return 52; }
@@ -334,6 +339,7 @@ class QFIELD_CORE_EXPORT Theme final : public QObject
     void appearanceChanged();
     void darkThemeChanged();
     void fontScaleChanged();
+    void toolButtonSizeChanged();
     void themeDataLoaded();
     void screenPpiChanged();
 
@@ -405,6 +411,7 @@ class QFIELD_CORE_EXPORT Theme final : public QObject
     QString mAppearance;
     bool mDarkTheme = false;
     qreal mFontScale = 1.0;
+    int mToolButtonSize = 48;
     qreal mSystemFontPointSize = 14.0;
     qreal mScreenPpi = 160.0;
 };

--- a/src/qml/BluetoothDeviceChooser.qml
+++ b/src/qml/BluetoothDeviceChooser.qml
@@ -163,7 +163,7 @@ Item {
 
       QfSwitch {
         id: preferBLESwitch
-        Layout.preferredWidth: 48
+        Layout.preferredWidth: Theme.toolButtonSize
         Layout.alignment: Qt.AlignVCenter
         visible: Qt.platform.os !== "ios" && deviceClassicSupport
         checked: false

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -47,7 +47,7 @@ QfPaneDrawer {
     anchors.topMargin: topMargin
     anchors.left: parent.left
     anchors.right: parent.right
-    height: topMargin + 58
+    height: topMargin + Theme.toolButtonSize + 10
     color: Theme.mainBackgroundColor
     clip: true
 
@@ -81,7 +81,7 @@ QfPaneDrawer {
         anchors.top: parent.top
         anchors.leftMargin: balancedMargin + bookmarkListToolBar.leftMargin
         anchors.rightMargin: balancedMargin + bookmarkListToolBar.rightMargin
-        height: 48
+        height: Theme.toolButtonSize
 
         font: Theme.strongFont
         color: Theme.mainTextColor
@@ -130,8 +130,8 @@ QfPaneDrawer {
       anchors.leftMargin: bookmarkListToolBar.leftMargin
       anchors.top: parent.top
       anchors.topMargin: bookmarkListToolBar.topMargin + 5
-      width: 48
-      height: 48
+      width: Theme.toolButtonSize
+      height: Theme.toolButtonSize
       clip: true
       iconSource: bookmarkList.multiSelection ? Theme.getThemeVectorIcon("ic_clear_white_24dp") : Theme.getThemeVectorIcon("ic_arrow_left_white_24dp")
       iconColor: Theme.mainTextColor
@@ -153,9 +153,9 @@ QfPaneDrawer {
       anchors.top: parent.top
       anchors.topMargin: bookmarkListToolBar.topMargin + 5
 
-      width: (bookmarkList.multiSelection && bookmarkList.model ? 48 : 0)
+      width: (bookmarkList.multiSelection && bookmarkList.model ? Theme.toolButtonSize : 0)
       visible: width > 0
-      height: 48
+      height: Theme.toolButtonSize
       verticalAlignment: Text.AlignVCenter
       font: Theme.strongFont
       color: Theme.mainTextColor
@@ -172,8 +172,8 @@ QfPaneDrawer {
       anchors.rightMargin: bookmarkListToolBar.rightMargin
       anchors.top: parent.top
       anchors.topMargin: bookmarkListToolBar.topMargin + 5
-      width: 48
-      height: 48
+      width: Theme.toolButtonSize
+      height: Theme.toolButtonSize
       clip: true
 
       iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")
@@ -464,8 +464,8 @@ QfPaneDrawer {
           rightMargin: 5
           verticalCenter: parent.verticalCenter
         }
-        width: 48
-        height: 48
+        width: Theme.toolButtonSize
+        height: Theme.toolButtonSize
         visible: !bookmarkList.multiSelection && BookmarkUser
         round: true
         opacity: 0.5

--- a/src/qml/BookmarkProperties.qml
+++ b/src/qml/BookmarkProperties.qml
@@ -98,7 +98,7 @@ QfPopup {
           }
 
           Layout.fillWidth: true
-          height: 48
+          height: Theme.toolButtonSize
 
           clip: true
           interactive: false
@@ -107,14 +107,14 @@ QfPopup {
           RowLayout {
             id: currentColorView
             width: colorContainer.width
-            height: 48
+            height: Theme.toolButtonSize
             spacing: 5
 
             Rectangle {
               id: colorArea
               Layout.fillWidth: true
-              Layout.preferredHeight: 48
-              height: 48
+              Layout.preferredHeight: Theme.toolButtonSize
+              height: Theme.toolButtonSize
               radius: height / 2
 
               color: {
@@ -142,8 +142,8 @@ QfPopup {
                 id: colorPicker
                 anchors.right: parent.right
                 anchors.verticalCenter: parent.verticalCenter
-                width: 48
-                height: 48
+                width: Theme.toolButtonSize
+                height: Theme.toolButtonSize
                 visible: true
                 enabled: false
                 iconSource: Theme.getThemeVectorIcon("ic_chevron_right_white_24dp")
@@ -165,12 +165,12 @@ QfPopup {
           RowLayout {
             id: selectColorView
             width: colorContainer.width
-            height: 48
+            height: Theme.toolButtonSize
             spacing: 5
 
             ListView {
               Layout.fillWidth: true
-              Layout.preferredHeight: 48
+              Layout.preferredHeight: Theme.toolButtonSize
               orientation: ListView.Horizontal
               spacing: 10
               model: ["", "orange", "red", "blue"]
@@ -178,8 +178,8 @@ QfPopup {
               clip: true
 
               delegate: QfToolButton {
-                Layout.preferredWidth: 48
-                Layout.preferredHeight: 48
+                Layout.preferredWidth: Theme.toolButtonSize
+                Layout.preferredHeight: Theme.toolButtonSize
                 bgcolor: {
                   switch (modelData) {
                   case "orange":
@@ -206,8 +206,8 @@ QfPopup {
         }
 
         QfToolButton {
-          height: 48
-          width: 48
+          height: Theme.toolButtonSize
+          width: Theme.toolButtonSize
           iconSource: Theme.getThemeVectorIcon("ic_copy_black_24dp")
           iconColor: enabled ? Theme.mainTextColor : Theme.mainTextDisabledColor
           bgcolor: "transparent"

--- a/src/qml/CodeReader.qml
+++ b/src/qml/CodeReader.qml
@@ -135,12 +135,12 @@ QfPopup {
 
       background: Rectangle {
         color: "transparent"
-        height: 48
+        height: Theme.toolButtonSize
       }
 
       RowLayout {
         width: parent.width
-        height: 48
+        height: Theme.toolButtonSize
 
         Label {
           Layout.leftMargin: 58

--- a/src/qml/CogoOperations.qml
+++ b/src/qml/CogoOperations.qml
@@ -37,7 +37,7 @@ Item {
   }
 
   width: content.contentWidth + cogoOperationsContainer.spacing * 2
-  height: 48
+  height: Theme.toolButtonSize
   enabled: false
   visible: enabled
 
@@ -60,14 +60,14 @@ Item {
     focusPolicy: Qt.NoFocus
 
     contentItem: Rectangle {
-      radius: 48 / 2
+      radius: Theme.toolButtonSize / 2
       color: Theme.toolButtonBackgroundSemiOpaqueColor
       clip: true
 
       ListView {
         id: content
         width: content.contentWidth
-        height: 46
+        height: Theme.toolButtonSize - 2
         x: 4
         y: 4
         model: cogoOperationsContainer.contentModel

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -544,6 +544,8 @@ Drawer {
         height: parent.height
         anchors.verticalCenter: parent.verticalCenter
         icon.source: Theme.getThemeVectorIcon("ic_home_black_24dp")
+        icon.width: Theme.toolButtonSize / 2
+        icon.height: Theme.toolButtonSize / 2
         font: Theme.defaultFont
         text: qsTr("Return home")
 

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -120,7 +120,7 @@ Drawer {
         Row {
           id: buttonsRow
           objectName: "dashboardActionsToolbar"
-          height: 48
+          height: Theme.toolButtonSize
           spacing: 1
 
           QfToolButton {
@@ -525,13 +525,13 @@ Drawer {
 
   Rectangle {
     id: bottomRow
-    height: 48 + mainWindow.sceneBottomMargin
+    height: Theme.toolButtonSize + mainWindow.sceneBottomMargin
     width: parent.width
     anchors.bottom: parent.bottom
     color: Theme.darkTheme ? Theme.mainBackgroundColorSemiOpaque : Theme.lightestGraySemiOpaque
 
     Item {
-      height: 48
+      height: Theme.toolButtonSize
       anchors.bottom: parent.bottom
       anchors.bottomMargin: mainWindow.sceneBottomMargin
       anchors.left: parent.left
@@ -553,7 +553,7 @@ Drawer {
         id: modeSwitch
         objectName: "modeSwitch"
         width: 56 + 36
-        height: 48
+        height: Theme.toolButtonSize
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
         indicator: Rectangle {

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -541,7 +541,8 @@ Drawer {
       MenuItem {
         id: homeButton
         width: parent.width - modeSwitch.width
-        height: 48
+        height: parent.height
+        anchors.verticalCenter: parent.verticalCenter
         icon.source: Theme.getThemeVectorIcon("ic_home_black_24dp")
         font: Theme.defaultFont
         text: qsTr("Return home")
@@ -552,23 +553,24 @@ Drawer {
       QfSwitch {
         id: modeSwitch
         objectName: "modeSwitch"
-        width: 56 + 36
         height: Theme.toolButtonSize
+        width: height * 1.9
+        leftPadding: height / 3
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
         indicator: Rectangle {
-          implicitHeight: 36
-          implicitWidth: 36 * 2
+          implicitHeight: modeSwitch.height * 0.75
+          implicitWidth: modeSwitch.height * 1.5
           x: modeSwitch.leftPadding
-          radius: 4
+          radius: modeSwitch.height / 12
           color: "#24212121"
           border.color: "#14FFFFFF"
           anchors.verticalCenter: parent.verticalCenter
           Image {
-            width: 28
-            height: 28
+            width: modeSwitch.height * 0.58
+            height: width
             anchors.left: parent.left
-            anchors.leftMargin: 4
+            anchors.leftMargin: modeSwitch.height / 12
             anchors.verticalCenter: parent.verticalCenter
             source: Theme.getThemeVectorIcon('ic_map_white_24dp')
             sourceSize.width: parent.height * screen.devicePixelRatio
@@ -576,10 +578,10 @@ Drawer {
             opacity: 0.6
           }
           Image {
-            width: 28
-            height: 28
+            width: modeSwitch.height * 0.58
+            height: width
             anchors.right: parent.right
-            anchors.rightMargin: 4
+            anchors.rightMargin: modeSwitch.height / 12
             anchors.verticalCenter: parent.verticalCenter
             source: Theme.getThemeVectorIcon('ic_create_white_24dp')
             sourceSize.width: parent.height * screen.devicePixelRatio
@@ -588,14 +590,14 @@ Drawer {
           }
           Rectangle {
             x: modeSwitch.checked ? parent.width - width : 0
-            width: 36
-            height: 36
-            radius: 4
+            width: modeSwitch.height * 0.75
+            height: width
+            radius: modeSwitch.height / 12
             color: projectInfo.insertRights ? Theme.mainColor : Theme.darkTheme ? Theme.mainBackgroundColorSemiOpaque : Theme.lightestGray
             border.color: Theme.mainOverlayColor
             Image {
-              width: 28
-              height: 28
+              width: modeSwitch.height * 0.58
+              height: width
               anchors.centerIn: parent
               source: modeSwitch.checked ? Theme.getThemeVectorIcon('ic_create_white_24dp') : Theme.getThemeVectorIcon('ic_map_white_24dp')
               sourceSize.width: parent.height * screen.devicePixelRatio

--- a/src/qml/FeatureForm.qml
+++ b/src/qml/FeatureForm.qml
@@ -892,7 +892,7 @@ Page {
 
           visible: attributeEditorLoader.isEnabled && attributeEditorLoader.item && attributeEditorLoader.item.hasMenu
           enabled: visible
-          width: visible ? 48 : 0
+          width: visible ? Theme.toolButtonSize : 0
 
           iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")
           iconColor: Theme.mainTextColor
@@ -906,7 +906,7 @@ Page {
         QfToolButton {
           id: rememberButton
           visible: !!CanRememberValue && form.state === "Add" && EditorWidget !== "Hidden" && EditorWidget !== 'RelationEditor'
-          width: visible ? 48 : 0
+          width: visible ? Theme.toolButtonSize : 0
 
           iconSource: Theme.getThemeVectorIcon("ic_pin_black_24dp")
           iconColor: RememberValue ? Theme.mainColor : Theme.mainTextColor
@@ -1044,7 +1044,7 @@ Page {
     rightPadding: 0
     bottomPadding: 0
 
-    height: visible ? form.topMargin + 58 : 0
+    height: visible ? form.topMargin + Theme.toolButtonSize + 10 : 0
     visible: form.state === 'Add'
     objectName: "toolbar"
     background: Rectangle {
@@ -1077,8 +1077,8 @@ Page {
 
         Layout.alignment: Qt.AlignTop | Qt.AlignLeft
         visible: isVisible
-        width: 48
-        height: 48
+        width: Theme.toolButtonSize
+        height: Theme.toolButtonSize
         clip: true
 
         iconSource: Theme.getThemeVectorIcon("ic_check_white_24dp")
@@ -1105,8 +1105,8 @@ Page {
 
         Layout.fillWidth: true
         Layout.preferredHeight: parent.height
-        Layout.leftMargin: (!saveButton.isVisible ? 48 : 0) + (!setupOnly && form.model.hasRemembrance ? 48 : 0)
-        Layout.rightMargin: !setupOnly ? 0 : 48
+        Layout.leftMargin: (!saveButton.isVisible ? Theme.toolButtonSize : 0) + (!setupOnly && form.model.hasRemembrance ? Theme.toolButtonSize : 0)
+        Layout.rightMargin: !setupOnly ? 0 : Theme.toolButtonSize
         objectName: "titleLabel"
 
         font: Theme.strongFont
@@ -1169,8 +1169,8 @@ Page {
         property bool isVisible: !setupOnly
 
         Layout.alignment: Qt.AlignTop | Qt.AlignRight
-        width: 48
-        height: 48
+        width: Theme.toolButtonSize
+        height: Theme.toolButtonSize
         clip: true
         visible: isVisible
 
@@ -1194,8 +1194,8 @@ Page {
 
         Layout.alignment: Qt.AlignTop | Qt.AlignRight
 
-        width: 48
-        height: 48
+        width: Theme.toolButtonSize
+        height: Theme.toolButtonSize
         clip: true
         visible: isVisible
 

--- a/src/qml/FileDeviceChooser.qml
+++ b/src/qml/FileDeviceChooser.qml
@@ -49,8 +49,8 @@ Item {
         inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase | Qt.ImhPreferLowercase
       }
       QfToolButton {
-        width: 48
-        height: 48
+        width: Theme.toolButtonSize
+        height: Theme.toolButtonSize
 
         iconSource: Theme.getThemeVectorIcon("ic_folder_open_black_24dp")
         iconColor: Theme.mainTextColor

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -40,7 +40,7 @@ Item {
       }
       PropertyChanges {
         target: searchFieldRect
-        width: mainWindow.width - mainWindow.sceneLeftMargin - mainWindow.sceneRightMargin - 62
+        width: mainWindow.width - mainWindow.sceneLeftMargin - mainWindow.sceneRightMargin - (Theme.toolButtonSize + 14)
       }
       PropertyChanges {
         target: codeReaderButton
@@ -71,7 +71,7 @@ Item {
       }
       PropertyChanges {
         target: searchFieldRect
-        width: 48
+        width: Theme.toolButtonSize
       }
       PropertyChanges {
         target: searchFieldRect
@@ -199,9 +199,9 @@ Item {
     z: 10
     anchors.top: parent.top
     anchors.right: parent.right
-    width: 48
-    height: 48
-    radius: 24
+    width: Theme.toolButtonSize
+    height: Theme.toolButtonSize
+    radius: height / 2
     color: Theme.controlBackgroundColor
     visible: false
 
@@ -209,7 +209,7 @@ Item {
       id: searchField
       focus: locatorItem.state == "on" ? true : false
       width: parent.width - busyIndicator.width - 76
-      height: 48
+      height: Theme.toolButtonSize
       anchors.top: parent.top
       anchors.left: parent.left
       anchors.verticalCenter: searchFieldRect.verticalCenter
@@ -222,8 +222,8 @@ Item {
       selectByMouse: true
       verticalAlignment: TextInput.AlignVCenter
       background: Rectangle {
-        height: 48
-        radius: 24
+        height: Theme.toolButtonSize
+        radius: height / 2
         color: "transparent"
       }
       inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
@@ -327,10 +327,10 @@ Item {
     id: resultsBox
     z: 1
     width: searchFieldRect.width - 24
-    height: searchFieldRect.visible && resultsList.count > 0 ? resultsList.height + 24 : 0
+    height: searchFieldRect.visible && resultsList.count > 0 ? resultsList.height + searchFieldRect.height / 2 : 0
     anchors.top: searchFieldRect.top
     anchors.left: searchFieldRect.left
-    anchors.topMargin: 24
+    anchors.topMargin: searchFieldRect.height / 2
     color: Theme.mainBackgroundColor
     visible: searchFieldRect.visible && resultsList.count > 0
     clip: true
@@ -346,7 +346,7 @@ Item {
       id: resultsList
       z: 2
       anchors.top: resultsBox.top
-      anchors.topMargin: 24
+      anchors.topMargin: searchFieldRect.height / 2
       model: searchField.displayText !== '' ? locatorBridge.proxyModel() : showAvailableSearchDescription ? locatorFilters : []
       width: parent.width
       height: resultsList.count > 0 ? Math.min(contentHeight, mainWindow.height / 2 - searchFieldRect.height - 10) : 0

--- a/src/qml/NavigationBar.qml
+++ b/src/qml/NavigationBar.qml
@@ -71,7 +71,7 @@ Rectangle {
   anchors.topMargin: 5
   anchors.left: parent.left
   anchors.right: parent.right
-  height: toolBar.topMargin + 58
+  height: toolBar.topMargin + Theme.toolButtonSize + 10
   color: Theme.mainBackgroundColor
   clip: true
 
@@ -118,7 +118,7 @@ Rectangle {
       anchors.top: parent.top
       anchors.leftMargin: 0 + balancedMargin + toolBar.leftMargin
       anchors.rightMargin: 0 + balancedMargin + toolBar.rightMargin
-      height: 48
+      height: Theme.toolButtonSize
 
       text: {
         if (model && selection && selection.focusedItem > -1 && (toolBar.state === 'Navigation' || toolBar.state === 'Edit')) {
@@ -183,8 +183,8 @@ Rectangle {
     anchors.topMargin: toolBar.topMargin + 5
 
     visible: toolBar.state === "Navigation"
-    width: visible ? 48 : 0
-    height: 48
+    width: visible ? Theme.toolButtonSize : 0
+    height: Theme.toolButtonSize
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_chevron_right_white_24dp")
@@ -217,8 +217,8 @@ Rectangle {
     anchors.topMargin: toolBar.topMargin + 5
 
     visible: enabled
-    width: visible ? 48 : 0
-    height: 48
+    width: visible ? Theme.toolButtonSize : 0
+    height: Theme.toolButtonSize
     clip: true
 
     iconSource: toolBar.state === "Navigation" ? Theme.getThemeVectorIcon("ic_chevron_left_white_24dp") : Theme.getThemeVectorIcon("ic_arrow_left_white_24dp")
@@ -251,8 +251,8 @@ Rectangle {
     anchors.topMargin: toolBar.topMargin + 5
 
     visible: toolBar.state === "Edit" || toolBar.state === "ProcessingLaunch"
-    width: visible ? 48 : 0
-    height: 48
+    width: visible ? Theme.toolButtonSize : 0
+    height: Theme.toolButtonSize
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_check_white_24dp")
@@ -289,8 +289,8 @@ Rectangle {
     anchors.topMargin: toolBar.topMargin + 5
 
     visible: !qfieldSettings.autoSave && toolBar.state === "Edit"
-    width: visible ? 48 : 0
-    height: 48
+    width: visible ? Theme.toolButtonSize : 0
+    height: Theme.toolButtonSize
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_clear_white_24dp")
@@ -322,8 +322,8 @@ Rectangle {
     iconSource: Theme.getThemeVectorIcon("ic_edit_geometry_white_24dp")
     iconColor: Theme.mainTextColor
 
-    width: visible ? 48 : 0
-    height: 48
+    width: visible ? Theme.toolButtonSize : 0
+    height: Theme.toolButtonSize
     clip: true
 
     onClicked: {
@@ -357,8 +357,8 @@ Rectangle {
     anchors.topMargin: toolBar.topMargin + 5
 
     visible: toolBar.state === "Navigation" && supportsEditing && !featureForm.model.featureModel.attributeEditingLocked && (projectInfo.editRights || isCreatedCloudFeature)
-    width: visible ? 48 : 0
-    height: 48
+    width: visible ? Theme.toolButtonSize : 0
+    height: Theme.toolButtonSize
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_edit_attributes_white_24dp")
@@ -400,8 +400,8 @@ Rectangle {
     anchors.topMargin: toolBar.topMargin + 5
 
     visible: toolBar.state !== "Edit" && toolBar.state !== "Processing" && toolBar.state !== "ProcessingLaunch"
-    width: visible ? 48 : 0
-    height: 48
+    width: visible ? Theme.toolButtonSize : 0
+    height: Theme.toolButtonSize
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")
@@ -430,8 +430,8 @@ Rectangle {
     anchors.topMargin: toolBar.topMargin + 5
 
     visible: toolBar.multiSelection && toolBar.model && (toolBar.state === "Processing" || toolBar.state === "ProcessingLaunch" || toolBar.state === "Indication")
-    width: visible ? 48 : 0
-    height: 48
+    width: visible ? Theme.toolButtonSize : 0
+    height: Theme.toolButtonSize
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_clear_white_24dp")
@@ -455,9 +455,9 @@ Rectangle {
     anchors.top: parent.top
     anchors.topMargin: toolBar.topMargin + 5
 
-    width: (toolBar.state === "Indication" && toolBar.multiSelection && toolBar.model ? 48 : 0)
+    width: (toolBar.state === "Indication" && toolBar.multiSelection && toolBar.model ? Theme.toolButtonSize : 0)
     visible: width > 0
-    height: 48
+    height: Theme.toolButtonSize
     verticalAlignment: Text.AlignVCenter
     font: Theme.strongFont
     color: Theme.mainTextColor
@@ -475,8 +475,8 @@ Rectangle {
     anchors.topMargin: toolBar.topMargin + 5
 
     visible: toolBar.state === "Indication" && toolBar.model && toolBar.model.canEditAttributesSelection && toolBar.model.selectedCount > 1 && projectInfo.editRights
-    width: visible ? 48 : 0
-    height: 48
+    width: visible ? Theme.toolButtonSize : 0
+    height: Theme.toolButtonSize
     clip: true
 
     iconSource: Theme.getThemeVectorIcon("ic_edit_attributes_white_24dp")
@@ -628,15 +628,15 @@ Rectangle {
       leftPadding: 2
       rightPadding: 2
       spacing: 2
-      height: 48
+      height: Theme.toolButtonSize
       clip: true
 
       property color hoveredColor: Qt.hsla(Theme.mainTextColor.hslHue, Theme.mainTextColor.hslSaturation, Theme.mainTextColor.hslLightness, 0.2)
 
       QfToolButton {
         anchors.verticalCenter: parent.verticalCenter
-        height: 48
-        width: 48
+        height: Theme.toolButtonSize
+        width: Theme.toolButtonSize
         round: true
         iconSource: Theme.getThemeVectorIcon("ic_cut_black_24dp")
         iconColor: enabled ? Theme.mainTextColor : Theme.mainTextDisabledColor
@@ -654,8 +654,8 @@ Rectangle {
 
       QfToolButton {
         anchors.verticalCenter: parent.verticalCenter
-        height: 48
-        width: 48
+        height: Theme.toolButtonSize
+        width: Theme.toolButtonSize
         round: true
         iconSource: Theme.getThemeVectorIcon("ic_copy_black_24dp")
         iconColor: enabled ? Theme.mainTextColor : Theme.mainTextDisabledColor
@@ -669,8 +669,8 @@ Rectangle {
 
       QfToolButton {
         anchors.verticalCenter: parent.verticalCenter
-        height: 48
-        width: 48
+        height: Theme.toolButtonSize
+        width: Theme.toolButtonSize
         round: true
         iconSource: Theme.getThemeVectorIcon("ic_paste_black_24dp")
         iconColor: enabled ? Theme.mainTextColor : Theme.mainTextDisabledColor
@@ -690,8 +690,8 @@ Rectangle {
 
       QfToolButton {
         anchors.verticalCenter: parent.verticalCenter
-        height: 48
-        width: 48
+        height: Theme.toolButtonSize
+        width: Theme.toolButtonSize
         round: true
         iconSource: Theme.getThemeVectorIcon("ic_print_black_24dp")
         iconColor: enabled ? Theme.mainTextColor : Theme.mainTextDisabledColor
@@ -706,8 +706,8 @@ Rectangle {
 
       QfToolButton {
         anchors.verticalCenter: parent.verticalCenter
-        height: 48
-        width: 48
+        height: Theme.toolButtonSize
+        width: Theme.toolButtonSize
         round: true
         iconSource: Theme.getThemeVectorIcon("ic_navigation_flag_purple_24dp")
         iconColor: enabled ? Theme.mainTextColor : Theme.mainTextDisabledColor

--- a/src/qml/PluginItem.qml
+++ b/src/qml/PluginItem.qml
@@ -66,7 +66,7 @@ Rectangle {
     QfToolButton {
       id: configureEnabledPlugin
       enabled: Configurable
-      Layout.preferredWidth: enabled ? 48 : 0
+      Layout.preferredWidth: enabled ? Theme.toolButtonSize : 0
 
       iconSource: Theme.getThemeVectorIcon("ic_tune_white_24dp")
       iconColor: Theme.mainTextColor
@@ -79,7 +79,7 @@ Rectangle {
     QfToolButton {
       id: updatePlugin
       enabled: InstalledLocally && AvailableUpdate
-      Layout.preferredWidth: enabled ? 48 : 0
+      Layout.preferredWidth: enabled ? Theme.toolButtonSize : 0
 
       iconSource: Theme.getThemeVectorIcon("ic_update_white_24dp")
       iconColor: Theme.mainColor
@@ -92,7 +92,7 @@ Rectangle {
     QfToolButton {
       id: downloadPlugin
       enabled: !InstalledLocally && !itemDownloading
-      Layout.preferredWidth: enabled ? 48 : 0
+      Layout.preferredWidth: enabled ? Theme.toolButtonSize : 0
       visible: enabled
       iconSource: Theme.getThemeVectorIcon('ic_download_white_24dp')
       iconColor: Theme.mainColor

--- a/src/qml/PositioningNtripSettings.qml
+++ b/src/qml/PositioningNtripSettings.qml
@@ -258,8 +258,8 @@ QfPopup {
             iconSource: Theme.getThemeVectorIcon("refresh_24dp")
             iconColor: Theme.mainTextColor
             bgcolor: "transparent"
-            Layout.preferredWidth: 48
-            Layout.preferredHeight: 48
+            Layout.preferredWidth: Theme.toolButtonSize
+            Layout.preferredHeight: Theme.toolButtonSize
             padding: 0
 
             onClicked: {
@@ -334,7 +334,7 @@ QfPopup {
 
           QfSwitch {
             id: ntripForwardNmeaSentencesSwitch
-            Layout.preferredWidth: 48
+            Layout.preferredWidth: Theme.toolButtonSize
           }
         }
       }

--- a/src/qml/ProcessingAlgorithmsList.qml
+++ b/src/qml/ProcessingAlgorithmsList.qml
@@ -156,7 +156,7 @@ Item {
             right: parent.right
             verticalCenter: parent.verticalCenter
           }
-          width: 48
+          width: Theme.toolButtonSize
 
           iconSource: Theme.getThemeVectorIcon("ic_star_white_24dp")
           iconColor: AlgorithmFavorite ? Theme.mainColor : Theme.mainTextColor

--- a/src/qml/QFieldAudioRecorder.qml
+++ b/src/qml/QFieldAudioRecorder.qml
@@ -120,12 +120,12 @@ QfPopup {
 
       background: Rectangle {
         color: "transparent"
-        height: 48
+        height: Theme.toolButtonSize
       }
 
       RowLayout {
         width: parent.width
-        height: 48
+        height: Theme.toolButtonSize
 
         Label {
           Layout.leftMargin: 58

--- a/src/qml/QFieldCloudDeltaHistory.qml
+++ b/src/qml/QFieldCloudDeltaHistory.qml
@@ -35,7 +35,7 @@ QfPopup {
     padding: 5
     header: ToolBar {
       id: toolBar
-      height: 48
+      height: Theme.toolButtonSize
 
       topPadding: 0
       leftPadding: 0
@@ -48,8 +48,8 @@ QfPopup {
 
       Label {
         anchors.centerIn: parent
-        leftPadding: 48
-        rightPadding: 48
+        leftPadding: Theme.toolButtonSize
+        rightPadding: Theme.toolButtonSize
         width: parent.width - 20
         text: !!model ? qsTr("Push History") : qsTr("Loading…")
         font: Theme.strongFont

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -507,8 +507,8 @@ Page {
                 }
 
                 Item {
-                  width: 48
-                  height: 48
+                  width: Theme.toolButtonSize
+                  height: Theme.toolButtonSize
                   anchors.verticalCenter: line.verticalCenter
 
                   QfToolButton {
@@ -532,8 +532,8 @@ Page {
                     id: menuButton
                     round: true
                     opacity: 0.5
-                    width: 48
-                    height: 48
+                    width: Theme.toolButtonSize
+                    height: Theme.toolButtonSize
                     visible: LocalPath !== ''
 
                     bgcolor: "transparent"
@@ -575,7 +575,7 @@ Page {
               property Item pressedItem
               propagateComposedEvents: false
               anchors.fill: parent
-              anchors.rightMargin: 48
+              anchors.rightMargin: Theme.toolButtonSize
               onClicked: mouse => {
                 var item = table.itemAt(table.contentX + mouse.x, table.contentY + mouse.y);
                 if (item) {

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -348,7 +348,7 @@ Page {
         MouseArea {
           property Item pressedItem
           anchors.fill: parent
-          anchors.rightMargin: 48
+          anchors.rightMargin: Theme.toolButtonSize
           onClicked: mouse => {
             const item = table.itemAt(table.contentX + mouse.x, table.contentY + mouse.y);
             if (item && localFilesModel.inSelectionMode) {
@@ -1702,7 +1702,7 @@ Page {
               MouseArea {
                 enabled: !lineDialog.isImported
                 anchors.fill: parent
-                anchors.rightMargin: 48
+                anchors.rightMargin: Theme.toolButtonSize
                 onClicked: mouse => {
                   importWebdavPathInput.currentIndex = index;
                   importWebdavImportedFolderName.text = (lineDialog.label !== "" ? lineDialog.label : qsTr("root folder")) + " - " + webdavConnectionLoader.item.username;

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -555,8 +555,8 @@ Page {
 
               QfToolButton {
                 id: showSearchBarSettings
-                Layout.preferredWidth: 48
-                Layout.preferredHeight: 48
+                Layout.preferredWidth: Theme.toolButtonSize
+                Layout.preferredHeight: Theme.toolButtonSize
                 Layout.alignment: Qt.AlignVCenter
                 clip: true
 
@@ -585,8 +585,8 @@ Page {
 
               QfToolButton {
                 id: showPluginManagerSettings
-                Layout.preferredWidth: 48
-                Layout.preferredHeight: 48
+                Layout.preferredWidth: Theme.toolButtonSize
+                Layout.preferredHeight: Theme.toolButtonSize
                 Layout.alignment: Qt.AlignVCenter
                 clip: true
 
@@ -1424,8 +1424,8 @@ Page {
 
                 QfToolButton {
                   id: showNtripSettings
-                  Layout.preferredWidth: 48
-                  Layout.preferredHeight: 48
+                  Layout.preferredWidth: Theme.toolButtonSize
+                  Layout.preferredHeight: Theme.toolButtonSize
                   Layout.alignment: Qt.AlignVCenter
 
                   iconSource: Theme.getThemeVectorIcon("ic_tune_white_24dp")

--- a/src/qml/QFieldSketcher.qml
+++ b/src/qml/QFieldSketcher.qml
@@ -175,8 +175,8 @@ Popup {
         QfToolButton {
           property color colorValue: modelData[0]
 
-          width: 48
-          height: 48
+          width: Theme.toolButtonSize
+          height: Theme.toolButtonSize
           round: true
           borderColor: modelData[1]
           scale: settings.strokeColor == colorValue ? 1 : 0.66

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -565,8 +565,8 @@ Item {
       id: searchButton
       objectName: "openSearchFeaturePopupButton"
 
-      Layout.preferredWidth: enabled ? 48 : 0
-      Layout.preferredHeight: 48
+      Layout.preferredWidth: enabled ? Theme.toolButtonSize : 0
+      Layout.preferredHeight: Theme.toolButtonSize
       Layout.alignment: Qt.AlignTop
 
       bgcolor: "transparent"
@@ -584,8 +584,8 @@ Item {
       id: addFeatureButton
       objectName: "addFeatureButton"
 
-      Layout.preferredWidth: comboBox.enabled ? 48 : 0
-      Layout.preferredHeight: 48
+      Layout.preferredWidth: comboBox.enabled ? Theme.toolButtonSize : 0
+      Layout.preferredHeight: Theme.toolButtonSize
       Layout.alignment: Qt.AlignTop
 
       bgcolor: "transparent"

--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -42,7 +42,7 @@ EditorWidgetBase {
 
   Label {
     id: checkValue
-    height: Math.max(48, fontMetrics.height + 20)
+    height: Math.max(Theme.toolButtonSize, fontMetrics.height + 20)
     anchors {
       left: parent.left
       right: checkBox.left

--- a/src/qml/editorwidgets/Color.qml
+++ b/src/qml/editorwidgets/Color.qml
@@ -7,7 +7,7 @@ import Theme
 EditorWidgetBase {
   id: colorControl
 
-  property double desiredHeight: 48
+  property double desiredHeight: Theme.toolButtonSize
 
   height: desiredHeight
 
@@ -38,22 +38,22 @@ EditorWidgetBase {
     RowLayout {
       id: currentColorView
       width: colorControl.width
-      height: 48
+      height: Theme.toolButtonSize
       spacing: 5
 
       Rectangle {
         id: colorArea
         Layout.fillWidth: true
-        Layout.preferredHeight: 48
-        height: 48
+        Layout.preferredHeight: Theme.toolButtonSize
+        height: Theme.toolButtonSize
         radius: height / 2
 
         color: value == null ? "transparent" : value
 
         QfToolButton {
           anchors.right: parent.right
-          width: 48
-          height: 48
+          width: Theme.toolButtonSize
+          height: Theme.toolButtonSize
           visible: isEnabled
           enabled: false
           iconSource: Theme.getThemeVectorIcon("ic_ellipsis_black_24dp")
@@ -75,12 +75,12 @@ EditorWidgetBase {
     RowLayout {
       id: selectColorView
       width: colorControl.width
-      height: 48
+      height: Theme.toolButtonSize
       spacing: 5
 
       ListView {
         Layout.fillWidth: true
-        Layout.preferredHeight: 48
+        Layout.preferredHeight: Theme.toolButtonSize
         orientation: ListView.Horizontal
         spacing: 10
         model: ["#e41a1c", "#377eb8", "#4daf4a", "#984ea3", "#ff7f00"]
@@ -88,8 +88,8 @@ EditorWidgetBase {
         clip: true
 
         delegate: QfToolButton {
-          Layout.preferredWidth: 48
-          Layout.preferredHeight: 48
+          Layout.preferredWidth: Theme.toolButtonSize
+          Layout.preferredHeight: Theme.toolButtonSize
           bgcolor: modelData
           round: true
 

--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -177,7 +177,7 @@ EditorWidgetBase {
 
     QfToolButton {
       id: todayButton
-      width: enabled ? 48 : 0
+      width: enabled ? Theme.toolButtonSize : 0
       visible: enabled
 
       iconSource: Theme.getThemeVectorIcon("ic_calendar_today_black_24dp")

--- a/src/qml/editorwidgets/ExternalResource.qml
+++ b/src/qml/editorwidgets/ExternalResource.qml
@@ -591,8 +591,8 @@ EditorWidgetBase {
 
   QfToolButton {
     id: cameraButton
-    width: visible ? 48 : 0
-    height: 48
+    width: visible ? Theme.toolButtonSize : 0
+    height: Theme.toolButtonSize
 
     // QField has historically handled no viewer type as image, let's carry that on
     visible: documentViewer == ExternalResource.DocumentImage && isEnabled
@@ -609,8 +609,8 @@ EditorWidgetBase {
 
   QfToolButton {
     id: cameraVideoButton
-    width: visible ? 48 : 0
-    height: 48
+    width: visible ? Theme.toolButtonSize : 0
+    height: Theme.toolButtonSize
 
     visible: documentViewer == ExternalResource.DocumentVideo && isEnabled
 
@@ -626,8 +626,8 @@ EditorWidgetBase {
 
   QfToolButton {
     id: microphoneButton
-    width: visible ? 48 : 0
-    height: 48
+    width: visible ? Theme.toolButtonSize : 0
+    height: Theme.toolButtonSize
 
     visible: documentViewer == ExternalResource.DocumentAudio && isEnabled
 
@@ -643,8 +643,8 @@ EditorWidgetBase {
 
   QfToolButton {
     id: fileButton
-    width: visible ? 48 : 0
-    height: 48
+    width: visible ? Theme.toolButtonSize : 0
+    height: Theme.toolButtonSize
 
     visible: platformUtilities.capabilities & PlatformUtilities.FilePicker && documentViewer == ExternalResource.DocumentFile && isEnabled
 

--- a/src/qml/editorwidgets/Range.qml
+++ b/src/qml/editorwidgets/Range.qml
@@ -115,8 +115,8 @@ EditorWidgetBase {
 
     QfToolButton {
       id: decreaseButton
-      width: enabled ? 48 : 0
-      height: 48
+      width: enabled ? Theme.toolButtonSize : 0
+      height: Theme.toolButtonSize
 
       anchors.verticalCenter: textField.verticalCenter
 
@@ -147,8 +147,8 @@ EditorWidgetBase {
 
     QfToolButton {
       id: increaseButton
-      width: enabled ? 48 : 0
-      height: 48
+      width: enabled ? Theme.toolButtonSize : 0
+      height: Theme.toolButtonSize
 
       anchors.verticalCenter: textField.verticalCenter
 

--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -14,7 +14,7 @@ EditorWidgetBase {
   property alias footer: footer
   property alias headerEntry: headerEntry
 
-  property int itemHeight: 48
+  property int itemHeight: Theme.toolButtonSize
   property int bottomMargin: 10
   property int maximumVisibleItems: 4
   property bool showAllItems: false

--- a/src/qml/editorwidgets/RelationReference.qml
+++ b/src/qml/editorwidgets/RelationReference.qml
@@ -71,8 +71,8 @@ EditorWidgetBase {
       Layout.alignment: Qt.AlignTop
       visible: isVisible
       enabled: relationReference.currentKeyValue !== undefined && relationReference.currentKeyValue !== ''
-      width: isVisible && enabled ? 48 : 0
-      height: 48
+      width: isVisible && enabled ? Theme.toolButtonSize : 0
+      height: Theme.toolButtonSize
 
       iconSource: Theme.getThemeVectorIcon("ic_view_black_24dp")
       iconColor: Theme.mainTextColor
@@ -95,8 +95,8 @@ EditorWidgetBase {
 
       Layout.alignment: Qt.AlignTop
       enabled: showOpenFormButton && relationReference.currentKeyValue !== undefined && relationReference.currentKeyValue !== ''
-      width: enabled ? 48 : 0
-      height: 48
+      width: enabled ? Theme.toolButtonSize : 0
+      height: Theme.toolButtonSize
 
       iconSource: isEnabled ? Theme.getThemeVectorIcon('ic_edit_attributes_white_24dp') : Theme.getThemeVectorIcon('ic_baseline-list_white_24dp')
       iconColor: Theme.mainTextColor

--- a/src/qml/editorwidgets/ValueMap.qml
+++ b/src/qml/editorwidgets/ValueMap.qml
@@ -153,8 +153,8 @@ EditorWidgetBase {
     QfToolButton {
       id: searchButton
 
-      Layout.preferredWidth: enabled ? 48 : 0
-      Layout.preferredHeight: 48
+      Layout.preferredWidth: enabled ? Theme.toolButtonSize : 0
+      Layout.preferredHeight: Theme.toolButtonSize
 
       bgcolor: "transparent"
       iconSource: Theme.getThemeVectorIcon("ic_baseline_search_white")

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -325,8 +325,8 @@ RelationEditorBase {
 
   headerActions: [
     QfToolButton {
-      width: 48
-      height: 48
+      width: Theme.toolButtonSize
+      height: Theme.toolButtonSize
       enabled: isEnabled
       visible: isEnabled
 
@@ -847,8 +847,8 @@ RelationEditorBase {
           QfToolButton {
             id: listFormButton
             anchors.verticalCenter: parent.verticalCenter
-            width: 48
-            height: 48
+            width: Theme.toolButtonSize
+            height: Theme.toolButtonSize
             round: false
             iconSource: isEnabled ? Theme.getThemeVectorIcon('ic_edit_attributes_white_24dp') : Theme.getThemeVectorIcon('ic_baseline-list_white_24dp')
             iconColor: Theme.mainTextColor
@@ -860,8 +860,8 @@ RelationEditorBase {
           QfToolButton {
             id: listMenuButton
             anchors.verticalCenter: parent.verticalCenter
-            width: 48
-            height: 48
+            width: Theme.toolButtonSize
+            height: Theme.toolButtonSize
             round: false
             iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")
             iconColor: Theme.mainTextColor
@@ -1164,8 +1164,8 @@ RelationEditorBase {
 
           Rectangle {
             anchors.centerIn: parent
-            width: 48
-            height: 48
+            width: Theme.toolButtonSize
+            height: Theme.toolButtonSize
             radius: width / 2
             color: cardContainer.overlayColor
             border.width: 0.5
@@ -1299,8 +1299,8 @@ RelationEditorBase {
             anchors.right: parent.right
             anchors.rightMargin: 2
             anchors.verticalCenter: parent.verticalCenter
-            width: 48
-            height: 48
+            width: Theme.toolButtonSize
+            height: Theme.toolButtonSize
 
             round: false
             iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -132,8 +132,8 @@ RelationEditorBase {
             id: featureImage
             source: ImagePath ? UrlUtils.fromString(ImagePath) : Theme.getThemeVectorIcon("ic_photo_notavailable_black_24dp")
             anchors.verticalCenter: parent.verticalCenter
-            width: 48
-            height: 48
+            width: Theme.toolButtonSize
+            height: Theme.toolButtonSize
             fillMode: Image.PreserveAspectFit
             mipmap: true
             visible: !!ImagePath
@@ -156,8 +156,8 @@ RelationEditorBase {
           QfToolButton {
             id: viewButton
             anchors.verticalCenter: parent.verticalCenter
-            width: 48
-            height: 48
+            width: Theme.toolButtonSize
+            height: Theme.toolButtonSize
 
             round: false
             iconSource: isEnabled ? Theme.getThemeVectorIcon('ic_edit_attributes_white_24dp') : Theme.getThemeVectorIcon('ic_baseline-list_white_24dp')
@@ -173,8 +173,8 @@ RelationEditorBase {
             id: moveDownButton
             anchors.verticalCenter: parent.verticalCenter
             visible: isEnabled
-            width: visible ? 48 : 0
-            height: 48
+            width: visible ? Theme.toolButtonSize : 0
+            height: Theme.toolButtonSize
             opacity: (index === listView.count - 1) ? 0.3 : 1
 
             round: false
@@ -194,8 +194,8 @@ RelationEditorBase {
             id: moveUpButton
             anchors.verticalCenter: parent.verticalCenter
             visible: isEnabled
-            width: visible ? 48 : 0
-            height: 48
+            width: visible ? Theme.toolButtonSize : 0
+            height: Theme.toolButtonSize
             opacity: (index === 0) ? 0.3 : 1
 
             round: false
@@ -214,8 +214,8 @@ RelationEditorBase {
           QfToolButton {
             id: menuButton
             anchors.verticalCenter: parent.verticalCenter
-            width: 48
-            height: 48
+            width: Theme.toolButtonSize
+            height: Theme.toolButtonSize
 
             round: false
             iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -103,8 +103,8 @@ RelationEditorBase {
         QfToolButton {
           id: viewButton
           anchors.verticalCenter: parent.verticalCenter
-          width: 48
-          height: 48
+          width: Theme.toolButtonSize
+          height: Theme.toolButtonSize
 
           round: false
           iconSource: isEnabled ? Theme.getThemeVectorIcon('ic_edit_attributes_white_24dp') : Theme.getThemeVectorIcon('ic_baseline-list_white_24dp')
@@ -119,8 +119,8 @@ RelationEditorBase {
         QfToolButton {
           id: menuButton
           anchors.verticalCenter: parent.verticalCenter
-          width: 48
-          height: 48
+          width: Theme.toolButtonSize
+          height: Theme.toolButtonSize
 
           round: false
           iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")

--- a/src/qml/imports/Theme/QfActionButton.qml
+++ b/src/qml/imports/Theme/QfActionButton.qml
@@ -14,7 +14,7 @@ ToolButton {
   property string toolText: qsTr("close")
   property alias innerActionIcon: innerAction
 
-  height: 48
+  height: Theme.toolButtonSize
   width: height + (buttonText.visible ? buttonText.width + 24 : 0) + (innerAction.visible ? 32 : 0)
   clip: true
 
@@ -26,15 +26,15 @@ ToolButton {
 
   background: Rectangle {
     width: parent.width
-    height: 48
+    height: Theme.toolButtonSize
     color: Theme.toolButtonBackgroundSemiOpaqueColor
     radius: height / 2
 
     QfToolButton {
       anchors.left: parent.left
       anchors.top: parent.top
-      width: 48
-      height: 48
+      width: Theme.toolButtonSize
+      height: Theme.toolButtonSize
       enabled: false
       round: true
       iconSource: button.toolImage
@@ -46,7 +46,7 @@ ToolButton {
       id: ripple
       clip: true
       width: parent.width
-      height: 48
+      height: Theme.toolButtonSize
       clipRadius: 4
       pressed: button.down
       anchor: parent
@@ -57,7 +57,7 @@ ToolButton {
 
   contentItem: Row {
     anchors.left: parent.left
-    anchors.leftMargin: 48 + 8
+    anchors.leftMargin: Theme.toolButtonSize + 8
     spacing: 8
     padding: 0
     visible: button.toolText !== ""

--- a/src/qml/imports/Theme/QfPageHeader.qml
+++ b/src/qml/imports/Theme/QfPageHeader.qml
@@ -31,7 +31,7 @@ ToolBar {
   signal remove
   signal openMenu
 
-  height: topMargin + 48
+  height: topMargin + Theme.toolButtonSize
 
   topPadding: 0
   leftPadding: 0
@@ -147,8 +147,8 @@ ToolBar {
 
     Label {
       id: titleLabel
-      leftPadding: !showApplyButton && (showCancelButton || showRemoveButton) ? 48 : 0
-      rightPadding: (showApplyButton || showBackButton) && !showCancelButton && !showRemoveButton && !showMenuButton ? 48 : 0
+      leftPadding: !showApplyButton && (showCancelButton || showRemoveButton) ? Theme.toolButtonSize : 0
+      rightPadding: (showApplyButton || showBackButton) && !showCancelButton && !showRemoveButton && !showMenuButton ? Theme.toolButtonSize : 0
       font: Theme.strongTitleFont
       color: backgroundFill ? Theme.mainOverlayColor : Theme.mainTextColor
       elide: Label.ElideRight

--- a/src/qml/imports/Theme/QfToggleButtonGroup.qml
+++ b/src/qml/imports/Theme/QfToggleButtonGroup.qml
@@ -34,7 +34,7 @@ Item {
   /**
    * Minimum width for buttons to handle empty text gracefully
    */
-  property real buttonMininumWidth: 48
+  property real buttonMininumWidth: Theme.toolButtonSize
 
   /**
    * Spacing between buttons

--- a/src/qml/imports/Theme/QfToolButton.qml
+++ b/src/qml/imports/Theme/QfToolButton.qml
@@ -80,12 +80,12 @@ RoundButton {
     visible: bottomRightIndicatorText
     color: bottomRightIndicatorBgColor
     border.color: Theme.mainBackgroundColor
-    border.width: 2
+    border.width: Math.max(1, button.width / 24)
 
     badgeText.color: bottomRightIndicatorFgColor
     badgeText.text: bottomRightIndicatorText
 
-    bottomMargin: 7
-    rightMargin: 5
+    bottomMargin: button.width * 0.15
+    rightMargin: button.width * 0.1
   }
 }

--- a/src/qml/imports/Theme/QfToolButton.qml
+++ b/src/qml/imports/Theme/QfToolButton.qml
@@ -64,6 +64,8 @@ RoundButton {
 
   icon.source: ""
   icon.color: "transparent" // setting the color to transparent tells Qt to draw the icon using the original source color(s)
+  icon.width: Math.min(width, height) / 2
+  icon.height: Math.min(width, height) / 2
 
   Material.foreground: icon.color
   font: Theme.tipFont

--- a/src/qml/imports/Theme/QfToolButton.qml
+++ b/src/qml/imports/Theme/QfToolButton.qml
@@ -21,8 +21,8 @@ RoundButton {
   property alias bgcolor: backgroundRectangle.color
   property color borderColor: 'transparent'
 
-  width: 48
-  height: 48
+  width: Theme.toolButtonSize
+  height: Theme.toolButtonSize
   implicitWidth: width
   implicitHeight: height
   focusPolicy: Qt.NoFocus

--- a/src/qml/imports/Theme/QfToolButtonDrawer.qml
+++ b/src/qml/imports/Theme/QfToolButtonDrawer.qml
@@ -16,7 +16,7 @@ Container {
   }
 
   property string name: ''
-  property real size: 48
+  property real size: Theme.toolButtonSize
   property int direction: QfToolButtonDrawer.Direction.Down
   property bool collapsed: true
   property alias round: toggleButton.round

--- a/src/qml/imports/Theme/QfToolButtonPie.qml
+++ b/src/qml/imports/Theme/QfToolButtonPie.qml
@@ -13,7 +13,7 @@ Menu {
 
   readonly property int numberOfButtons: menuItemsView.count
 
-  property int bandWidth: 48
+  property int bandWidth: Theme.toolButtonSize
   property real openingAngle: 0
 
   property alias strokeColor: shapePath.strokeColor

--- a/src/qml/imports/Theme/QfWelcomeAction.qml
+++ b/src/qml/imports/Theme/QfWelcomeAction.qml
@@ -19,8 +19,8 @@ ColumnLayout {
   QfToolButton {
     id: actionButton
     Layout.alignment: Qt.AlignHCenter
-    Layout.minimumWidth: 48
-    Layout.minimumHeight: 48
+    Layout.minimumWidth: Theme.toolButtonSize
+    Layout.minimumHeight: Theme.toolButtonSize
     Layout.preferredWidth: Math.min(Screen.height / 4, root.width / 1.5)
     Layout.preferredHeight: Layout.preferredWidth
     icon.width: width / 2.2

--- a/src/qml/processingparameterwidgets/area.qml
+++ b/src/qml/processingparameterwidgets/area.qml
@@ -133,8 +133,8 @@ ProcessingParameterWidgetBase {
 
     QfToolButton {
       id: decreaseButton
-      width: enabled ? 48 : 0
-      height: 48
+      width: enabled ? Theme.toolButtonSize : 0
+      height: Theme.toolButtonSize
 
       anchors.verticalCenter: textField.verticalCenter
 
@@ -165,8 +165,8 @@ ProcessingParameterWidgetBase {
 
     QfToolButton {
       id: increaseButton
-      width: enabled ? 48 : 0
-      height: 48
+      width: enabled ? Theme.toolButtonSize : 0
+      height: Theme.toolButtonSize
 
       anchors.verticalCenter: textField.verticalCenter
 

--- a/src/qml/processingparameterwidgets/distance.qml
+++ b/src/qml/processingparameterwidgets/distance.qml
@@ -125,8 +125,8 @@ ProcessingParameterWidgetBase {
 
     QfToolButton {
       id: decreaseButton
-      width: enabled ? 48 : 0
-      height: 48
+      width: enabled ? Theme.toolButtonSize : 0
+      height: Theme.toolButtonSize
 
       anchors.verticalCenter: textField.verticalCenter
 
@@ -157,8 +157,8 @@ ProcessingParameterWidgetBase {
 
     QfToolButton {
       id: increaseButton
-      width: enabled ? 48 : 0
-      height: 48
+      width: enabled ? Theme.toolButtonSize : 0
+      height: Theme.toolButtonSize
 
       anchors.verticalCenter: textField.verticalCenter
 

--- a/src/qml/processingparameterwidgets/number.qml
+++ b/src/qml/processingparameterwidgets/number.qml
@@ -52,8 +52,8 @@ ProcessingParameterWidgetBase {
 
     QfToolButton {
       id: decreaseButton
-      width: enabled ? 48 : 0
-      height: 48
+      width: enabled ? Theme.toolButtonSize : 0
+      height: Theme.toolButtonSize
 
       anchors.verticalCenter: textField.verticalCenter
 
@@ -84,8 +84,8 @@ ProcessingParameterWidgetBase {
 
     QfToolButton {
       id: increaseButton
-      width: enabled ? 48 : 0
-      height: 48
+      width: enabled ? Theme.toolButtonSize : 0
+      height: Theme.toolButtonSize
 
       anchors.verticalCenter: textField.verticalCenter
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2224,7 +2224,7 @@ ApplicationWindow {
 
       anchors.right: locatorItem.right
       anchors.top: locatorItem.top
-      anchors.topMargin: 48 + 4
+      anchors.topMargin: Theme.toolButtonSize + 4
       spacing: 4
     }
 
@@ -2422,7 +2422,6 @@ ApplicationWindow {
       QfToolButtonDrawer {
         objectName: "digitizingDrawer"
         name: "digitizingDrawer"
-        size: 48
         round: true
         bgcolor: Theme.toolButtonBackgroundColor
         iconSource: Theme.getThemeVectorIcon('ic_digitizing_settings_black_24dp')
@@ -2859,7 +2858,6 @@ ApplicationWindow {
 
       QfToolButtonDrawer {
         name: "3dDrawer"
-        size: 48
         round: true
         collapsed: false
         bgcolor: Theme.toolButtonBackgroundColor

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -1322,7 +1322,9 @@ ApplicationWindow {
           bgcolor: Theme.toolButtonBackgroundColor
 
           QfBadge {
-            width: 16
+            width: identifyFeaturesButton.width / 2.5
+            topMargin: identifyFeaturesButton.width / 20
+            rightMargin: identifyFeaturesButton.width / 20
             color: Theme.toolButtonColor
             border.width: 1
             border.color: Theme.toolButtonColor
@@ -2356,6 +2358,9 @@ ApplicationWindow {
 
         QfBadge {
           alignment: QfBadge.Alignment.TopRight
+          width: menuButton.width / 4
+          topMargin: menuButton.width / 24
+          rightMargin: menuButton.width / 24
           visible: showSync || showPush
           color: showSync ? Theme.mainColor : Theme.cloudColor
           enableGradient: showSync && showPush
@@ -3169,6 +3174,9 @@ ApplicationWindow {
 
         QfBadge {
           alignment: QfBadge.Alignment.TopRight
+          width: gnssButton.width / 4
+          topMargin: gnssButton.width / 24
+          rightMargin: gnssButton.width / 24
           visible: positioningSettings.accuracyIndicator && gnssButton.state === "On" && positionSource.positionInformation.accuracyQuality != GnssPositionInformation.AccuracyUndetermined
           color: {
             if (!positionSource.positionInformation || !positionSource.positionInformation.haccValid)

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -2436,8 +2436,8 @@ ApplicationWindow {
 
         QfToolButton {
           id: cogoButton
-          width: 40
-          height: 40
+          width: Theme.toolButtonSize * 5 / 6
+          height: Theme.toolButtonSize * 5 / 6
           padding: 2
           round: true
           state: digitizingToolbar.cogoEnabled ? "On" : "Off"
@@ -2473,8 +2473,8 @@ ApplicationWindow {
 
         QfToolButton {
           id: snappingButton
-          width: 40
-          height: 40
+          width: Theme.toolButtonSize * 5 / 6
+          height: Theme.toolButtonSize * 5 / 6
           padding: 2
           round: true
           state: qgisProject && qgisProject.snappingConfig.enabled ? "On" : "Off"
@@ -2513,8 +2513,8 @@ ApplicationWindow {
 
         QfToolButton {
           id: topologyButton
-          width: 40
-          height: 40
+          width: Theme.toolButtonSize * 5 / 6
+          height: Theme.toolButtonSize * 5 / 6
           padding: 2
           round: true
           state: qgisProject && qgisProject.topologicalEditing ? "On" : "Off"
@@ -2550,8 +2550,8 @@ ApplicationWindow {
 
         QfToolButton {
           id: freehandButton
-          width: visible ? 40 : 0
-          height: visible ? 40 : 0
+          width: visible ? Theme.toolButtonSize * 5 / 6 : 0
+          height: visible ? Theme.toolButtonSize * 5 / 6 : 0
           padding: 2
           round: true
           visible: hoverHandler.hasBeenHovered && !(positionSource.active && coordinateLocator.positionLocked) && stateMachine.state === "digitize" && ((digitizingToolbar.geometryRequested && digitizingToolbar.geometryRequestedLayer && digitizingToolbar.geometryRequestedLayer.isValid && (digitizingToolbar.geometryRequestedLayer.geometryType() === Qgis.GeometryType.Polygon || digitizingToolbar.geometryRequestedLayer.geometryType() === Qgis.GeometryType.Line)) || (!digitizingToolbar.geometryRequested && dashBoard.activeLayer && dashBoard.activeLayer.isValid && (dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Polygon || dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Line)))
@@ -2598,8 +2598,8 @@ ApplicationWindow {
         QfToolButton {
           id: snapToCommonAngleButton
 
-          width: visible ? 40 : 0
-          height: visible ? 40 : 0
+          width: visible ? Theme.toolButtonSize * 5 / 6 : 0
+          height: visible ? Theme.toolButtonSize * 5 / 6 : 0
           round: true
           visible: dashBoard.activeLayer && (dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Polygon || dashBoard.activeLayer.geometryType() === Qgis.GeometryType.Line)
           iconSource: Theme.getThemeVectorIcon("ic_common_angle_white_24dp")


### PR DESCRIPTION
### 🚀 Description

Tool button dimensions were hard-coded to `48` throughout the QML tree. This PR introduces a single, read & write `Theme.toolButtonSize` property (default `48`) and routes every tool-button-related component through it, so the button size can be changed centrally.

### ✨ Key Changes

- **New property**: `Theme.toolButtonSize`.
- **Icons scale with the button**
- **Badges are responsive**
- **Switches & bespoke controls**: the digitize/browse mode switch, the custom search button.
- etc

### 🔌 Plugin to use
[**qfield-interface-size.zip**](https://github.com/user-attachments/files/29766223/qfield-interface-size.zip)


### Demo


https://github.com/user-attachments/assets/49774a67-90d8-4af9-b28a-65b06a80ff34

