### PR TITLE
Add gallery image picking to the code reader

### DIFF
--- a/src/core/barcodedecoder.cpp
+++ b/src/core/barcodedecoder.cpp
@@ -16,6 +16,7 @@
 
 #include "barcodedecoder.h"
 
+#include <QImageReader>
 #include <QVideoFrame>
 
 #include <ZXing/ReadBarcode.h>
@@ -129,12 +130,10 @@ bool BarcodeDecoder::decodeImage( const QImage &image )
 
 bool BarcodeDecoder::decodeImageFile( const QString &path )
 {
-  if ( mDecodingThread )
-  {
-    return false;
-  }
+  QImageReader reader( path );
+  reader.setDecideFormatFromContent( true );
 
-  QImage image( path );
+  QImage image = reader.read();
   if ( image.isNull() )
   {
     return false;

--- a/src/core/barcodedecoder.cpp
+++ b/src/core/barcodedecoder.cpp
@@ -60,7 +60,7 @@ void BarcodeDecoder::clearDecodedString()
   emit decodedStringChanged();
 }
 
-void BarcodeDecoder::decodeImage( const QImage &image )
+bool BarcodeDecoder::decodeImage( const QImage &image )
 {
   auto imageFormatFromQImage = []( const QImage &img ) {
     switch ( img.format() )
@@ -119,11 +119,35 @@ void BarcodeDecoder::decodeImage( const QImage &image )
       {
         mDecodedString = resultText;
         emit decodedStringChanged();
+        return true;
       }
     }
   }
 
-  return;
+  return false;
+}
+
+bool BarcodeDecoder::decodeImageFile( const QString &path )
+{
+  if ( mDecodingThread )
+  {
+    return false;
+  }
+
+  QImage image( path );
+  if ( image.isNull() )
+  {
+    return false;
+  }
+
+  if ( image.format() != QImage::Format_ARGB32 )
+  {
+    image = image.convertToFormat( QImage::Format_ARGB32 );
+  }
+
+  clearDecodedString();
+
+  return decodeImage( image );
 }
 
 QVideoSink *BarcodeDecoder::videoSink() const

--- a/src/core/barcodedecoder.h
+++ b/src/core/barcodedecoder.h
@@ -48,8 +48,15 @@ class BarcodeDecoder : public QObject
 
     /**
      * Scans a provided \a image for barcodes and if present sets the decoded string value.
+     * Returns TRUE when a barcode was decoded.
      */
-    void decodeImage( const QImage &image );
+    bool decodeImage( const QImage &image );
+
+    /**
+     * Scans an image found at a given \a path for barcodes and if present sets the decoded
+     * string value. Returns TRUE when a barcode was decoded.
+     */
+    Q_INVOKABLE bool decodeImageFile( const QString &path );
 
     QVideoSink *videoSink() const;
     void setVideoSink( QVideoSink *sink );

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -86,7 +86,7 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
      *          this includes local qfieldcloud data or sample projects.
      *          A \a subDir is appended to the path.
      */
