### PR TITLE
Add vertex on double tap when finger tap digitizing is enabled

### DIFF
--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -204,7 +204,7 @@ Page {
     }
     ListElement {
       title: qsTr("Allow finger tap on canvas to add vertices")
-      description: qsTr("When enabled, tapping on the map canvas with a finger moves the coordinate cursor, and double tapping adds a vertex.")
+      description: qsTr("When enabled, tapping on the map canvas with a finger moves the coordinate cursor while double tapping adds a vertex.")
       settingAlias: "fingerTapDigitizing"
       isVisible: true
     }

--- a/src/qml/QFieldSettings.qml
+++ b/src/qml/QFieldSettings.qml
@@ -204,7 +204,7 @@ Page {
     }
     ListElement {
       title: qsTr("Allow finger tap on canvas to add vertices")
-      description: qsTr("When enabled, tapping on the map canvas with a finger will add a vertex at the tapped location.")
+      description: qsTr("When enabled, tapping on the map canvas with a finger moves the coordinate cursor, and double tapping adds a vertex.")
       settingAlias: "fingerTapDigitizing"
       isVisible: true
     }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -995,6 +995,18 @@ ApplicationWindow {
           return;
         }
         if (type === "touch") {
+          const positionLocked = positionSource.active && coordinateLocator.positionLocked;
+          if (qfieldSettings.fingerTapDigitizing && !digitizingToolbar.cogoEnabled && ((stateMachine.state === "digitize" && digitizingFeature.currentLayer && digitizingToolbar.digitizingAllowed) || stateMachine.state === "measure")) {
+            if (!positionLocked && (!featureListForm.visible || digitizingToolbar.geometryRequested)) {
+              coordinateLocator.sourceLocation = point;
+              if (Number(currentRubberband.model.geometryType) === Qgis.GeometryType.Point || Number(currentRubberband.model.geometryType) === Qgis.GeometryType.Null) {
+                digitizingToolbar.confirm();
+              } else {
+                digitizingToolbar.addVertex();
+              }
+              return;
+            }
+          }
           mapCanvasWrapper.zoomByFactor(Qt.point(point.x, point.y), 0.8);
         }
       }

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -995,8 +995,8 @@ ApplicationWindow {
           return;
         }
         if (type === "touch") {
-          const positionLocked = positionSource.active && coordinateLocator.positionLocked;
           if (qfieldSettings.fingerTapDigitizing && !digitizingToolbar.cogoEnabled && ((stateMachine.state === "digitize" && digitizingFeature.currentLayer && digitizingToolbar.digitizingAllowed) || stateMachine.state === "measure")) {
+            const positionLocked = positionSource.active && coordinateLocator.positionLocked;
             if (!positionLocked && (!featureListForm.visible || digitizingToolbar.geometryRequested)) {
               coordinateLocator.sourceLocation = point;
               if (Number(currentRubberband.model.geometryType) === Qgis.GeometryType.Point || Number(currentRubberband.model.geometryType) === Qgis.GeometryType.Null) {


### PR DESCRIPTION
With "Allow finger tap on canvas to add vertices" enabled, double tapping the canvas while digitizing adds a vertex, or confirms the feature for point layers, instead of zooming. Double tap continues to zoom when the option is off, in COGO mode, or when the coordinate cursor is locked to a position.

fixes #7719