### PR TITLE
[Backport release-4_2] Fix ordering of relation editor's children list not respecting project configuration

### DIFF
--- a/src/core/referencingfeaturelistmodel.cpp
+++ b/src/core/referencingfeaturelistmodel.cpp
@@ -635,3 +635,8 @@ void ReferencingFeatureListModel::setSortOrder( Qt::SortOrder sortOrder )
 
   sort( 0, mSortOrder );
 }
+
+bool ReferencingFeatureListModel::lessThan( const QModelIndex &left, const QModelIndex &right ) const
+{
+  return Qt::AscendingOrder ? left.row() > right.row() : left.row() < right.row();
+}

--- a/src/core/referencingfeaturelistmodel.h
+++ b/src/core/referencingfeaturelistmodel.h
@@ -427,6 +427,9 @@ class ReferencingFeatureListModel : public QSortFilterProxyModel
      */
     void setSortOrder( Qt::SortOrder sortOrder );
 
+  protected:
+    bool lessThan( const QModelIndex &left, const QModelIndex &right ) const override;
+
   signals:
     void attributeFormModelChanged();
     void featureChanged();
@@ -470,7 +473,17 @@ class FeatureGatherer : public QThread
           }
         }
       }
+
       mRequest = relation.getRelatedFeaturesRequest( feature );
+      QgsAttributeTableConfig config = relation.referencingLayer()->attributeTableConfig();
+      if ( !config.sortExpression().isEmpty() )
+      {
+        mRequest.addOrderBy( config.sortExpression(), config.sortOrder() == Qt::AscendingOrder );
+      }
+      else if ( !relation.referencingLayer()->displayExpression().isEmpty() )
+      {
+        mRequest.addOrderBy( relation.referencingLayer()->displayExpression() );
+      }
 
       mContext = relation.referencingLayer()->createExpressionContext();
       mDisplayExpression = relation.referencingLayer()->displayExpression();


### PR DESCRIPTION
Backport #7746
 **Authored by:** @nirvn