### PR TITLE
Fix stylus hover leaking through floating UI onto the map crosshair

### DIFF
--- a/src/qml/MapCanvasPointHandler.qml
+++ b/src/qml/MapCanvasPointHandler.qml
@@ -14,6 +14,9 @@ Item {
   }
 
   function pointInItem(point, item) {
+    if (!item || !item.visible) {
+      return false;
+    }
     const itemCoordinates = item.mapToItem(mainWindow.contentItem, 0, 0);
     return point.x >= itemCoordinates.x && point.x <= itemCoordinates.x + item.width && point.y >= itemCoordinates.y && point.y <= itemCoordinates.y + item.height;
   }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -612,8 +612,8 @@ ApplicationWindow {
       property bool hasBeenHovered: false
       property bool skipHover: false
 
-      function pointOverFloatingComponent(pt) {
-        return pointHandler.pointInItem(pt, digitizingToolbar) || pointHandler.pointInItem(pt, digitizingToolbarContainer) || pointHandler.pointInItem(pt, geometryEditorsToolbar) || pointHandler.pointInItem(pt, zoomToolbar) || pointHandler.pointInItem(pt, mainToolbar) || pointHandler.pointInItem(pt, mainMenuBar) || pointHandler.pointInItem(pt, locationToolbar) || pointHandler.pointInItem(pt, locatorItem) || pointHandler.pointInItem(pt, elevationProfileButton) || (informationDrawer.cogoOperationSettings.visible && pointHandler.pointInItem(pt, informationDrawer.cogoOperationSettings)) || (featureListForm.visible && pointHandler.pointInItem(pt, featureListForm)) || overlayFeatureFormDrawer.opened;
+      function isPointOverFloatingComponents(pt) {
+        return pointHandler.pointInItem(pt, digitizingToolbarContainer) || pointHandler.pointInItem(pt, zoomToolbar) || pointHandler.pointInItem(pt, mainToolbar) || pointHandler.pointInItem(pt, mainMenuBar) || pointHandler.pointInItem(pt, locationToolbar) || pointHandler.pointInItem(pt, locatorItem) || (informationDrawer.cogoOperationSettings.visible && pointHandler.pointInItem(pt, informationDrawer.cogoOperationSettings)) || (featureListForm.visible && pointHandler.pointInItem(pt, featureListForm)) || overlayFeatureFormDrawer.opened;
       }
 
       onPointChanged: {
@@ -633,7 +633,7 @@ ApplicationWindow {
 
         // Over any other floating component, do not move the crosshair at all
         // freeze it wherever it last was on the map.
-        if (pointOverFloatingComponent(point.position)) {
+        if (isPointOverFloatingComponents(point.position)) {
           return;
         }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -606,26 +606,39 @@ ApplicationWindow {
       id: hoverHandler
       enabled: !digitizingToolbar.rubberbandModel || !digitizingToolbar.rubberbandModel.frozen
       acceptedDevices: !qfieldSettings.mouseAsTouchScreen ? PointerDevice.TouchPad | PointerDevice.Stylus | PointerDevice.Mouse : PointerDevice.Stylus
+
       grabPermissions: PointerHandler.TakeOverForbidden
 
       property bool hasBeenHovered: false
       property bool skipHover: false
+
+      function pointOverFloatingComponent(pt) {
+        return pointHandler.pointInItem(pt, digitizingToolbar) || pointHandler.pointInItem(pt, digitizingToolbarContainer) || pointHandler.pointInItem(pt, geometryEditorsToolbar) || pointHandler.pointInItem(pt, zoomToolbar) || pointHandler.pointInItem(pt, mainToolbar) || pointHandler.pointInItem(pt, mainMenuBar) || pointHandler.pointInItem(pt, locationToolbar) || pointHandler.pointInItem(pt, locatorItem) || pointHandler.pointInItem(pt, elevationProfileButton) || (informationDrawer.cogoOperationSettings.visible && pointHandler.pointInItem(pt, informationDrawer.cogoOperationSettings)) || (featureListForm.visible && pointHandler.pointInItem(pt, featureListForm)) || overlayFeatureFormDrawer.opened;
+      }
 
       onPointChanged: {
         if (skipHover || !mapCanvasMap.hovered) {
           return;
         }
 
-        // when hovering various toolbars, reset coordinate locator position for nicer UX
+        // Park the crosshair at the last digitized vertex when hovering the digitizing / geometry-editor toolbars
         if (!freehandHandler.active && (pointHandler.pointInItem(point.position, digitizingToolbar) || pointHandler.pointInItem(point.position, elevationProfileButton))) {
           coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen(digitizingToolbar.rubberbandModel.lastCoordinate);
-        } else if (!freehandHandler.active && pointHandler.pointInItem(point.position, geometryEditorsToolbar)) {
+          return;
+        }
+        if (!freehandHandler.active && pointHandler.pointInItem(point.position, geometryEditorsToolbar)) {
           coordinateLocator.sourceLocation = mapCanvas.mapSettings.coordinateToScreen(geometryEditorsToolbar.editorRubberbandModel.lastCoordinate);
-        } else if (!freehandHandler.active) {
-          // after a click, it seems that the position is sent once at 0,0 => weird)
-          if (point.position !== Qt.point(0, 0)) {
-            coordinateLocator.sourceLocation = point.position;
-          }
+          return;
+        }
+
+        // Over any other floating component, do not move the crosshair at all
+        // freeze it wherever it last was on the map.
+        if (pointOverFloatingComponent(point.position)) {
+          return;
+        }
+
+        if (!freehandHandler.active && point.position !== Qt.point(0, 0)) {
+          coordinateLocator.sourceLocation = point.position;
         }
       }
 

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -613,7 +613,7 @@ ApplicationWindow {
       property bool skipHover: false
 
       function isPointOverFloatingComponents(pt) {
-        return pointHandler.pointInItem(pt, digitizingToolbarContainer) || pointHandler.pointInItem(pt, zoomToolbar) || pointHandler.pointInItem(pt, mainToolbar) || pointHandler.pointInItem(pt, mainMenuBar) || pointHandler.pointInItem(pt, locationToolbar) || pointHandler.pointInItem(pt, locatorItem) || (informationDrawer.cogoOperationSettings.visible && pointHandler.pointInItem(pt, informationDrawer.cogoOperationSettings)) || (featureListForm.visible && pointHandler.pointInItem(pt, featureListForm)) || overlayFeatureFormDrawer.opened;
+        return pointHandler.pointInItem(pt, digitizingToolbarContainer) || pointHandler.pointInItem(pt, zoomToolbar) || pointHandler.pointInItem(pt, mainToolbar) || pointHandler.pointInItem(pt, mainMenuBar) || pointHandler.pointInItem(pt, locationToolbar) || pointHandler.pointInItem(pt, locatorItem) || pointHandler.pointInItem(pt, informationDrawer.cogoOperationSettings) || pointHandler.pointInItem(pt, featureListForm) || overlayFeatureFormDrawer.opened;
       }
 
       onPointChanged: {


### PR DESCRIPTION
The pr fixes issue ##7637,
The problem that the crosshair followed hover, and hover reached every handler under the pointer regardless of stacking order, so the map kept dragging the crosshair even when the stylus was over a toolbar or drawer on top of it.

I first tried consuming the event on the panel side (a TapHandler sink, then TakeOverForbidden), but the maps hover handler still fired, turns out hover can't be consumed the way a press can. So instead the map's hover handler now checks whether the point is over a floating component and, if so, freezes the crosshair at its last map position instead of moving it unintentionally while trying to perform action on on-top floating components present.