### PR TITLE
Increase result font size, harmonize bold usage, implement conditional features list bold styling 

### DIFF
--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -59,6 +59,7 @@ class MultiFeatureListModel : public QSortFilterProxyModel
       EditGeometryRole,
       ConditionalTextColorRole,
       ConditionalBackgroundColorRole,
+      ConditionalFontBoldRole,
       ConditionalFontItalicRole,
       ConditionalFontUnderlineRole,
       ConditionalFontStrikeOutRole,

--- a/src/core/multifeaturelistmodelbase.cpp
+++ b/src/core/multifeaturelistmodelbase.cpp
@@ -287,6 +287,7 @@ QHash<int, QByteArray> MultiFeatureListModelBase::roleNames() const
   roleNames[MultiFeatureListModel::ConditionalFontUnderlineRole] = "conditionalFontUnderline";
   roleNames[MultiFeatureListModel::ConditionalFontStrikeOutRole] = "conditionalFontStrikeOut";
   roleNames[MultiFeatureListModel::ConditionalFontItalicRole] = "conditionalFontItalic";
+  roleNames[MultiFeatureListModel::ConditionalFontBoldRole] = "conditionalFontBold";
 
   return roleNames;
 }
@@ -412,6 +413,19 @@ QVariant MultiFeatureListModelBase::data( const QModelIndex &index, int role ) c
       }
 
       return QVariant();
+      break;
+
+    case MultiFeatureListModel::ConditionalFontBoldRole:
+      if ( vlayer )
+      {
+        const QString featureUniqueKey = QStringLiteral( "%1:%2" ).arg( vlayer->id(), QString::number( feature->second.id() ) );
+        if ( mFeaturesConditionalStyle.contains( featureUniqueKey ) )
+        {
+          return mFeaturesConditionalStyle[featureUniqueKey].font().bold();
+        }
+      }
+
+      return false;
       break;
 
     case MultiFeatureListModel::ConditionalFontItalicRole:
