### PR TITLE
[Backport release-4_2] When opening a cloud project from the cloud projects screen, use the cloud project name instead of filename for the loading overlay

### DIFF
--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -581,7 +581,7 @@ Page {
                 if (item) {
                   if (item.projectLocalPath !== '') {
                     qfieldCloudScreen.visible = false;
-                    iface.loadFile(item.projectLocalPath);
+                    iface.loadFile(item.projectLocalPath, item.projectName);
                   } else {
                     projectDetails.cloudProject = cloudProjectsModel.findProject(item.projectId);
                     projectsSwipeView.currentIndex = 1;
@@ -798,7 +798,7 @@ Page {
       onTriggered: {
         if (projectActions.projectLocalPath != '') {
           qfieldCloudScreen.visible = false;
-          iface.loadFile(projectActions.projectLocalPath);
+          iface.loadFile(projectActions.projectLocalPath, projectActions.projectName);
         }
       }
     }

--- a/test/qml/tst_positioning.qml
+++ b/test/qml/tst_positioning.qml
@@ -62,16 +62,12 @@ TestCase {
     verify(featureModel.feature.attribute("x") === undefined);
     verify(featureModel.feature.attribute("y") === undefined);
     verify(featureModel.feature.attribute("z") === undefined);
+    wait(500);
+    tryVerify(() => positioning.positionInformation.sourceName !== undefined && positioning.positionInformation.fixStatus !== undefined);
 
-    for (let i = 0; i < 10; i++) {
-      wait(500);
-      if (positioning.positionInformation.qualityDescription !== undefined && positioning.positionInformation.fixStatus !== undefined) {
-        break;
-      }
-    }
-
+    sleep(5);
     featureModel.resetAttributes();
-    tryVerify(() => featureModel.feature.attribute("source") === "manual", 2000);
+    tryVerify(() => featureModel.feature.attribute("source") === "manual", 4000);
     verify(featureModel.feature.attribute("Quality") !== undefined);
     verify(featureModel.feature.attribute("Fix status") !== undefined);
     verify(featureModel.feature.attribute("Horizontal accuracy") !== undefined);
@@ -80,9 +76,12 @@ TestCase {
     verify(featureModel.feature.attribute("y") !== undefined);
     verify(featureModel.feature.attribute("z") !== undefined);
     verify(featureModel.appExpressionContextScopesGenerator.positionInformation.latitude !== undefined);
+
     featureModel.appExpressionContextScopesGenerator.positionLocked = true;
+
+    sleep(5);
     featureModel.resetAttributes();
-    tryVerify(() => featureModel.feature.attribute("source") === "nmea", 2000);
+    tryVerify(() => featureModel.feature.attribute("source") === "nmea", 4000);
     verify(featureModel.feature.attribute("Quality") !== undefined);
     verify(featureModel.feature.attribute("Fix status") !== undefined);
     verify(featureModel.feature.attribute("Horizontal accuracy") !== undefined);


### PR DESCRIPTION
Backport #7716
 **Authored by:** @nirvn