### PR TITLE
Reload value relation list when a dependency layer changes

### DIFF
--- a/src/core/featurelistmodel.cpp
+++ b/src/core/featurelistmodel.cpp
@@ -133,6 +133,7 @@ void FeatureListModel::setCurrentLayer( QgsVectorLayer *currentLayer )
     disconnect( mCurrentLayer, &QgsVectorLayer::featureAdded, this, &FeatureListModel::onFeatureAdded );
     disconnect( mCurrentLayer, &QgsVectorLayer::attributeValueChanged, this, &FeatureListModel::onAttributeValueChanged );
     disconnect( mCurrentLayer, &QgsVectorLayer::featureDeleted, this, &FeatureListModel::onFeatureDeleted );
+    disconnect( mCurrentLayer, &QgsVectorLayer::dataChanged, this, &FeatureListModel::reloadLayer );
   }
 
   mCurrentLayer = currentLayer;
@@ -142,6 +143,7 @@ void FeatureListModel::setCurrentLayer( QgsVectorLayer *currentLayer )
     connect( mCurrentLayer, &QgsVectorLayer::featureAdded, this, &FeatureListModel::onFeatureAdded );
     connect( mCurrentLayer, &QgsVectorLayer::attributeValueChanged, this, &FeatureListModel::onAttributeValueChanged );
     connect( mCurrentLayer, &QgsVectorLayer::featureDeleted, this, &FeatureListModel::onFeatureDeleted );
+    connect( mCurrentLayer, &QgsVectorLayer::dataChanged, this, &FeatureListModel::reloadLayer );
   }
 
   reloadLayer();


### PR DESCRIPTION
FeatureListModel only connected to its own layer's edit signals, so a value relation whose filter expression references another layer, didn't reload when that layer changed.
Listening to dataChanged() on the current layer, which QgsVectorLayer emits when a declared dependency is modified.

Fixes #7491