-    virtual QString systemLocalDataLocation( const QString &subDir = QString() ) const;
+    Q_INVOKABLE virtual QString systemLocalDataLocation( const QString &subDir = QString() ) const;
 
     /**
      * Returns TRUE is a project file has been provided and should be opened at launch.

--- a/src/qml/CodeReader.qml
+++ b/src/qml/CodeReader.qml
@@ -62,8 +62,11 @@ QfPopup {
     }
   }
 
+  property bool pickingImage: false
+
   function pickImage() {
-    imageResourceSource = platformUtilities.getGalleryPicture(platformUtilities.systemLocalDataLocation() + '/', 'codereader.{extension}', codeReader);
+    pickingImage = true;
+    imageResourceSource = platformUtilities.getGalleryPicture(platformUtilities.systemLocalDataLocation() + '/', 'codereader.{extension}', codeReader.contentItem);
     imageResourceSource.resourceReceived.connect(codeReader.decodeImageResource);
   }
 
@@ -74,6 +77,7 @@ QfPopup {
     }
     platformUtilities.rmFile(filePath);
     imageResourceSource = undefined;
+    pickingImage = false;
   }
 
   QfCameraPermission {
@@ -224,7 +228,7 @@ QfPopup {
               CaptureSession {
                 id: captureSession
                 camera: Camera {
-                  active: codeReader.visible && settings.cameraActive
+                  active: codeReader.visible && settings.cameraActive && !codeReader.pickingImage
                   flashMode: Camera.FlashOff
                 }
                 videoOutput: videoOutput

--- a/src/qml/CodeReader.qml
+++ b/src/qml/CodeReader.qml
@@ -22,6 +22,7 @@ QfPopup {
   property var barcodeRequestedItem: undefined //<! when a feature form is requesting a bardcode, this will be set to attribute editor widget which triggered the request
   property int popupWidth: mainWindow.width <= mainWindow.height ? mainWindow.width - Theme.popupScreenEdgeHorizontalMargin : mainWindow.height - Theme.popupScreenEdgeVerticalMargin
   property bool openedOnce: false
+  property var imageResourceSource: undefined
 
   width: popupWidth
   height: Math.min(mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4), popupWidth + toolBar.height + acceptButton.height)
@@ -59,6 +60,20 @@ QfPopup {
     if (decodedString != "") {
       decoded(decodedString);
     }
+  }
+
+  function pickImage() {
+    imageResourceSource = platformUtilities.getGalleryPicture(platformUtilities.systemLocalDataLocation() + '/', 'codereader.{extension}', codeReader);
+    imageResourceSource.resourceReceived.connect(codeReader.decodeImageResource);
+  }
+
+  function decodeImageResource(path) {
+    const filePath = platformUtilities.systemLocalDataLocation() + '/' + path;
+    if (!barcodeDecoder.decodeImageFile(filePath)) {
+      displayToast(qsTr('No readable code found in the selected image'));
+    }
+    platformUtilities.rmFile(filePath);
+    imageResourceSource = undefined;
   }
 
   QfCameraPermission {
@@ -397,9 +412,10 @@ QfPopup {
 
         QfToolButton {
           id: flashlightButton
-          anchors.bottom: parent.bottom
-          anchors.bottomMargin: 20
+          anchors.bottom: buttonsRow.top
+          anchors.bottomMargin: 10
           anchors.horizontalCenter: parent.horizontalCenter
+          width: buttonsRow.width
           round: true
           iconSource: Theme.getThemeVectorIcon('ic_flashlight_white_48dp')
           iconColor: Theme.toolButtonColor
@@ -435,75 +451,87 @@ QfPopup {
           }
         }
 
-        QfToolButton {
-          id: cameraButton
+        Row {
+          id: buttonsRow
           anchors.bottom: parent.bottom
           anchors.bottomMargin: 20
-          anchors.right: flashlightButton.left
-          anchors.rightMargin: 10
-          round: true
-          iconSource: Theme.getThemeVectorIcon('ic_qr_code_black_24dp')
-          iconColor: Theme.toolButtonColor
-          bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
+          anchors.horizontalCenter: parent.horizontalCenter
+          spacing: 10
 
-          visible: withNfc
-          state: settings.cameraActive ? "On" : "Off"
-          states: [
-            State {
-              name: "Off"
-              PropertyChanges {
-                target: cameraButton
-                bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
+          QfToolButton {
+            id: cameraButton
+            round: true
+            iconSource: Theme.getThemeVectorIcon('ic_qr_code_black_24dp')
+            iconColor: Theme.toolButtonColor
+            bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
+
+            visible: withNfc
+            state: settings.cameraActive ? "On" : "Off"
+            states: [
+              State {
+                name: "Off"
+                PropertyChanges {
+                  target: cameraButton
+                  bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
+                }
+              },
+              State {
+                name: "On"
+                PropertyChanges {
+                  target: cameraButton
+                  iconColor: Theme.mainColor
+                  bgcolor: Theme.toolButtonBackgroundColor
+                }
               }
-            },
-            State {
-              name: "On"
-              PropertyChanges {
-                target: cameraButton
-                iconColor: Theme.mainColor
-                bgcolor: Theme.toolButtonBackgroundColor
-              }
+            ]
+
+            onClicked: {
+              settings.cameraActive = !settings.cameraActive;
             }
-          ]
-
-          onClicked: {
-            settings.cameraActive = !settings.cameraActive;
           }
-        }
 
-        QfToolButton {
-          id: nearfieldButton
-          anchors.bottom: parent.bottom
-          anchors.bottomMargin: 20
-          anchors.left: flashlightButton.right
-          anchors.leftMargin: 10
-          round: true
-          iconSource: Theme.getThemeVectorIcon('ic_nfc_code_black_24dp')
-          iconColor: Theme.toolButtonColor
-          bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
+          QfToolButton {
+            id: imageButton
+            round: true
+            iconSource: Theme.getThemeVectorIcon('ic_gallery_black_24dp')
+            iconColor: Theme.toolButtonColor
+            bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
 
-          visible: withNfc
-          state: settings.nearfieldActive ? "On" : "Off"
-          states: [
-            State {
-              name: "Off"
-              PropertyChanges {
-                target: nearfieldButton
-                bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
-              }
-            },
-            State {
-              name: "On"
-              PropertyChanges {
-                target: nearfieldButton
-                iconColor: Theme.mainColor
-                bgcolor: Theme.toolButtonBackgroundColor
-              }
+            onClicked: {
+              codeReader.pickImage();
             }
-          ]
+          }
 
-          onClicked: {
-            settings.nearfieldActive = !settings.nearfieldActive;
+          QfToolButton {
+            id: nearfieldButton
+            round: true
+            iconSource: Theme.getThemeVectorIcon('ic_nfc_code_black_24dp')
+            iconColor: Theme.toolButtonColor
+            bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
+
+            visible: withNfc
+            state: settings.nearfieldActive ? "On" : "Off"
+            states: [
+              State {
+                name: "Off"
+                PropertyChanges {
+                  target: nearfieldButton
+                  bgcolor: Theme.toolButtonBackgroundSemiOpaqueColor
+                }
+              },
+              State {
+                name: "On"
+                PropertyChanges {
+                  target: nearfieldButton
+                  iconColor: Theme.mainColor
+                  bgcolor: Theme.toolButtonBackgroundColor
+                }
+              }
+            ]
+
+            onClicked: {
+              settings.nearfieldActive = !settings.nearfieldActive;
+            }
           }
         }
       }


### PR DESCRIPTION
Currently the code reader only works if you can point a camera at a code. So if sends you a QR on WhatsApp, or a plugin has one on its GitHub page, and you're on your phone with nothing to point the camera at.
This adds a gallery button next to the existing camera and NFC toggles. Pick an image, it gets decoded the same way a camera frame would. If there's no code in it, a toast says so for better ux 

The bottom button row is now centred as a group rather than hung off the flashlight button, so it stays balanced when the camera or NFC toggles aren't shown

Because the code reader is a single shared component, this should work everywhere i.e barcode attribute widgets, project import URL, and anything else that opens the reader.


Thanks to @mbernasocchi and @nirvn for this idea..

## Demo

https://github.com/user-attachments/assets/8d8bc312-702f-4b1b-8cb4-a464cea24757