### PR TITLE
Close the feature form on back when opened from a single identify

### DIFF
--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -50,9 +50,7 @@ QfPaneDrawer {
 
   property bool multiSelection: false
 
-  function isFormOpenedFromSingleIdentify() {
-    return qfieldSettings.autoOpenFormSingleIdentify && !multiSelection && model.count === 1;
-  }
+  readonly property bool formOpenedFromSingleIdentify: qfieldSettings.autoOpenFormSingleIdentify && !multiSelection && globalFeaturesList.count === 1
 
   isFullscreen: qfieldSettings.fullScreenIdentifyView
 
@@ -506,7 +504,7 @@ QfPaneDrawer {
 
     onBackClicked: {
       featureFormList.focus = true;
-      if (featureFormList.state !== "FeatureList" && !featureFormList.isFormOpenedFromSingleIdentify()) {
+      if (featureFormList.state !== "FeatureList" && !featureFormList.formOpenedFromSingleIdentify) {
         featureFormList.state = "FeatureList";
       } else {
         featureFormList.state = "Hidden";
@@ -716,7 +714,7 @@ QfPaneDrawer {
       if (state != "FeatureList") {
         if (featureListToolBar.state === "Edit") {
           featureForm.requestCancel();
-        } else if (isFormOpenedFromSingleIdentify()) {
+        } else if (formOpenedFromSingleIdentify) {
           state = "Hidden";
         } else {
           state = "FeatureList";

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -49,6 +49,11 @@ QfPaneDrawer {
   property bool allowDelete
 
   property bool multiSelection: false
+
+  function isFormOpenedFromSingleIdentify() {
+    return qfieldSettings.autoOpenFormSingleIdentify && !multiSelection && model.count === 1;
+  }
+
   isFullscreen: qfieldSettings.fullScreenIdentifyView
 
   property bool canvasOperationRequested: digitizingToolbar.geometryRequested || moveFeaturesToolbar.moveFeaturesRequested || rotateFeaturesToolbar.rotateFeaturesRequested
@@ -501,7 +506,7 @@ QfPaneDrawer {
 
     onBackClicked: {
       featureFormList.focus = true;
-      if (featureFormList.state !== "FeatureList") {
+      if (featureFormList.state !== "FeatureList" && !featureFormList.isFormOpenedFromSingleIdentify()) {
         featureFormList.state = "FeatureList";
       } else {
         featureFormList.state = "Hidden";
@@ -711,6 +716,8 @@ QfPaneDrawer {
       if (state != "FeatureList") {
         if (featureListToolBar.state === "Edit") {
           featureForm.requestCancel();
+        } else if (isFormOpenedFromSingleIdentify()) {
+          state = "Hidden";
         } else {
           state = "FeatureList";
         }


### PR DESCRIPTION
### 🚀 Description

With `open feature form for single feature identification` enabled, identifying a single feature opens its form directly, bypassing the feature list. But pressing back from that form went to the feature list… instead of closing and returning to the map.


### Issue


https://github.com/user-attachments/assets/2320e1e2-181a-4307-a36b-3826df107bb6


### Fixed - pressing back

https://github.com/user-attachments/assets/814210fd-d940-4d77-865b-829c0ff0c243