@@ -1068,6 +1082,7 @@ void MultiFeatureListModelBase::attributeValueChanged( QgsFeatureId fid, int idx
       {
         rolesChanged << MultiFeatureListModel::ConditionalBackgroundColorRole
                      << MultiFeatureListModel::ConditionalTextColorRole
+                     << MultiFeatureListModel::ConditionalFontBoldRole
                      << MultiFeatureListModel::ConditionalFontItalicRole
                      << MultiFeatureListModel::ConditionalFontUnderlineRole
                      << MultiFeatureListModel::ConditionalFontStrikeOutRole;
@@ -1117,6 +1132,7 @@ void MultiFeatureListModelBase::geometryChanged( QgsFeatureId fid, const QgsGeom
       {
         rolesChanged << MultiFeatureListModel::ConditionalBackgroundColorRole
                      << MultiFeatureListModel::ConditionalTextColorRole
+                     << MultiFeatureListModel::ConditionalFontBoldRole
                      << MultiFeatureListModel::ConditionalFontItalicRole
                      << MultiFeatureListModel::ConditionalFontUnderlineRole
                      << MultiFeatureListModel::ConditionalFontStrikeOutRole;

--- a/src/core/theme.h
+++ b/src/core/theme.h
@@ -109,6 +109,7 @@ class QFIELD_CORE_EXPORT Theme final : public QObject
     Q_PROPERTY( QFont resultFont READ resultFont NOTIFY fontScaleChanged )
     Q_PROPERTY( QFont strongFont READ strongFont NOTIFY fontScaleChanged )
     Q_PROPERTY( QFont strongTipFont READ strongTipFont NOTIFY fontScaleChanged )
+    Q_PROPERTY( QFont strongResultFont READ strongResultFont NOTIFY fontScaleChanged )
     Q_PROPERTY( QFont secondaryTitleFont READ secondaryTitleFont NOTIFY fontScaleChanged )
     Q_PROPERTY( QFont titleFont READ titleFont NOTIFY fontScaleChanged )
     Q_PROPERTY( QFont strongTitleFont READ strongTitleFont NOTIFY fontScaleChanged )
@@ -300,6 +301,7 @@ class QFIELD_CORE_EXPORT Theme final : public QObject
     QFont resultFont() const { return makeFont( 0.9, false ); }
     QFont strongFont() const { return makeFont( 1.0, true ); }
     QFont strongTipFont() const { return makeFont( 0.875, true ); }
+    QFont strongResultFont() const { return makeFont( 0.9, true ); }
     QFont secondaryTitleFont() const { return makeFont( 1.125, false ); }
     QFont titleFont() const { return makeFont( 1.25, false ); }
     QFont strongTitleFont() const { return makeFont( 1.25, true ); }

--- a/src/core/theme.h
+++ b/src/core/theme.h
@@ -297,7 +297,7 @@ class QFIELD_CORE_EXPORT Theme final : public QObject
     QFont defaultFont() const { return makeFont( 1.0, false ); }
     QFont tinyFont() const { return makeFont( 0.75, false ); }
     QFont tipFont() const { return makeFont( 0.875, false ); }
-    QFont resultFont() const { return makeFont( 0.8125, false ); }
+    QFont resultFont() const { return makeFont( 0.9, false ); }
     QFont strongFont() const { return makeFont( 1.0, true ); }
     QFont strongTipFont() const { return makeFont( 0.875, true ); }
     QFont secondaryTitleFont() const { return makeFont( 1.125, false ); }

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -450,8 +450,7 @@ QfPaneDrawer {
           right: parent.right
           verticalCenter: parent.verticalCenter
         }
-        font.bold: true
-        font.pointSize: Theme.resultFont.pointSize
+        font: Theme.resultFont
         color: Theme.mainTextColor
         text: BookmarkName !== '' ? BookmarkName : qsTr("Untitled bookmark")
         wrapMode: Text.WordWrap

--- a/src/qml/BookmarkList.qml
+++ b/src/qml/BookmarkList.qml
@@ -387,8 +387,7 @@ QfPaneDrawer {
             horizontalCenter: parent.horizontalCenter
             verticalCenter: parent.verticalCenter
           }
-          font.bold: true
-          font.pointSize: Theme.resultFont.pointSize
+          font: Theme.strongResultFont
           color: Theme.mainTextColor
           text: {
             switch (section) {

--- a/src/qml/DashBoard.qml
+++ b/src/qml/DashBoard.qml
@@ -501,7 +501,7 @@ Drawer {
           icon.source: legend.model.isCollapsed ? Theme.getThemeVectorIcon('ic_expand_all_24dp') : Theme.getThemeVectorIcon('ic_collapse_all_24dp')
           icon.width: 14
           icon.height: 14
-          font.pointSize: 8
+          font.pointSize: Theme.tinyFont.pointSize - 2
 
           onClicked: {
             legend.model.setAllCollapsed(!legend.model.isCollapsed);

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -255,7 +255,7 @@ QfPaneDrawer {
             verticalCenter: parent.verticalCenter
           }
           font.bold: true
-          font.pointSize: Theme.resultFont.pointSize
+          font.pointSize: Theme.resultFont
           color: Theme.mainTextColor
           text: section
         }
@@ -300,7 +300,6 @@ QfPaneDrawer {
           right: parent.right
           verticalCenter: parent.verticalCenter
         }
-        font.bold: true
         font.pointSize: Theme.resultFont.pointSize
         font.italic: conditionalFontItalic
         font.underline: conditionalFontUnderline

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -254,8 +254,7 @@ QfPaneDrawer {
             horizontalCenter: parent.horizontalCenter
             verticalCenter: parent.verticalCenter
           }
-          font.bold: true
-          font.pointSize: Theme.resultFont
+          font: Theme.strongResultFont
           color: Theme.mainTextColor
           text: section
         }

--- a/src/qml/FeatureListForm.qml
+++ b/src/qml/FeatureListForm.qml
@@ -300,6 +300,7 @@ QfPaneDrawer {
           verticalCenter: parent.verticalCenter
         }
         font.pointSize: Theme.resultFont.pointSize
+        font.bold: conditionalFontBold
         font.italic: conditionalFontItalic
         font.underline: conditionalFontUnderline
         font.strikeout: conditionalFontStrikeOut

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -484,7 +484,7 @@ Item {
             font.pointSize: Theme.resultFont.pointSize
             color: isFilterName ? Theme.mainOverlayColor : Theme.mainTextColor
             elide: Text.ElideRight
-            horizontalAlignment: isGroup ? Text.AlignHCenter : Text.AlignLeft
+            horizontalAlignment: isFilterName || isGroup ? Text.AlignHCenter : Text.AlignLeft
           }
 
           Text {

--- a/src/qml/LocatorItem.qml
+++ b/src/qml/LocatorItem.qml
@@ -395,8 +395,7 @@ Item {
             anchors.leftMargin: 5
             anchors.rightMargin: 5
             text: Name + ' (' + Prefix + ')' + (Prefix === 'f' && dashBoard.activeLayer ? ' — ' + dashBoard.activeLayer.name : '')
-            font.bold: false
-            font.pointSize: Theme.resultFont.pointSize
+            font: Theme.resultFont
             color: Theme.mainTextColor
             elide: Text.ElideRight
             horizontalAlignment: Text.AlignLeft
@@ -409,8 +408,7 @@ Item {
             anchors.leftMargin: 5
             anchors.rightMargin: 5
             text: Description || ''
-            font.bold: false
-            font.pointSize: Theme.resultFont.pointSize
+            font: Theme.resultFont
             color: Theme.secondaryTextColor
             wrapMode: Text.WordWrap
             horizontalAlignment: Text.AlignLeft
@@ -482,7 +480,7 @@ Item {
             anchors.leftMargin: 5
             anchors.rightMargin: 5
             text: isFilterName ? ResultFilterName : typeof (model.Text) == 'string' ? model.Text.trim() : ''
-            font.bold: false
+            font.bold: isFilterName || isGroup
             font.pointSize: Theme.resultFont.pointSize
             color: isFilterName ? Theme.mainOverlayColor : Theme.mainTextColor
             elide: Text.ElideRight
@@ -497,8 +495,7 @@ Item {
             anchors.leftMargin: 5
             anchors.rightMargin: 5
             text: locatorBridge.getLocatorModelDescription(index)
-            font.bold: false
-            font.pointSize: Theme.resultFont.pointSize
+            font: Theme.resultFont
             color: Theme.secondaryTextColor
             wrapMode: Text.WordWrap
             horizontalAlignment: Text.AlignLeft

--- a/src/qml/ProcessingAlgorithmsList.qml
+++ b/src/qml/ProcessingAlgorithmsList.qml
@@ -134,8 +134,7 @@ Item {
             verticalCenter: parent.verticalCenter
           }
           width: parent.width - favoriteButton.width - 10
-          font.bold: true
-          font.pointSize: Theme.resultFont.pointSize
+          font: Theme.resultFont
           color: Theme.mainTextColor
           text: AlgorithmName
         }

--- a/src/qml/ProcessingAlgorithmsList.qml
+++ b/src/qml/ProcessingAlgorithmsList.qml
@@ -98,8 +98,7 @@ Item {
               horizontalCenter: parent.horizontalCenter
               verticalCenter: parent.verticalCenter
             }
-            font.bold: true
-            font.pointSize: Theme.resultFont.pointSize
+            font: Theme.strongResultFont
             color: Theme.mainTextColor
             text: section
           }

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -310,8 +310,7 @@ Page {
                     horizontalCenter: parent.horizontalCenter
                     verticalCenter: parent.verticalCenter
                   }
-                  font.bold: true
-                  font.pointSize: Theme.resultFont.pointSize
+                  font: Theme.strongResultFont
                   color: Theme.mainTextColor
                   text: section
                 }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -134,8 +134,7 @@ Page {
                 horizontalCenter: parent.horizontalCenter
                 verticalCenter: parent.verticalCenter
               }
-              font.bold: true
-              font.pointSize: Theme.resultFont.pointSize
+              font: Theme.strongResultFont
               color: Theme.mainTextColor
               text: {
                 switch (parseInt(section)) {

--- a/src/qml/RelationCombobox.qml
+++ b/src/qml/RelationCombobox.qml
@@ -128,8 +128,7 @@ Item {
                 horizontalCenter: parent.horizontalCenter
                 verticalCenter: parent.verticalCenter
               }
-              font.bold: true
-              font.pointSize: Theme.resultFont.pointSize
+              font: Theme.strongResultFont
               color: Theme.mainTextColor
               text: section
               visible: featureListModel.displayGroupName
@@ -366,8 +365,7 @@ Item {
                   horizontalCenter: parent.horizontalCenter
                   verticalCenter: parent.verticalCenter
                 }
-                font.bold: true
-                font.pointSize: Theme.resultFont.pointSize
+                font: Theme.strongResultFont
                 color: Theme.mainTextColor
                 text: section
                 visible: featureListModel.displayGroupName

--- a/src/qml/VariableEditor.qml
+++ b/src/qml/VariableEditor.qml
@@ -56,8 +56,7 @@ ColumnLayout {
               horizontalCenter: parent.horizontalCenter
               verticalCenter: parent.verticalCenter
             }
-            font.bold: true
-            font.pointSize: Theme.resultFont.pointSize
+            font: Theme.strongResultFont
             color: Theme.mainTextColor
             text: section == "GlobalScope" ? qsTr("Global variables") : qsTr("Project variables")
           }

--- a/src/qml/editorwidgets/ValueRelation.qml
+++ b/src/qml/editorwidgets/ValueRelation.qml
@@ -263,8 +263,7 @@ EditorWidgetBase {
                   id: groupFieldValueText
                   width: parent.width
                   text: groupFieldValue ? groupFieldValue : ""
-                  font.bold: true
-                  font.pointSize: Theme.resultFont.pointSize
+                  font: Theme.strongResultFont
                   color: Theme.mainTextColor
                   horizontalAlignment: Text.AlignHCenter
                   anchors.verticalCenter: parent.verticalCenter

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -838,7 +838,7 @@ RelationEditorBase {
             width: listRow.width - listThumbnail.width - listFormButton.width - listMenuButton.width - listRow.spacing * 2
             text: model.displayString
             color: Theme.mainTextColor
-            font: Theme.defaultFont
+            font: Theme.resultFont
             elide: Text.ElideRight
             wrapMode: Text.WordWrap
             maximumLineCount: 2
@@ -1212,7 +1212,7 @@ RelationEditorBase {
               id: cardSuffixText
               anchors.centerIn: parent
               text: FileUtils.fileSuffix(attachmentFullPath).toUpperCase()
-              font.pointSize: Theme.tinyFont.pointSize
+              font.pointSize: Theme.tinyFont
               font.weight: Font.Bold
               color: Theme.mainTextColor
               opacity: 0.6
@@ -1289,8 +1289,7 @@ RelationEditorBase {
 
             text: model.displayString
             color: Theme.mainTextColor
-            font.pointSize: Theme.tipFont.pointSize
-            font.weight: Font.Medium
+            font: Theme.tipFont
             elide: Text.ElideRight
           }
 

--- a/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/ordered_relation_editor.qml
@@ -146,7 +146,7 @@ RelationEditorBase {
             topPadding: 5
             bottomPadding: 5
             leftPadding: featureImage.visible ? 5 : 0
-            font: Theme.defaultFont
+            font: Theme.resultFont
             color: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
             elide: Text.ElideRight
             wrapMode: Text.WordWrap

--- a/src/qml/editorwidgets/relationeditors/relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/relation_editor.qml
@@ -93,7 +93,7 @@ RelationEditorBase {
           width: parent.width - viewButton.width - menuButton.width
           topPadding: 5
           bottomPadding: 5
-          font: Theme.defaultFont
+          font: Theme.resultFont
           color: (!isEditable && isEditing) ? Theme.mainTextDisabledColor : Theme.mainTextColor
           elide: Text.ElideRight
           wrapMode: Text.WordWrap


### PR DESCRIPTION
This PR cleans up the use of the resultFont style by:
- slightly increasing the font size (larger, easier to read, an important UX with results list :) )
- insuring that all lists use the result font (i.e. relation editor widgets)
- insuring that all lists' result items have non-bold font weight (significant win for the features list)
- insuring that all lists' section header use the brand new strongResultFont

This is how the features list look now (i.e. your eyes are not drowning in bold fonts ;) ):

<img width="1001" height="509" alt="Screenshot From 2026-07-12 13-57-04" src="https://github.com/user-attachments/assets/3cb300fc-a128-448d-9e59-54324a6d7c6a" />

In turn, this allows us to implement _conditional bold styling_ of features list items, something that couldn't be done when we added conditional styling in QField 4.2 since the items were always bold.

Conditional bold styling in action:

<img width="1001" height="509" alt="Screenshot From 2026-07-12 14-11-20" src="https://github.com/user-attachments/assets/26254bbf-558b-45cb-9207-c4d97ed1472d" />
