### PR TITLE
Fix ordering of relation editor's children list not respecting project configuration

### DIFF
--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -635,3 +635,8 @@ void ReferencingFeatureListModel::setSortOrder( Qt::SortOrder sortOrder )
 
   sort( 0, mSortOrder );
 }
+
+bool ReferencingFeatureListModel::lessThan( const QModelIndex &left, const QModelIndex &right ) const
+{
+  return Qt::AscendingOrder ? left.row() > right.row() : left.row() < right.row();
+}

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -427,6 +427,9 @@ class ReferencingFeatureListModel : public QSortFilterProxyModel
      */
     void setSortOrder( Qt::SortOrder sortOrder );
 
+  protected:
+    bool lessThan( const QModelIndex &left, const QModelIndex &right ) const override;
+
   signals:
     void attributeFormModelChanged();
     void featureChanged();
@@ -470,7 +473,17 @@ class FeatureGatherer : public QThread
           }
         }
       }
+
       mRequest = relation.getRelatedFeaturesRequest( feature );
+      QgsAttributeTableConfig config = relation.referencingLayer()->attributeTableConfig();
+      if ( !config.sortExpression().isEmpty() )
+      {
+        mRequest.addOrderBy( config.sortExpression(), config.sortOrder() == Qt::AscendingOrder );
+      }
+      else if ( !relation.referencingLayer()->displayExpression().isEmpty() )
+      {
+        mRequest.addOrderBy( relation.referencingLayer()->displayExpression() );
+      }
 
       mContext = relation.referencingLayer()->createExpressionContext();
       mDisplayExpression = relation.referencingLayer()->displayExpression();


### PR DESCRIPTION
Small number of lines added, big impact :wink: 

This PR insures that the children list attached to QField's relation editor widgets (normal, ordered, gallery) matches the order defined in the QGIS project file. This ensures that the children list in our feature form matches that of the QGIS feature form.

Until now, the list was ordered by display name. One nice thing this fix unlocks is the ability to sort by e.g. a datetime attribute while using a display name that wouldn't perfectly sort (e.g. 9AM, 2PM would sort properly :) )