### PR TITLE
Fix date/time editor widget's handling of a time value stored in a string attribute

### DIFF
--- a/src/qml/editorwidgets/DateTime.qml
+++ b/src/qml/editorwidgets/DateTime.qml
@@ -68,7 +68,7 @@ EditorWidgetBase {
           try {
             return Qt.formatDateTime(value, displayFormat);
           } catch (e) {
-            return qsTr('(no date)');
+            return value;
           }
         }
         return Qt.formatDateTime(date, displayFormat);
@@ -207,18 +207,22 @@ EditorWidgetBase {
     showTimePicker: {
       if (main.fieldIsDateTime || main.fieldIsTime) {
         return true;
-      } else if (main.fieldIsString && !!config['field_format_overwrite'] && (config['field_format'].includes("HH:mm") || !!config['field_iso_format'])) {
-        return true;
       }
-      return false;
+      if (main.fieldIsString && !!config['field_format_overwrite']) {
+        return config['field_format'].includes("HH") || !!config['field_iso_format'];
+      }
+      return config['display_format'].includes("HH");
     }
     showDatePicker: {
-      if (main.fieldIsTime) {
-        return false;
-      } else if (main.fieldIsString && !!config['field_format_overwrite'] && !config['field_format'].includes("yyyy-MM") && !config['field_format'].includes("yyyy.MM") && !config['field_iso_format']) {
+      if (main.fieldIsDateTime || main.fieldIsDate) {
+        return true;
+      } else if (main.fieldIsTime) {
         return false;
       }
-      return true;
+      if (main.fieldIsString && !!config['field_format_overwrite']) {
+        return config['field_format'].includes("yy") || config['field_format'].includes("yy") || !!config['field_iso_format'];
+      }
+      return config['display_format'].includes("yy");
     }
 
     onDateTimePicked: date => {

--- a/test/qml/tst_editorwidgets.qml
+++ b/test/qml/tst_editorwidgets.qml
@@ -340,6 +340,17 @@ TestCase {
     const invalidDatetimeValue = new Date("-");
     const date = dateTime.convertValueToDate(invalidDatetimeValue);
     verify(!isNaN(date.getTime()));
+
+    dateTime.isEnabled = true;
+    dateTime.fieldIsDate = false;
+    dateTime.fieldIsDateTime = false;
+    dateTime.fieldIsTime = false;
+    dateTime.config = {
+      "display_format": "HH:mm",
+      "calendar_popup": true
+    };
+    dateTime.value = "13:50";
+    compare(label.text, "13:50");
   }
 
   /**

--- a/test/qml/tst_editorwidgets.qml
+++ b/test/qml/tst_editorwidgets.qml
@@ -318,13 +318,37 @@ TestCase {
   function test_01_dateTime() {
     const label = dateTime.children[0].children[0];
     compare(label.text, "2022-01-01");
-    const testTimes = ["2023-01-01", "2023-01-01 23:33:56"];
+
     const displayFormats = ["yyyy-MM-dd", "yyyy-MM.dd", "yyyy-MM-dd HH:mm:ss", "HH:mm:ss", "HH:mm"];
     const results = ["2023-01-01", "2023-01.01", "2023-01-01 00:00:00", "00:00:00", "00:00", "2023-01-01", "2023-01.01", "2023-01-01 23:33:56", "23:33:56", "23:33"];
+
+    let testTimes = ["2023-01-01", "2023-01-01 23:33:56"];
     let resultIdx = 0;
     for (let time of testTimes) {
       for (let format of displayFormats) {
+        dateTime.isDateTimeType = false;
         dateTime.fieldIsDate = false;
+        dateTime.fieldIsDateTime = false;
+        dateTime.fieldIsTime = false;
+        dateTime.config = {
+          "display_format": format,
+          "calendar_popup": true,
+          "field_format": "yyyy-MM-dd",
+          "allow_null": false
+        };
+        dateTime.value = time;
+        compare(label.text, results[resultIdx++]);
+      }
+    }
+
+    testTimes = [new Date("2023-01-01 00:00:00"), new Date("2023-01-01 23:33:56")];
+    resultIdx = 0;
+    for (let time of testTimes) {
+      for (let format of displayFormats) {
+        dateTime.isDateTimeType = true;
+        dateTime.fieldIsDateTime = true;
+        dateTime.fieldIsDateTime = false;
+        dateTime.fieldIsTime = false;
         dateTime.config = {
           "display_format": format,
           "calendar_popup": true,
@@ -342,6 +366,7 @@ TestCase {
     verify(!isNaN(date.getTime()));
 
     dateTime.isEnabled = true;
+    dateTime.isDateTimeType = false;
     dateTime.fieldIsDate = false;
     dateTime.fieldIsDateTime = false;
     dateTime.fieldIsTime = false;


### PR DESCRIPTION
The PR fixes https://github.com/opengisch/QField/issues/7628 and adds test coverage.