### PR TITLE
Update qfield.entitlements to fix release deployment

### DIFF
--- a/platform/ios/qfield.entitlements
+++ b/platform/ios/qfield.entitlements
@@ -4,7 +4,6 @@
 <dict>
     <key>com.apple.developer.nfc.readersession.formats</key>
     <array>
-        <string>NDEF</string>
         <string>TAG</string>
     </array>
 </dict>


### PR DESCRIPTION
We should look into a way to validate IPA against TestFlight before we actually hit release and discover something is wrong :/

The error we got: 

[altool.6000006CC480] Validation failed (409) Invalid entitlement for core nfc framework. The sdk version '26.2' and min OS version '16.0' are not compatible for the entitlement 'com.apple.developer.nfc.readersession.formats' because 'NDEF is disallowed'. (ID: 88a39e05-0eab-42fa-8dd9-8c2babf0e52e)