### PR TITLE
Fix dead back button when adding a feature

### DIFF
--- a/src/qml/OverlayFeatureFormDrawer.qml
+++ b/src/qml/OverlayFeatureFormDrawer.qml
@@ -76,6 +76,7 @@ Drawer {
    */
   onOpened: {
     isAdding = true;
+    overlayFeatureForm.forceActiveFocus();
   }
 
   onClosed: {
@@ -204,8 +205,7 @@ Drawer {
         if (overlayFeatureForm.model.constraintsHardValid || qfieldSettings.autoSave) {
           overlayFeatureFormDrawer.close();
         } else {
-          //block closing to fix constraints or cancel with button
-          displayToast(qsTr("Hard constraints not satisfied"), 'error');
+          overlayFeatureForm.requestCancel();
         }
         event.accepted = true;
       }


### PR DESCRIPTION
### 🚀 Description
Pressing the back button (or Escape) while adding a feature did nothing. Users with unsaved geometry had no way to leave the form other than filling in required fields or force-closing. This PR fixes this issue.

### Demo 

https://github.com/user-attachments/assets/dd59d41c-fa6f-41d3-8fc1-ac03a1f1c04a

Closes #7511 