### PR TITLE
Revert obsolete QVariantList properties added while dissecting (now gone) top crasher

### DIFF
--- a/src/core/featuremodel.cpp
+++ b/src/core/featuremodel.cpp
@@ -126,36 +126,6 @@ void FeatureModel::setFeatures( const QList<QgsFeature> &features )
   endResetModel();
 }
 
-QVariantList FeatureModel::featuresVariant() const
-{
-  QVariantList featuresVariant;
-
-  featuresVariant.reserve( mFeatures.size() );
-  for ( const QgsFeature &feature : mFeatures )
-  {
-    // Pack the custom QgsFeature object into a QVariant safely
-    featuresVariant.append( QVariant::fromValue( feature ) );
-  }
-
-  return featuresVariant;
-}
-
-void FeatureModel::setFeaturesVariant( const QVariantList &features )
-{
-  QList<QgsFeature> featuresList;
-  featuresList.reserve( features.size() );
-
-  for ( const QVariant &variant : features )
-  {
-    if ( variant.canConvert<QgsFeature>() )
-    {
-      featuresList.append( variant.value<QgsFeature>() );
-    }
-  }
-
-  setFeatures( featuresList );
-}
-
 void FeatureModel::setCurrentLayer( QgsVectorLayer *layer )
 {
   if ( layer == mLayer )

--- a/src/core/featuremodel.h
+++ b/src/core/featuremodel.h
@@ -35,7 +35,7 @@ class FeatureModel : public QAbstractListModel
     Q_OBJECT
     Q_PROPERTY( FeatureModel::ModelModes modelMode READ modelMode WRITE setModelMode NOTIFY modelModeChanged )
     Q_PROPERTY( QgsFeature feature READ feature WRITE setFeature NOTIFY featureChanged )
-    Q_PROPERTY( QVariantList features READ featuresVariant WRITE setFeaturesVariant NOTIFY featuresChanged )
+    Q_PROPERTY( QList<QgsFeature> features READ features WRITE setFeatures NOTIFY featuresChanged )
     Q_PROPERTY( QgsFeature linkedParentFeature READ linkedParentFeature WRITE setLinkedParentFeature NOTIFY linkedParentFeatureChanged )
     Q_PROPERTY( QgsRelation linkedRelation READ linkedRelation WRITE setLinkedRelation NOTIFY linkedRelationChanged )
     Q_PROPERTY( QString linkedRelationOrderingField READ linkedRelationOrderingField WRITE setLinkedRelationOrderingField NOTIFY linkedRelationOrderingFieldChanged )
@@ -84,16 +84,9 @@ class FeatureModel : public QAbstractListModel
 
     void setFeature( const QgsFeature &feature );
 
-    /**
-     * Return the feature wrapped in a QVariant for passing it around in QML
-     */
     QgsFeature feature() const;
 
     void setFeatures( const QList<QgsFeature> &features );
-
-    QVariantList featuresVariant() const;
-
-    void setFeaturesVariant( const QVariantList &features );
 
     /**
      * Return the features list for passing it around in QML

--- a/src/core/gridmodel.cpp
+++ b/src/core/gridmodel.cpp
@@ -449,11 +449,11 @@ void GridModel::update()
       {
         if ( currentLine.intersects( topBorder, &intersectionPoint ) )
         {
-          mAnnotations << QVariant::fromValue( GridAnnotation( GridAnnotation::Top, intersectionPoint, xPos ) );
+          mAnnotations << GridAnnotation( GridAnnotation::Top, intersectionPoint, xPos );
         }
         if ( currentLine.intersects( bottomBorder, &intersectionPoint ) )
         {
-          mAnnotations << QVariant::fromValue( GridAnnotation( GridAnnotation::Bottom, intersectionPoint, xPos ) );
+          mAnnotations << GridAnnotation( GridAnnotation::Bottom, intersectionPoint, xPos );
         }
       }
 
@@ -478,11 +478,11 @@ void GridModel::update()
       {
         if ( currentLine.intersects( leftBorder, &intersectionPoint ) )
         {
-          mAnnotations << QVariant::fromValue( GridAnnotation( GridAnnotation::Left, intersectionPoint, yPos ) );
+          mAnnotations << GridAnnotation( GridAnnotation::Left, intersectionPoint, yPos );
         }
         if ( currentLine.intersects( rightBorder, &intersectionPoint ) )
         {
-          mAnnotations << QVariant::fromValue( GridAnnotation( GridAnnotation::Right, intersectionPoint, yPos ) );
+          mAnnotations << GridAnnotation( GridAnnotation::Right, intersectionPoint, yPos );
         }
       }
 

--- a/src/core/gridmodel.h
+++ b/src/core/gridmodel.h
@@ -77,7 +77,7 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     Q_PROPERTY( QString majorLinesPath READ majorLinesPath NOTIFY majorLinesChanged )
     Q_PROPERTY( QString minorLinesPath READ minorLinesPath NOTIFY minorLinesChanged )
     Q_PROPERTY( QString markersPath READ markersPath NOTIFY markersChanged )
-    Q_PROPERTY( QVariantList annotations READ annotations NOTIFY annotationsChanged )
+    Q_PROPERTY( QList<GridAnnotation> annotations READ annotations NOTIFY annotationsChanged )
 
     Q_PROPERTY( bool autoColor READ autoColor WRITE setAutoColor NOTIFY autoColorChanged )
     Q_PROPERTY( QColor majorLineColor READ majorLineColor WRITE setMajorLineColor NOTIFY majorLineColorChanged )
@@ -169,7 +169,7 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     void setPrepareAnnotations( bool prepare );
 
     //! Returns the grid annotations
-    QVariantList annotations() const { return mAnnotations; }
+    QList<GridAnnotation> annotations() const { return mAnnotations; }
 
     /**
      * Returns whether grid line and marker colors will be automatically assigned to
@@ -320,7 +320,7 @@ class QFIELD_CORE_EXPORT GridModel : public QObject
     QString mMarkersPath;
 
     bool mPrepareAnnotations = false;
-    QVariantList mAnnotations;
+    QList<GridAnnotation> mAnnotations;
 
     bool mAutoColor = false;
     QColor mMajorLineColor = QColor( 0, 0, 0, 100 );

--- a/src/core/linepolygonshape.cpp
+++ b/src/core/linepolygonshape.cpp
@@ -56,6 +56,8 @@ void LinePolygonShape::createPolylines()
   if ( mGeometry && !geometry.isEmpty() && geometry.type() != Qgis::GeometryType::Point )
   {
     geometry = geometry.simplify( mMapSettings->mapUnitsPerPoint() );
+    geometry = geometry.makeValid();
+
     geomType = geometry.type();
     switch ( geomType )
     {

--- a/src/core/linepolygonshape.h
+++ b/src/core/linepolygonshape.h
@@ -38,7 +38,7 @@ class LinePolygonShape : public QQuickItem
     Q_PROPERTY( QgsGeometryWrapper *geometry READ geometry WRITE setGeometry NOTIFY qgsGeometryChanged )
 
     //! List of polylines representing the geometry
-    Q_PROPERTY( QVariantList polylines READ polylines NOTIFY polylinesChanged )
+    Q_PROPERTY( QList<QPolygonF> polylines READ polylines NOTIFY polylinesChanged )
     //! The geometry type associated to the polylines
     Q_PROPERTY( Qgis::GeometryType polylinesType READ polylinesType NOTIFY polylinesTypeChanged )
 
@@ -58,7 +58,7 @@ class LinePolygonShape : public QQuickItem
     void setLineWidth( float width );
 
     //! \copydoc polylines
-    QVariantList polylines() const { return mPolylines; }
+    QList<QPolygonF> polylines() const { return mPolylines; }
 
     //! \copydoc polylinesType
     Qgis::GeometryType polylinesType() const { return mPolylinesType; }
@@ -91,7 +91,7 @@ class LinePolygonShape : public QQuickItem
     QgsGeometryWrapper *mGeometry = nullptr;
     QgsPoint mGeometryCorner;
     double mGeometryMUPP = 0.0;
-    QVariantList mPolylines;
+    QList<QPolygonF> mPolylines;
     Qgis::GeometryType mPolylinesType = Qgis::GeometryType::Null;
 };
 

--- a/src/core/multifeaturelistmodel.cpp
+++ b/src/core/multifeaturelistmodel.cpp
@@ -219,21 +219,6 @@ QList<QgsFeature> MultiFeatureListModel::selectedFeatures()
   return mSourceModel->selectedFeatures();
 }
 
-QVariantList MultiFeatureListModel::selectedFeaturesVariant()
-{
-  QVariantList featuresVariant;
-  const QList<QgsFeature> features = mSourceModel->selectedFeatures();
-
-  featuresVariant.reserve( features.size() );
-  for ( const QgsFeature &feature : features )
-  {
-    // Pack the custom QgsFeature object into a QVariant safely
-    featuresVariant.append( QVariant::fromValue( feature ) );
-  }
-
-  return featuresVariant;
-}
-
 QgsVectorLayer *MultiFeatureListModel::selectedLayer()
 {
   return mFilterLayer.data();

--- a/src/core/multifeaturelistmodel.h
+++ b/src/core/multifeaturelistmodel.h
@@ -33,7 +33,7 @@ class MultiFeatureListModel : public QSortFilterProxyModel
     Q_OBJECT
 
     Q_PROPERTY( int count READ count NOTIFY countChanged )
-    Q_PROPERTY( QVariantList selectedFeatures READ selectedFeaturesVariant NOTIFY selectedCountChanged )
+    Q_PROPERTY( QList<QgsFeature> selectedFeatures READ selectedFeatures NOTIFY selectedCountChanged )
     Q_PROPERTY( QgsVectorLayer *selectedLayer READ selectedLayer NOTIFY selectedLayerChanged )
     Q_PROPERTY( int selectedCount READ selectedCount NOTIFY selectedCountChanged )
     Q_PROPERTY( bool canEditAttributesSelection READ canEditAttributesSelection NOTIFY selectedCountChanged )
@@ -175,11 +175,6 @@ class MultiFeatureListModel : public QSortFilterProxyModel
      * Returns the list of currently selected features.
      */
     QList<QgsFeature> selectedFeatures();
-
-    /**
-     * Returns the list of currently selected features as a QVariantList object.
-     */
-    QVariantList selectedFeaturesVariant();
 
     /**
      * Returns the vector layer within which one or more features are currently selected

--- a/src/core/processing/processingalgorithm.cpp
+++ b/src/core/processing/processingalgorithm.cpp
@@ -91,36 +91,6 @@ void ProcessingAlgorithm::setInPlaceFeatures( const QList<QgsFeature> &features 
   }
 }
 
-QVariantList ProcessingAlgorithm::inPlaceFeaturesVariant() const
-{
-  QVariantList featuresVariant;
-
-  featuresVariant.reserve( mInPlaceFeatures.size() );
-  for ( const QgsFeature &feature : mInPlaceFeatures )
-  {
-    // Pack the custom QgsFeature object into a QVariant safely
-    featuresVariant.append( QVariant::fromValue( feature ) );
-  }
-
-  return featuresVariant;
-}
-
-void ProcessingAlgorithm::setInPlaceFeaturesVariant( const QVariantList &features )
-{
-  QList<QgsFeature> featuresList;
-  featuresList.reserve( features.size() );
-
-  for ( const QVariant &variant : features )
-  {
-    if ( variant.canConvert<QgsFeature>() )
-    {
-      featuresList.append( variant.value<QgsFeature>() );
-    }
-  }
-
-  setInPlaceFeatures( featuresList );
-}
-
 void ProcessingAlgorithm::setParameters( const QVariantMap &parameters )
 {
   if ( mAlgorithmParameters == parameters )
@@ -235,7 +205,7 @@ bool ProcessingAlgorithm::run( bool previewMode )
         {
           for ( const QgsFeature &outputFeature : outputFeatures )
           {
-            mPreviewGeometries << QVariant::fromValue( outputFeature.geometry() );
+            mPreviewGeometries << outputFeature.geometry();
           }
 
           emit previewGeometriesChanged();
@@ -326,7 +296,7 @@ bool ProcessingAlgorithm::run( bool previewMode )
           {
             for ( const QgsFeature &previewFeature : outputFeatures )
             {
-              mPreviewGeometries << QVariant::fromValue( previewFeature.geometry() );
+              mPreviewGeometries << previewFeature.geometry();
             }
 
             emit previewGeometriesChanged();

--- a/src/core/processing/processingalgorithm.h
+++ b/src/core/processing/processingalgorithm.h
@@ -45,10 +45,10 @@ class ProcessingAlgorithm : public QObject
 
     Q_PROPERTY( QVariantMap parameters READ parameters WRITE setParameters NOTIFY parametersChanged )
     Q_PROPERTY( QgsVectorLayer *inPlaceLayer READ inPlaceLayer WRITE setInPlaceLayer NOTIFY inPlaceLayerChanged )
-    Q_PROPERTY( QVariantList inPlaceFeatures READ inPlaceFeaturesVariant WRITE setInPlaceFeaturesVariant NOTIFY inPlaceFeaturesChanged )
+    Q_PROPERTY( QList<QgsFeature> inPlaceFeatures READ inPlaceFeatures WRITE setInPlaceFeatures NOTIFY inPlaceFeaturesChanged )
 
     Q_PROPERTY( bool preview READ preview WRITE setPreview NOTIFY previewChanged )
-    Q_PROPERTY( QVariantList previewGeometries READ previewGeometries NOTIFY previewGeometriesChanged )
+    Q_PROPERTY( QList<QgsGeometry> previewGeometries READ previewGeometries NOTIFY previewGeometriesChanged )
 
   public:
     explicit ProcessingAlgorithm( QObject *parent = nullptr );
@@ -99,16 +99,6 @@ class ProcessingAlgorithm : public QObject
     void setInPlaceFeatures( const QList<QgsFeature> &features );
 
     /**
-     * Returns the vector \a layer for in-place algorithm filter as a QVariantList.
-     */
-    QVariantList inPlaceFeaturesVariant() const;
-
-    /**
-     * Sets the vector \a layer for in-place algorithm filter from a QVariantList.
-     */
-    void setInPlaceFeaturesVariant( const QVariantList &features );
-
-    /**
      * Returns the algorithm parameters as a map of parameter names as keys and values.
      */
     QVariantMap parameters() const { return mAlgorithmParameters; }
@@ -133,7 +123,7 @@ class ProcessingAlgorithm : public QObject
     /**
      * Returns a list of geometries previewing the algorithm result using current parameters.
      */
-    QVariantList previewGeometries() const { return mPreviewGeometries; }
+    QList<QgsGeometry> previewGeometries() const { return mPreviewGeometries; }
 
     /**
      * Executes the algorithm.
@@ -180,7 +170,7 @@ class ProcessingAlgorithm : public QObject
     QList<QgsFeature> mInPlaceFeatures;
 
     bool mPreview = false;
-    QVariantList mPreviewGeometries;
+    QList<QgsGeometry> mPreviewGeometries;
 };
 
 #endif // PROCESSINGALGORITHM

--- a/src/core/qfieldcloud/qfieldcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfieldcloudconnection.cpp
@@ -305,18 +305,9 @@ bool QFieldCloudConnection::isFetchingAvailableProviders() const
   return mIsFetchingAvailableProviders;
 }
 
-QVariantList QFieldCloudConnection::availableProviders() const
+QList<AuthenticationProvider> QFieldCloudConnection::availableProviders() const
 {
-  const QList<AuthenticationProvider> providers = mAvailableProviders.values();
-  QVariantList providersVariant;
-  providersVariant.reserve( providers.size() );
-
-  for ( const AuthenticationProvider &provider : providers )
-  {
-    providersVariant.append( QVariant::fromValue( provider ) );
-  }
-
-  return providersVariant;
+  return mAvailableProviders.values();
 }
 
 void QFieldCloudConnection::getServerInformation()

--- a/src/core/qfieldcloud/qfieldcloudconnection.h
+++ b/src/core/qfieldcloud/qfieldcloudconnection.h
@@ -83,7 +83,7 @@ class QFieldCloudConnection : public QObject
 
     Q_PROPERTY( CloudUserInformation userInformation READ userInformation NOTIFY userInformationChanged )
 
-    Q_PROPERTY( QVariantList availableProviders READ availableProviders NOTIFY availableProvidersChanged )
+    Q_PROPERTY( QList<AuthenticationProvider> availableProviders READ availableProviders NOTIFY availableProvidersChanged )
     Q_PROPERTY( bool isFetchingAvailableProviders READ isFetchingAvailableProviders NOTIFY isFetchingAvailableProvidersChanged )
 
     Q_PROPERTY( CloudServerInformation serverInformation READ serverInformation NOTIFY serverInformationChanged )
@@ -175,7 +175,7 @@ class QFieldCloudConnection : public QObject
     Q_INVOKABLE void getSubscriptionInformation( const QString &user );
 
     Q_INVOKABLE void getServerInformation();
-    QVariantList availableProviders() const;
+    QList<AuthenticationProvider> availableProviders() const;
     bool isFetchingAvailableProviders() const;
 
     CloudServerInformation serverInformation() const { return mServerInformation; }

--- a/src/core/rubberbandmodel.cpp
+++ b/src/core/rubberbandmodel.cpp
@@ -366,6 +366,7 @@ void RubberbandModel::smoothSegment( qsizetype firstVertex, qsizetype lastVertex
   }
 
   geom = geom.smooth();
+  geom = geom.makeValid();
 
   const QgsLineString *smoothed = qgsgeometry_cast<const QgsLineString *>( geom.constGet() );
   if ( !smoothed || smoothed->numPoints() < 2 )

--- a/src/core/rubberbandshape.h
+++ b/src/core/rubberbandshape.h
@@ -53,7 +53,7 @@ class RubberbandShape : public QQuickItem
     Q_PROPERTY( qreal lineWidth READ lineWidth WRITE setLineWidth NOTIFY lineWidthChanged )
 
     //! List of polylines representing the rubber band
-    Q_PROPERTY( QVariantList polylines READ polylines NOTIFY polylinesChanged )
+    Q_PROPERTY( QList<QPolygonF> polylines READ polylines NOTIFY polylinesChanged )
     //! The geometry type associated to the polylines
     Q_PROPERTY( Qgis::GeometryType polylinesType READ polylinesType NOTIFY polylinesTypeChanged )
 
@@ -95,7 +95,7 @@ class RubberbandShape : public QQuickItem
     void setGeometryType( const Qgis::GeometryType geometryType );
 
     //! \copydoc polylines
-    QVariantList polylines() const { return mPolylines; }
+    QList<QPolygonF> polylines() const { return mPolylines; }
 
     //! \copydoc polylinesType
     Qgis::GeometryType polylinesType() const { return mPolylinesType; }
@@ -139,7 +139,7 @@ class RubberbandShape : public QQuickItem
     Qgis::GeometryType mGeometryType = Qgis::GeometryType::Null;
     QgsPoint mGeometryCorner;
     double mGeometryMUPP = 0.0;
-    QVariantList mPolylines;
+    QList<QPolygonF> mPolylines;
     Qgis::GeometryType mPolylinesType = Qgis::GeometryType::Null;
 };
 

--- a/src/core/trackingmodel.cpp
+++ b/src/core/trackingmodel.cpp
@@ -102,22 +102,6 @@ bool TrackingModel::featureInTracking( QgsVectorLayer *layer, const QgsFeatureId
   return false;
 }
 
-bool TrackingModel::featuresInTracking( QgsVectorLayer *layer, const QVariantList &features )
-{
-  QList<QgsFeature> featuresList;
-
-  featuresList.reserve( features.size() );
-  for ( const QVariant &variant : features )
-  {
-    if ( variant.canConvert<QgsFeature>() )
-    {
-      featuresList.append( variant.value<QgsFeature>() );
-    }
-  }
-
-  return featuresInTracking( layer, featuresList );
-}
-
 bool TrackingModel::featuresInTracking( QgsVectorLayer *layer, const QList<QgsFeature> &features )
 {
   auto it = trackerIterator( layer );

--- a/src/core/trackingmodel.h
+++ b/src/core/trackingmodel.h
@@ -64,9 +64,7 @@ class TrackingModel : public QAbstractItemModel
     //! Returns TRUE if the \a featureId is attached to a vector \a layer tracking session.
     Q_INVOKABLE bool featureInTracking( QgsVectorLayer *layer, QgsFeatureId featureId );
     //! Returns TRUE if the list of \a features is attached to a vector \a layer tracking session.
-    Q_INVOKABLE bool featuresInTracking( QgsVectorLayer *layer, const QVariantList &features );
-    //! Returns TRUE if the list of \a features is attached to a vector \a layer tracking session.
-    bool featuresInTracking( QgsVectorLayer *layer, const QList<QgsFeature> &features );
+    Q_INVOKABLE bool featuresInTracking( QgsVectorLayer *layer, const QList<QgsFeature> &features );
     //! Returns TRUE if the vector \a layer has a tracking session.
     Q_INVOKABLE bool layerInTracking( QgsVectorLayer *layer ) const;
     //! Returns TRUE if the vector \a layer has an active tracking session.


### PR DESCRIPTION
This PR reverts the obsolete change applied while dissecting QField's (now gone) top crasher. 