### PR TITLE
[Backport release-4_2] Use cloud project name when loading the cloud project in two more places

### DIFF
--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -819,7 +819,7 @@ Popup {
       if (error !== '') {
         displayToast(error, 'error');
       }
-      iface.loadFile(cloudProjectCreationConnection.target.localPath);
+      iface.loadFile(cloudProjectCreationConnection.target.localPath, cloudProjectCreationConnection.target.name);
       cloudProjectCreationConnection.target = null;
       popup.close();
     }

--- a/src/qml/QFieldCloudProjectDetails.qml
+++ b/src/qml/QFieldCloudProjectDetails.qml
@@ -377,7 +377,7 @@ ColumnLayout {
     onClicked: {
       if (cloudProject != undefined) {
         qfieldCloudScreen.visible = false;
-        iface.loadFile(cloudProject.localPath);
+        iface.loadFile(cloudProject.localPath, cloudProject.name);
       }
       projectsSwipeView.currentIndex = 0;
       cloudProject = undefined;


### PR DESCRIPTION
Backport #7733
 **Authored by:** @nirvn