### PR TITLE
Redesign the QFieldCloud project popup with action cards and a dedicated danger zone

### DIFF
--- a/src/qml/ProjectCreationScreen.qml
+++ b/src/qml/ProjectCreationScreen.qml
@@ -508,7 +508,7 @@ Page {
             Label {
               Layout.fillWidth: true
               Layout.alignment: Qt.AlignVCenter
-              text: qsTr("Automatically push changes on a regular interval")
+              text: qsTr("Automatically upload changes on a regular interval")
               font: Theme.defaultFont
               color: Theme.mainTextColor
               wrapMode: Text.WordWrap

--- a/src/qml/QFieldCloudDangerZone.qml
+++ b/src/qml/QFieldCloudDangerZone.qml
@@ -13,6 +13,8 @@ Item {
   signal discardRequested
   signal resetRequested
 
+  readonly property bool hasDeltaError: !!(cloudProjectsModel.layerObserver.deltaFileWrapper && cloudProjectsModel.layerObserver.deltaFileWrapper.hasError)
+
   ScrollView {
     anchors.fill: parent
 
@@ -27,45 +29,33 @@ Item {
       width: parent.width
       spacing: 10
 
-      QfCollapsibleMessage {
+      QfContainerCard {
         Layout.fillWidth: true
         Layout.margins: 10
-        color: Theme.darkRed
-        font: Theme.tipFont
-        iconSource: Theme.getThemeVectorIcon('ic_error_outline_24dp')
-        titleText: qsTr('The action below is irreversible and permanently affects your local data. Proceed with caution.')
-      }
+        Layout.maximumWidth: 525
+        Layout.alignment: Qt.AlignHCenter
+        accentColor: Theme.darkRed
+        iconSource: Theme.getThemeVectorIcon('ic_delete_forever_white_24dp')
+        title: dangerZone.hasDeltaError ? qsTr('Reset project') : qsTr('Discard local changes')
+        description: dangerZone.hasDeltaError ? qsTr('The local copy of this cloud project has been corrupted. Resetting the project will re-download the cloud version and will remove any local changes, make sure those were copied first if needed.\n\nWhile you can still view and use the project, it is strongly recommended to reset to avoid any accidental data loss as none of the changes made will be pushed back to the cloud.') : qsTr('Removes all your local edits that have not yet been uploaded.')
 
-      QfButton {
-        id: discardButton
-        Layout.fillWidth: true
-        Layout.leftMargin: 10
-        Layout.rightMargin: 10
-        bgcolor: Theme.darkRed
-        text: cloudProjectsModel.layerObserver.deltaFileWrapper && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError ? qsTr('Discard local changes') : qsTr('Reset project')
-        enabled: cloudProjectsModel.layerObserver.deltaFileWrapper && (cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0 || cloudProjectsModel.layerObserver.deltaFileWrapper.hasError)
-        icon.source: Theme.getThemeVectorIcon('ic_undo_black_24dp')
+        QfButton {
+          Layout.fillWidth: true
+          Layout.topMargin: 4
 
-        onClicked: {
-          if (!cloudProjectsModel.layerObserver.deltaFileWrapper.hasError) {
-            dangerZone.discardRequested();
-          } else {
-            dangerZone.resetRequested();
+          bgcolor: Theme.darkRed
+          color: Theme.light
+          text: dangerZone.hasDeltaError ? qsTr('Reset') : qsTr('Discard')
+          enabled: cloudProjectsModel.layerObserver.deltaFileWrapper && (cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0 || dangerZone.hasDeltaError)
+
+          onClicked: {
+            if (!dangerZone.hasDeltaError) {
+              dangerZone.discardRequested();
+            } else {
+              dangerZone.resetRequested();
+            }
           }
         }
-      }
-
-      Text {
-        id: discardText
-        Layout.fillWidth: true
-        Layout.leftMargin: 10
-        Layout.rightMargin: 10
-        Layout.bottomMargin: 10
-        font: Theme.tipFont
-        color: Theme.secondaryTextColor
-        wrapMode: Text.WordWrap
-        horizontalAlignment: Text.AlignHCenter
-        text: cloudProjectsModel.layerObserver.deltaFileWrapper && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError ? qsTr('Revert all modified features in the local layers. You cannot restore those changes.') : qsTr('The local copy of this cloud project has been corrupted. Resetting the project will re-download the cloud version and will remove any local changes, make sure those were copied first if needed.\n\nWhile you can still view and use the project, it is strongly recommended to reset to avoid any accidental data loss as none of the changes made will be pushed back to the cloud.')
       }
     }
   }

--- a/src/qml/QFieldCloudDangerZone.qml
+++ b/src/qml/QFieldCloudDangerZone.qml
@@ -1,0 +1,72 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.qfield
+import Theme
+
+/**
+ * \ingroup qml
+ */
+Item {
+  id: dangerZone
+
+  signal discardRequested
+  signal resetRequested
+
+  ScrollView {
+    anchors.fill: parent
+
+    ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+    ScrollBar.vertical: QfScrollBar {}
+    contentWidth: width
+    contentHeight: dangerZoneColumn.height
+    clip: true
+
+    ColumnLayout {
+      id: dangerZoneColumn
+      width: parent.width
+      spacing: 10
+
+      QfCollapsibleMessage {
+        Layout.fillWidth: true
+        Layout.margins: 10
+        color: Theme.darkRed
+        font: Theme.tipFont
+        iconSource: Theme.getThemeVectorIcon('ic_error_outline_24dp')
+        titleText: qsTr('The action below is irreversible and permanently affects your local data. Proceed with caution.')
+      }
+
+      QfButton {
+        id: discardButton
+        Layout.fillWidth: true
+        Layout.leftMargin: 10
+        Layout.rightMargin: 10
+        bgcolor: Theme.darkRed
+        text: cloudProjectsModel.layerObserver.deltaFileWrapper && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError ? qsTr('Discard local changes') : qsTr('Reset project')
+        enabled: cloudProjectsModel.layerObserver.deltaFileWrapper && (cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0 || cloudProjectsModel.layerObserver.deltaFileWrapper.hasError)
+        icon.source: Theme.getThemeVectorIcon('ic_undo_black_24dp')
+
+        onClicked: {
+          if (!cloudProjectsModel.layerObserver.deltaFileWrapper.hasError) {
+            dangerZone.discardRequested();
+          } else {
+            dangerZone.resetRequested();
+          }
+        }
+      }
+
+      Text {
+        id: discardText
+        Layout.fillWidth: true
+        Layout.leftMargin: 10
+        Layout.rightMargin: 10
+        Layout.bottomMargin: 10
+        font: Theme.tipFont
+        color: Theme.secondaryTextColor
+        wrapMode: Text.WordWrap
+        horizontalAlignment: Text.AlignHCenter
+        text: cloudProjectsModel.layerObserver.deltaFileWrapper && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError ? qsTr('Revert all modified features in the local layers. You cannot restore those changes.') : qsTr('The local copy of this cloud project has been corrupted. Resetting the project will re-download the cloud version and will remove any local changes, make sure those were copied first if needed.\n\nWhile you can still view and use the project, it is strongly recommended to reset to avoid any accidental data loss as none of the changes made will be pushed back to the cloud.')
+      }
+    }
+  }
+}

--- a/src/qml/QFieldCloudDangerZone.qml
+++ b/src/qml/QFieldCloudDangerZone.qml
@@ -29,6 +29,14 @@ Item {
       width: parent.width
       spacing: 10
 
+      QfCollapsibleMessage {
+        Layout.fillWidth: true
+        Layout.margins: 10
+        color: Theme.darkRed
+        font: Theme.tipFont
+        iconSource: Theme.getThemeVectorIcon('ic_error_outline_24dp')
+        titleText: qsTr('The action below is irreversible and permanently affects your local data. Proceed with caution.')
+      }
       QfContainerCard {
         Layout.fillWidth: true
         Layout.margins: 10

--- a/src/qml/QFieldCloudDeltaHistory.qml
+++ b/src/qml/QFieldCloudDeltaHistory.qml
@@ -10,6 +10,7 @@ import Theme
  */
 QfPopup {
   id: popup
+  focus: true
 
   property alias model: deltaList.model
 
@@ -83,6 +84,14 @@ QfPopup {
 
   Page {
     id: page
+
+    Keys.onReleased: event => {
+      if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+        event.accepted = true;
+        popup.close();
+      }
+    }
+
     width: parent.width
     height: {
       const chromeHeight = toolBar.childrenRect.height + 20;

--- a/src/qml/QFieldCloudDeltaHistory.qml
+++ b/src/qml/QFieldCloudDeltaHistory.qml
@@ -13,8 +13,61 @@ QfPopup {
 
   property alias model: deltaList.model
 
+  function deltaStatusColor(status) {
+    switch (status) {
+    case DeltaListModel.AppliedStatus:
+      return Theme.mainColor;
+    case DeltaListModel.PendingStatus:
+    case DeltaListModel.BusyStatus:
+      return Theme.cloudColor;
+    case DeltaListModel.ConflictStatus:
+    case DeltaListModel.NotAppliedStatus:
+      return Theme.warningColor;
+    case DeltaListModel.ErrorStatus:
+    case DeltaListModel.UnpermittedStatus:
+      return Theme.errorColor;
+    default:
+      return Theme.secondaryTextColor;
+    }
+  }
+
+  function deltaStatusLabel(status) {
+    switch (status) {
+    case DeltaListModel.AppliedStatus:
+      return qsTr('Applied');
+    case DeltaListModel.PendingStatus:
+      return qsTr('Pending');
+    case DeltaListModel.BusyStatus:
+      return qsTr('Busy');
+    case DeltaListModel.ConflictStatus:
+      return qsTr('Conflict');
+    case DeltaListModel.NotAppliedStatus:
+      return qsTr('Not applied');
+    case DeltaListModel.ErrorStatus:
+      return qsTr('Error');
+    case DeltaListModel.IgnoredStatus:
+      return qsTr('Ignored');
+    case DeltaListModel.UnpermittedStatus:
+      return qsTr('Unpermitted');
+    default:
+      return qsTr('Unknown');
+    }
+  }
+
+  function deltaStatusIcon(status) {
+    switch (status) {
+    case DeltaListModel.AppliedStatus:
+      return Theme.getThemeVectorIcon('ic_check_white_24dp');
+    case DeltaListModel.PendingStatus:
+    case DeltaListModel.BusyStatus:
+      return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
+    default:
+      return Theme.getThemeVectorIcon('ic_error_outline_24dp');
+    }
+  }
+
   width: Math.min(400, mainWindow.width - Theme.popupScreenEdgeHorizontalMargin * 2)
-  height: page.height
+  height: page.height + padding * 2
   x: (mainWindow.width - width) / 2
   y: (mainWindow.height - height) / 2
 
@@ -31,8 +84,19 @@ QfPopup {
   Page {
     id: page
     width: parent.width
-    height: Math.min(deltaList.contentHeight + toolBar.childrenRect.height + 20, mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4))
+    height: {
+      const chromeHeight = toolBar.childrenRect.height + 20;
+      const maximumHeight = mainWindow.height - Math.max(Theme.popupScreenEdgeVerticalMargin * 2, mainWindow.sceneTopMargin * 2 + 4, mainWindow.sceneBottomMargin * 2 + 4);
+      let contentHeight = deltaList.contentHeight;
+      if (!popup.model) {
+        contentHeight = loadingIndicator.implicitHeight;
+      } else if (deltaList.count === 0) {
+        contentHeight = emptyLabel.implicitHeight;
+      }
+      return Math.min(contentHeight + chromeHeight, maximumHeight);
+    }
     padding: 5
+    background: null
     header: ToolBar {
       id: toolBar
       height: Theme.toolButtonSize
@@ -51,9 +115,9 @@ QfPopup {
         leftPadding: Theme.toolButtonSize
         rightPadding: Theme.toolButtonSize
         width: parent.width - 20
-        text: !!model ? qsTr("Push History") : qsTr("Loading…")
+        text: qsTr("Upload History")
         font: Theme.strongFont
-        color: Theme.mainColor
+        color: Theme.mainTextColor
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
       }
@@ -78,14 +142,42 @@ QfPopup {
       anchors.fill: parent
       spacing: 4
 
+      Item {
+        id: loadingIndicator
+        Layout.fillWidth: true
+        implicitHeight: loadingContent.height + 30
+        visible: !popup.model
+
+        Column {
+          id: loadingContent
+          anchors.centerIn: parent
+          spacing: 10
+
+          BusyIndicator {
+            id: busyIndicator
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: 48
+            height: 48
+          }
+
+          Label {
+            anchors.horizontalCenter: parent.horizontalCenter
+            font: Theme.tipFont
+            color: Theme.secondaryTextColor
+            text: qsTr("Fetching upload history…")
+          }
+        }
+      }
+
       Label {
+        id: emptyLabel
         Layout.fillWidth: true
         leftPadding: 48
         rightPadding: 48
         width: parent.width
-        visible: deltaList.count === 0
+        visible: !!popup.model && deltaList.count === 0
 
-        text: qsTr("No changes have been pushed yet!")
+        text: qsTr("No changes have been uploaded yet!")
         color: Theme.mainTextDisabledColor
         horizontalAlignment: Text.AlignHCenter
         wrapMode: Text.WordWrap
@@ -97,64 +189,17 @@ QfPopup {
         Layout.fillHeight: true
         visible: count !== 0
         clip: true
+        spacing: 5
         ScrollBar.vertical: QfScrollBar {}
 
-        delegate: Rectangle {
-          id: rectangle
+        delegate: QfCollapsibleMessage {
           width: parent ? parent.width : undefined
-          height: inner.height
-          color: "transparent"
-
-          ColumnLayout {
-            id: inner
-            width: parent.width
-
-            Text {
-              Layout.fillWidth: true
-              topPadding: 5
-              leftPadding: 5
-              text: {
-                var dt = new Date(CreatedAt);
-                return dt.toLocaleString();
-              }
-              font: Theme.defaultFont
-              color: Theme.mainTextColor
-              wrapMode: Text.WordWrap
-            }
-
-            Text {
-              Layout.fillWidth: true
-              leftPadding: 5
-              bottomPadding: 5
-              text: {
-                var status = '';
-                switch (Status) {
-                case DeltaListModel.PendingStatus:
-                  status = 'pending';
-                  break;
-                case DeltaListModel.BusyStatus:
-                  status = 'busy';
-                  break;
-                case DeltaListModel.AppliedStatus:
-                  status = 'applied';
-                  break;
-                case DeltaListModel.ConflictStatus:
-                  status = 'conflict';
-                  break;
-                case DeltaListModel.NotAppliedStatus:
-                  status = 'not applied';
-                  break;
-                case DeltaListModel.ErrorStatus:
-                  status = 'error';
-                  break;
-                }
-                return 'Status: ' + status + (Output != '' ? ' (' + Output + ')' : '');
-              }
-              font: Theme.tipFont
-              color: Theme.secondaryTextColor
-              wrapMode: Text.WordWrap
-            }
-          }
+          color: popup.deltaStatusColor(Status)
+          detailsColor: Theme.secondaryTextColor
+          font: Theme.tipFont
+          iconSource: popup.deltaStatusIcon(Status)
+          titleText: popup.deltaStatusLabel(Status) + ' • ' + new Date(CreatedAt).toLocaleString(Qt.locale(), Locale.ShortFormat)
+          detailsText: Output
         }
       }
     }

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -12,12 +12,17 @@ Popup {
   padding: 0
   leftPadding: mainWindow.sceneLeftMargin
   rightPadding: mainWindow.sceneRightMargin
+  closePolicy: Popup.CloseOnPressOutside
 
   property QFieldCloudStatus cloudServiceStatus: null
   property string pendingAction: ""
   property string pendingCreationTitle: ""
   property string pendingUploadPath: ""
   property string lastSubscriptionUser: ""
+
+  property date currentDateTime: new Date()
+
+  onAboutToShow: currentDateTime = new Date()
 
   onAboutToHide: {
     pendingAction = "";
@@ -40,24 +45,100 @@ Popup {
 
       topMargin: mainWindow.sceneTopMargin
 
-      onFinished: {
-        if (swipeView.currentIndex === 1) {
-          swipeView.currentIndex = 0;
-        } else if (connectionSettings.visible) {
-          if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
-            connectionSettings.visible = false;
-          } else {
-            popup.close();
+      onFinished: popup.goBack()
+    }
+
+    focus: true
+
+    Keys.onReleased: event => {
+      if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+        event.accepted = true;
+        popup.goBack();
+      }
+    }
+
+    RowLayout {
+      id: connectionInformation
+      anchors.top: parent.top
+      anchors.left: parent.left
+      anchors.right: parent.right
+
+      QfMeterBar {
+        id: storageMeterBar
+        Layout.fillWidth: true
+        Layout.margins: 10
+        Layout.alignment: Qt.AlignVCenter
+        visible: false
+      }
+
+      Item {
+        Layout.fillWidth: true
+        visible: !storageMeterBar.visible
+      }
+
+      Rectangle {
+        id: cloudAvatarRect
+        Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+        Layout.margins: 10
+        width: 48
+        height: 48
+        radius: width / 2
+        color: Theme.controlBackgroundAlternateColor
+        layer.enabled: true
+
+        Rectangle {
+          id: cloudAvatarMask
+          anchors.centerIn: parent
+          width: cloudAvatar.width
+          height: cloudAvatar.height
+          radius: width / 2
+          color: "white"
+          visible: false
+          layer.enabled: true
+        }
+
+        Image {
+          id: cloudAvatar
+          anchors.centerIn: parent
+          fillMode: Image.PreserveAspectCrop
+          smooth: true
+          source: cloudConnection.avatarUrl !== '' ? cloudConnection.avatarUrl : 'qrc:/images/nyuki.svg'
+          width: 48
+          height: 48
+          sourceSize.width: width * screen.devicePixelRatio
+          sourceSize.height: height * screen.devicePixelRatio
+          layer.enabled: true
+          layer.effect: QfOpacityMask {
+            maskSource: cloudAvatarMask
           }
-        } else {
-          popup.close();
+
+          onStatusChanged: {
+            // In case the avatar URL fails to load or the image is corrupted, revert to our lovely Nyuki
+            if (status == Image.Error) {
+              source = 'qrc:/images/nyuki.svg';
+            }
+          }
+
+          MouseArea {
+            anchors.fill: parent
+
+            onClicked: {
+              if (cloudConnection.status !== QFieldCloudConnection.LoggedIn || !cloudProjectsModel.currentProject || cloudProjectsModel.currentProject.status !== QFieldCloudProject.Idle)
+                return;
+              connectionSettings.visible = !connectionSettings.visible;
+              storageMeterBar.visible = Qt.binding(() => (storageMeterBar.value > 0 || storageMeterBar.loading) && !connectionSettings.visible);
+            }
+          }
         }
       }
     }
 
     SwipeView {
       id: swipeView
-      anchors.fill: parent
+      anchors.top: connectionInformation.bottom
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.bottom: parent.bottom
       clip: true
       interactive: false
 
@@ -78,79 +159,6 @@ Popup {
           columns: 1
           columnSpacing: 2
           rowSpacing: 2
-
-          RowLayout {
-            id: connectionInformation
-
-            QfMeterBar {
-              id: storageMeterBar
-              Layout.fillWidth: true
-              Layout.margins: 10
-              Layout.alignment: Qt.AlignVCenter
-              visible: false
-            }
-
-            Item {
-              Layout.fillWidth: true
-              visible: !storageMeterBar.visible
-            }
-
-            Rectangle {
-              id: cloudAvatarRect
-              Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-              Layout.margins: 10
-              width: 48
-              height: 48
-              radius: width / 2
-              color: Theme.controlBackgroundAlternateColor
-              layer.enabled: true
-
-              Rectangle {
-                id: cloudAvatarMask
-                anchors.centerIn: parent
-                width: cloudAvatar.width
-                height: cloudAvatar.height
-                radius: width / 2
-                color: "white"
-                visible: false
-                layer.enabled: true
-              }
-
-              Image {
-                id: cloudAvatar
-                anchors.centerIn: parent
-                fillMode: Image.PreserveAspectCrop
-                smooth: true
-                source: cloudConnection.avatarUrl !== '' ? cloudConnection.avatarUrl : 'qrc:/images/nyuki.svg'
-                width: 48
-                height: 48
-                sourceSize.width: width * screen.devicePixelRatio
-                sourceSize.height: height * screen.devicePixelRatio
-                layer.enabled: true
-                layer.effect: QfOpacityMask {
-                  maskSource: cloudAvatarMask
-                }
-
-                onStatusChanged: {
-                  // In case the avatar URL fails to load or the image is corrupted, revert to our lovely Nyuki
-                  if (status == Image.Error) {
-                    source = 'qrc:/images/nyuki.svg';
-                  }
-                }
-
-                MouseArea {
-                  anchors.fill: parent
-
-                  onClicked: {
-                    if (cloudConnection.status !== QFieldCloudConnection.LoggedIn || !cloudProjectsModel.currentProject || cloudProjectsModel.currentProject.status !== QFieldCloudProject.Idle)
-                      return;
-                    connectionSettings.visible = !connectionSettings.visible;
-                    storageMeterBar.visible = Qt.binding(() => (storageMeterBar.value > 0 || storageMeterBar.loading) && !connectionSettings.visible);
-                  }
-                }
-              }
-            }
-          }
 
           QFieldCloudStatusBanner {
             cloudServiceStatus: popup.cloudServiceStatus
@@ -432,14 +440,14 @@ Popup {
                     return '';
                   }
                   const uploadedAt = cloudProjectsModel.currentProject.lastLocalPushDeltas;
-                  const timeDeltaMinutes = parseInt(Math.max(new Date() - uploadedAt, 0) / (60 * 1000));
+                  const timeDeltaMinutes = parseInt(Math.max(popup.currentDateTime - uploadedAt, 0) / (60 * 1000));
                   if (isNaN(timeDeltaMinutes)) {
                     return qsTr('No changes uploaded yet');
                   } else if (timeDeltaMinutes < 1) {
                     return qsTr('Last uploaded just now');
                   } else if (timeDeltaMinutes < 60) {
                     return qsTr('Last uploaded %1 minutes ago').arg(timeDeltaMinutes);
-                  } else if (uploadedAt.toLocaleDateString() === new Date().toLocaleDateString()) {
+                  } else if (uploadedAt.toLocaleDateString() === popup.currentDateTime.toLocaleDateString()) {
                     return qsTr('Last uploaded today at %1').arg(uploadedAt.toLocaleTimeString(Qt.locale(), Locale.ShortFormat));
                   }
                   return qsTr('Last uploaded on %1').arg(uploadedAt.toLocaleString(Qt.locale(), Locale.ShortFormat));
@@ -513,14 +521,14 @@ Popup {
                     return '';
                   }
                   const synchronizedAt = cloudProjectsModel.currentProject.lastLocalExportedAt;
-                  const timeDeltaMinutes = parseInt(Math.max(new Date() - synchronizedAt, 0) / (60 * 1000));
+                  const timeDeltaMinutes = parseInt(Math.max(popup.currentDateTime - synchronizedAt, 0) / (60 * 1000));
                   if (isNaN(timeDeltaMinutes)) {
                     return '';
                   } else if (timeDeltaMinutes < 1) {
                     return qsTr('Last synchronized just now');
                   } else if (timeDeltaMinutes < 60) {
                     return qsTr('Last synchronized %1 minutes ago').arg(timeDeltaMinutes);
-                  } else if (synchronizedAt.toLocaleDateString() === new Date().toLocaleDateString()) {
+                  } else if (synchronizedAt.toLocaleDateString() === popup.currentDateTime.toLocaleDateString()) {
                     return qsTr('Last synchronized today at %1').arg(synchronizedAt.toLocaleTimeString(Qt.locale(), Locale.ShortFormat));
                   }
                   return qsTr('Last synchronized on %1').arg(synchronizedAt.toLocaleString(Qt.locale(), Locale.ShortFormat));
@@ -631,7 +639,6 @@ Popup {
             id: connectionSettings
             Layout.fillWidth: true
             Layout.fillHeight: true
-            Layout.topMargin: connectionInformation.visible ? 0 : connectionInformation.childrenRect.height
             spacing: 2
 
             visible: (cloudProjectsModel.currentProjectId || popup.pendingAction != "") && cloudConnection.status !== QFieldCloudConnection.LoggedIn
@@ -875,6 +882,20 @@ Popup {
     onRejected: {
       visible = false;
       popup.focus = true;
+    }
+  }
+
+  function goBack() {
+    if (swipeView.currentIndex === 1) {
+      swipeView.currentIndex = 0;
+    } else if (connectionSettings.visible) {
+      if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
+        connectionSettings.visible = false;
+      } else {
+        popup.close();
+      }
+    } else {
+      popup.close();
     }
   }
 

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -359,22 +359,28 @@ Popup {
             readonly property bool isCloudifying: cloudProjectsModel.isCreating || !!cloudProjectCreationConnection.target
             readonly property real cloudifyProgress: cloudProjectCreationConnection.target ? cloudProjectCreationConnection.target.uploadProgress : 0
 
-            QfActionCard {
+            QfContainerCard {
               id: cloudifyCard
               Layout.fillWidth: true
               accentColor: Theme.cloudColor
               iconSource: Theme.getThemeVectorIcon('ic_cloud_active_24dp')
               title: qsTr('Cloudify project')
-              description: localProjectGrid.isCloudifying ? qsTr('Uploading the current project to QFieldCloud.') : qsTr('The current project is not stored on QFieldCloud. Storing projects on QFieldCloud offers seamless synchronization, offline editing, and team management.') + '<br><a href="https://qfield.cloud/">' + qsTr('Learn more about QFieldCloud') + '</a>'
-              buttonText: localProjectGrid.isCloudifying ? (localProjectGrid.cloudifyProgress > 0 ? qsTr('Cloudifying %1%').arg(Math.round(localProjectGrid.cloudifyProgress * 100)) : qsTr('Cloudifying')) : qsTr('Cloudify project')
-              buttonColor: Theme.light
-              buttonEnabled: !localProjectGrid.isCloudifying
-              buttonShowProgress: localProjectGrid.isCloudifying
-              buttonProgressValue: localProjectGrid.cloudifyProgress
+              description: localProjectGrid.isCloudifying ? qsTr('Uploading the current project to QFieldCloud.') : qsTr('The current project is not stored on QFieldCloud. Storing projects on QFieldCloud offers seamless synchronization, offline editing, and team management.') + ' <a href="https://qfield.cloud/">' + qsTr('Learn more about QFieldCloud') + '</a>.'
 
-              onActionClicked: {
-                if (qgisProject.fileName != "") {
-                  cloudify(ProjectUtils.title(qgisProject), FileUtils.absolutePath(qgisProject.fileName));
+              QfButton {
+                Layout.fillWidth: true
+                Layout.topMargin: 4
+                bgcolor: Theme.cloudColor
+                color: Theme.light
+                text: localProjectGrid.isCloudifying ? (localProjectGrid.cloudifyProgress > 0 ? qsTr('Cloudifying %1%').arg(Math.round(localProjectGrid.cloudifyProgress * 100)) : qsTr('Cloudifying')) : qsTr('Cloudify project')
+                enabled: !localProjectGrid.isCloudifying
+                showProgress: localProjectGrid.isCloudifying
+                progressValue: localProjectGrid.cloudifyProgress
+
+                onClicked: {
+                  if (qgisProject.fileName != "") {
+                    cloudify(ProjectUtils.title(qgisProject), FileUtils.absolutePath(qgisProject.fileName));
+                  }
                 }
               }
             }
@@ -413,18 +419,15 @@ Popup {
               spacing: 10
               visible: cloudProjectGrid.hasDeltaFileWrapper && !cloudProjectGrid.hasDeltaError
 
-              QfActionCard {
+              QfContainerCard {
                 id: uploadCard
                 Layout.fillWidth: true
                 accentColor: Theme.cloudColor
                 iconSource: Theme.getThemeVectorIcon('ic_cloud_upload_24dp')
                 title: qsTr('Upload local changes')
-                badgeText: cloudProjectGrid.changesCount > 0 ? cloudProjectGrid.changesCount : ''
+                count: cloudProjectGrid.changesCount
                 description: qsTr('Sends your edits and attachments to the cloud without downloading project updates. Fast and low on data.')
-                buttonText: qsTr('Upload')
-                buttonColor: Theme.light
-                buttonEnabled: cloudProjectGrid.canUpload
-                metaText: {
+                footnote: {
                   if (!cloudProjectsModel.currentProject) {
                     return '';
                   }
@@ -433,16 +436,25 @@ Popup {
                   if (isNaN(timeDeltaMinutes)) {
                     return qsTr('No changes uploaded yet');
                   } else if (timeDeltaMinutes < 1) {
-                    return qsTr('Last upload just now');
+                    return qsTr('Last uploaded just now');
                   } else if (timeDeltaMinutes < 60) {
-                    return qsTr('Last upload %1 minutes ago').arg(timeDeltaMinutes);
+                    return qsTr('Last uploaded %1 minutes ago').arg(timeDeltaMinutes);
                   } else if (uploadedAt.toLocaleDateString() === new Date().toLocaleDateString()) {
-                    return qsTr('Last upload today at %1').arg(uploadedAt.toLocaleTimeString(Qt.locale(), Locale.ShortFormat));
+                    return qsTr('Last uploaded today at %1').arg(uploadedAt.toLocaleTimeString(Qt.locale(), Locale.ShortFormat));
                   }
-                  return qsTr('Last upload on %1').arg(uploadedAt.toLocaleString(Qt.locale(), Locale.ShortFormat));
+                  return qsTr('Last uploaded on %1').arg(uploadedAt.toLocaleString(Qt.locale(), Locale.ShortFormat));
                 }
 
-                onActionClicked: projectPush(false)
+                QfButton {
+                  Layout.fillWidth: true
+                  Layout.topMargin: 4
+                  bgcolor: Theme.cloudColor
+                  color: Theme.light
+                  text: qsTr('Upload')
+                  enabled: cloudProjectGrid.canUpload
+
+                  onClicked: projectPush(false)
+                }
 
                 RowLayout {
                   Layout.fillWidth: true
@@ -488,7 +500,7 @@ Popup {
                 }
               }
 
-              QfActionCard {
+              QfContainerCard {
                 id: synchronizeCard
                 Layout.fillWidth: true
                 accentColor: Theme.mainColor
@@ -496,10 +508,7 @@ Popup {
                 title: qsTr('Synchronize project')
                 indicatorVisible: !!(cloudProjectsModel.currentProject && (cloudProjectsModel.currentProject.isOutdated || cloudProjectsModel.currentProject.isProjectOutdated))
                 description: qsTr('Uploads your edits, then downloads the latest project from QFieldCloud so everything is up to date.')
-                buttonText: qsTr('Synchronize')
-                outlined: true
-                buttonEnabled: cloudProjectGrid.canSynchronize
-                metaText: {
+                footnote: {
                   if (!cloudProjectsModel.currentProject) {
                     return '';
                   }
@@ -508,16 +517,25 @@ Popup {
                   if (isNaN(timeDeltaMinutes)) {
                     return '';
                   } else if (timeDeltaMinutes < 1) {
-                    return qsTr('Last sync just now');
+                    return qsTr('Last synchronized just now');
                   } else if (timeDeltaMinutes < 60) {
-                    return qsTr('Last sync %1 minutes ago').arg(timeDeltaMinutes);
+                    return qsTr('Last synchronized %1 minutes ago').arg(timeDeltaMinutes);
                   } else if (synchronizedAt.toLocaleDateString() === new Date().toLocaleDateString()) {
-                    return qsTr('Last sync today at %1').arg(synchronizedAt.toLocaleTimeString(Qt.locale(), Locale.ShortFormat));
+                    return qsTr('Last synchronized today at %1').arg(synchronizedAt.toLocaleTimeString(Qt.locale(), Locale.ShortFormat));
                   }
-                  return qsTr('Last sync on %1').arg(synchronizedAt.toLocaleString(Qt.locale(), Locale.ShortFormat));
+                  return qsTr('Last synchronized on %1').arg(synchronizedAt.toLocaleString(Qt.locale(), Locale.ShortFormat));
                 }
 
-                onActionClicked: projectPush(true)
+                QfButton {
+                  Layout.fillWidth: true
+                  Layout.topMargin: 4
+                  bgcolor: "transparent"
+                  color: Theme.mainColor
+                  text: qsTr('Synchronize')
+                  enabled: cloudProjectGrid.canSynchronize
+
+                  onClicked: projectPush(true)
+                }
               }
             }
 

--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -23,13 +23,14 @@ Popup {
     pendingAction = "";
     pendingCreationTitle = "";
     pendingUploadPath = "";
+    swipeView.currentIndex = 0;
   }
 
   Page {
     anchors.fill: parent
 
     header: QfPageHeader {
-      title: qsTr('QFieldCloud')
+      title: swipeView.currentIndex === 1 ? qsTr('Danger Zone') : qsTr('QFieldCloud')
 
       showBackButton: true
       showCancelButton: false
@@ -40,7 +41,9 @@ Popup {
       topMargin: mainWindow.sceneTopMargin
 
       onFinished: {
-        if (connectionSettings.visible) {
+        if (swipeView.currentIndex === 1) {
+          swipeView.currentIndex = 0;
+        } else if (connectionSettings.visible) {
           if (cloudConnection.status === QFieldCloudConnection.LoggedIn) {
             connectionSettings.visible = false;
           } else {
@@ -52,223 +55,169 @@ Popup {
       }
     }
 
-    ScrollView {
-      id: scrollView
+    SwipeView {
+      id: swipeView
       anchors.fill: parent
-
-      ScrollBar.horizontal: QfScrollBar {}
-      ScrollBar.vertical: QfScrollBar {}
-      contentWidth: mainGrid.width
-      contentHeight: mainGrid.height
-      padding: 0
-      bottomPadding: uploadFeedback.isVisible ? uploadFeedback.height + 20 : 0
       clip: true
+      interactive: false
 
-      GridLayout {
-        id: mainGrid
-        width: popup.width - popup.leftPadding - popup.rightPadding
-        columns: 1
-        columnSpacing: 2
-        rowSpacing: 2
+      ScrollView {
+        id: scrollView
 
-        RowLayout {
-          id: connectionInformation
+        ScrollBar.horizontal: QfScrollBar {}
+        ScrollBar.vertical: QfScrollBar {}
+        contentWidth: mainGrid.width
+        contentHeight: mainGrid.height
+        padding: 0
+        bottomPadding: uploadFeedback.isVisible ? uploadFeedback.height + 20 : 0
+        clip: true
 
-          QfMeterBar {
-            id: storageMeterBar
-            Layout.fillWidth: true
-            Layout.margins: 10
-            Layout.alignment: Qt.AlignVCenter
-            visible: false
-          }
+        GridLayout {
+          id: mainGrid
+          width: popup.width - popup.leftPadding - popup.rightPadding
+          columns: 1
+          columnSpacing: 2
+          rowSpacing: 2
 
-          Item {
-            Layout.fillWidth: true
-            visible: !storageMeterBar.visible
-          }
+          RowLayout {
+            id: connectionInformation
 
-          Rectangle {
-            id: cloudAvatarRect
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            Layout.margins: 10
-            width: 48
-            height: 48
-            radius: width / 2
-            color: Theme.controlBackgroundAlternateColor
-            layer.enabled: true
+            QfMeterBar {
+              id: storageMeterBar
+              Layout.fillWidth: true
+              Layout.margins: 10
+              Layout.alignment: Qt.AlignVCenter
+              visible: false
+            }
+
+            Item {
+              Layout.fillWidth: true
+              visible: !storageMeterBar.visible
+            }
 
             Rectangle {
-              id: cloudAvatarMask
-              anchors.centerIn: parent
-              width: cloudAvatar.width
-              height: cloudAvatar.height
-              radius: width / 2
-              color: "white"
-              visible: false
-              layer.enabled: true
-            }
-
-            Image {
-              id: cloudAvatar
-              anchors.centerIn: parent
-              fillMode: Image.PreserveAspectCrop
-              smooth: true
-              source: cloudConnection.avatarUrl !== '' ? cloudConnection.avatarUrl : 'qrc:/images/nyuki.svg'
+              id: cloudAvatarRect
+              Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+              Layout.margins: 10
               width: 48
               height: 48
-              sourceSize.width: width * screen.devicePixelRatio
-              sourceSize.height: height * screen.devicePixelRatio
+              radius: width / 2
+              color: Theme.controlBackgroundAlternateColor
               layer.enabled: true
-              layer.effect: QfOpacityMask {
-                maskSource: cloudAvatarMask
+
+              Rectangle {
+                id: cloudAvatarMask
+                anchors.centerIn: parent
+                width: cloudAvatar.width
+                height: cloudAvatar.height
+                radius: width / 2
+                color: "white"
+                visible: false
+                layer.enabled: true
               }
 
-              onStatusChanged: {
-                // In case the avatar URL fails to load or the image is corrupted, revert to our lovely Nyuki
-                if (status == Image.Error) {
-                  source = 'qrc:/images/nyuki.svg';
+              Image {
+                id: cloudAvatar
+                anchors.centerIn: parent
+                fillMode: Image.PreserveAspectCrop
+                smooth: true
+                source: cloudConnection.avatarUrl !== '' ? cloudConnection.avatarUrl : 'qrc:/images/nyuki.svg'
+                width: 48
+                height: 48
+                sourceSize.width: width * screen.devicePixelRatio
+                sourceSize.height: height * screen.devicePixelRatio
+                layer.enabled: true
+                layer.effect: QfOpacityMask {
+                  maskSource: cloudAvatarMask
                 }
-              }
 
-              MouseArea {
-                anchors.fill: parent
-
-                onClicked: {
-                  if (cloudConnection.status !== QFieldCloudConnection.LoggedIn || !cloudProjectsModel.currentProject || cloudProjectsModel.currentProject.status !== QFieldCloudProject.Idle)
-                    return;
-                  connectionSettings.visible = !connectionSettings.visible;
-                  storageMeterBar.visible = Qt.binding(() => (storageMeterBar.value > 0 || storageMeterBar.loading) && !connectionSettings.visible);
-                }
-              }
-            }
-          }
-        }
-
-        QFieldCloudStatusBanner {
-          cloudServiceStatus: popup.cloudServiceStatus
-          Layout.margins: 10
-          visible: cloudServiceStatus && cloudServiceStatus.hasProblem && !connectionSettings.visible
-        }
-
-        Text {
-          id: wrongAccountText
-          visible: cloudProjectsModel.currentProjectId != '' && cloudProjectsModel.currentProject && cloudProjectsModel.currentProjectId !== cloudProjectsModel.currentProject.id
-          font: Theme.tipFont
-          color: Theme.secondaryTextColor
-          text: qsTr('This QFieldCloud project was first downloaded with another cloud account. Please sign in with the original account for this project to use the QFieldCloud functionality.')
-
-          wrapMode: Text.WordWrap
-          horizontalAlignment: Text.AlignHCenter
-          Layout.fillWidth: true
-          Layout.margins: 10
-        }
-
-        Text {
-          id: statusText
-          visible: (cloudProjectsModel.currentProject && (cloudProjectsModel.currentProject.status === QFieldCloudProject.Downloading || cloudProjectsModel.currentProject.status === QFieldCloudProject.Pushing)) || (cloudProjectCreationConnection.target && (cloudProjectCreationConnection.target.status === QFieldCloudProject.Downloading))
-          font: Theme.tipFont
-          color: Theme.secondaryTextColor
-          text: {
-            let status = QFieldCloudProject.Idle;
-            let packagingStatus = QFieldCloudProject.PackagingFinishedStatus;
-            let downloadProgress = 0.0;
-            let downloadBytesTotal = 0;
-            let deltaFilePushStatus = QFieldCloudProject.DeltaFileLocalStatus;
-            if (cloudProjectsModel.currentProject) {
-              status = cloudProjectsModel.currentProject.status;
-              packagingStatus = cloudProjectsModel.currentProject.packagingStatus;
-              downloadProgress = cloudProjectsModel.currentProject.downloadProgress;
-              downloadBytesTotal = cloudProjectsModel.currentProject.downloadBytesTotal;
-              deltaFilePushStatus = cloudProjectsModel.currentProject.deltaFilePushStatus;
-            } else if (cloudProjectCreationConnection.target) {
-              status = cloudProjectCreationConnection.target.status;
-              packagingStatus = cloudProjectCreationConnection.target.packagingStatus;
-              downloadProgress = cloudProjectCreationConnection.target.downloadProgress;
-              downloadBytesTotal = cloudProjectCreationConnection.target.downloadBytesTotal;
-              deltaFilePushStatus = cloudProjectCreationConnection.target.deltaFilePushStatus;
-            } else {
-              return '';
-            }
-            switch (status) {
-            case QFieldCloudProject.Downloading:
-              if (packagingStatus === QFieldCloudProject.PackagingBusyStatus) {
-                return qsTr('QFieldCloud is packaging the latest data just for you; this might take some time, please hold tight');
-              } else {
-                if (packagingStatus === QFieldCloudProject.PackagingFinishedStatus || downloadProgress > 0.0) {
-                  if (downloadBytesTotal > 0) {
-                    return qsTr('Downloading, %1% of %2 fetched').arg(Math.round(downloadProgress * 100)).arg(FileUtils.representFileSize(downloadBytesTotal));
-                  } else {
-                    return qsTr('Downloading, %1% fetched').arg(Math.round(downloadProgress * 100));
+                onStatusChanged: {
+                  // In case the avatar URL fails to load or the image is corrupted, revert to our lovely Nyuki
+                  if (status == Image.Error) {
+                    source = 'qrc:/images/nyuki.svg';
                   }
-                } else {
-                  return qsTr('Reaching out to QFieldCloud to download project');
+                }
+
+                MouseArea {
+                  anchors.fill: parent
+
+                  onClicked: {
+                    if (cloudConnection.status !== QFieldCloudConnection.LoggedIn || !cloudProjectsModel.currentProject || cloudProjectsModel.currentProject.status !== QFieldCloudProject.Idle)
+                      return;
+                    connectionSettings.visible = !connectionSettings.visible;
+                    storageMeterBar.visible = Qt.binding(() => (storageMeterBar.value > 0 || storageMeterBar.loading) && !connectionSettings.visible);
+                  }
                 }
               }
-            case QFieldCloudProject.Pushing:
-              switch (deltaFilePushStatus) {
-              case QFieldCloudProject.DeltaFileLocalStatus:
-                return qsTr('Pushing changes, %1%…').arg(Math.round(cloudProjectsModel.currentProject.pushDeltaProgress * 100));
-              default:
-                return qsTr('QFieldCloud is applying the latest pushed changes. This might take some time, please hold tight…');
-              }
-            default:
-              '';
             }
-            return '';
           }
 
-          wrapMode: Text.WordWrap
-          horizontalAlignment: Text.AlignHCenter
-          Layout.fillWidth: true
-          Layout.leftMargin: 10
-          Layout.rightMargin: 10
-          Layout.topMargin: 60
-          Layout.bottomMargin: 20
-        }
+          QFieldCloudStatusBanner {
+            cloudServiceStatus: popup.cloudServiceStatus
+            Layout.margins: 10
+            visible: cloudServiceStatus && cloudServiceStatus.hasProblem && !connectionSettings.visible
+          }
 
-        Rectangle {
-          id: cloudAnimation
-          Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-          Layout.margins: 10
-          width: 128
-          height: 128
-          color: 'transparent'
-          visible: statusText.visible
+          Text {
+            id: wrongAccountText
+            visible: cloudProjectsModel.currentProjectId != '' && cloudProjectsModel.currentProject && cloudProjectsModel.currentProjectId !== cloudProjectsModel.currentProject.id
+            font: Theme.tipFont
+            color: Theme.secondaryTextColor
+            text: qsTr('This QFieldCloud project was first downloaded with another cloud account. Please sign in with the original account for this project to use the QFieldCloud functionality.')
 
-          Image {
-            id: statusIcon
-            anchors.fill: parent
-            fillMode: Image.PreserveAspectFit
-            smooth: true
-            source: {
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            Layout.fillWidth: true
+            Layout.margins: 10
+          }
+
+          Text {
+            id: statusText
+            visible: (cloudProjectsModel.currentProject && (cloudProjectsModel.currentProject.status === QFieldCloudProject.Downloading || cloudProjectsModel.currentProject.status === QFieldCloudProject.Pushing)) || (cloudProjectCreationConnection.target && (cloudProjectCreationConnection.target.status === QFieldCloudProject.Downloading))
+            font: Theme.tipFont
+            color: Theme.secondaryTextColor
+            text: {
               let status = QFieldCloudProject.Idle;
               let packagingStatus = QFieldCloudProject.PackagingFinishedStatus;
+              let downloadProgress = 0.0;
+              let downloadBytesTotal = 0;
               let deltaFilePushStatus = QFieldCloudProject.DeltaFileLocalStatus;
               if (cloudProjectsModel.currentProject) {
                 status = cloudProjectsModel.currentProject.status;
                 packagingStatus = cloudProjectsModel.currentProject.packagingStatus;
+                downloadProgress = cloudProjectsModel.currentProject.downloadProgress;
+                downloadBytesTotal = cloudProjectsModel.currentProject.downloadBytesTotal;
                 deltaFilePushStatus = cloudProjectsModel.currentProject.deltaFilePushStatus;
               } else if (cloudProjectCreationConnection.target) {
                 status = cloudProjectCreationConnection.target.status;
                 packagingStatus = cloudProjectCreationConnection.target.packagingStatus;
+                downloadProgress = cloudProjectCreationConnection.target.downloadProgress;
+                downloadBytesTotal = cloudProjectCreationConnection.target.downloadBytesTotal;
                 deltaFilePushStatus = cloudProjectCreationConnection.target.deltaFilePushStatus;
               } else {
                 return '';
               }
               switch (status) {
               case QFieldCloudProject.Downloading:
-                switch (packagingStatus) {
-                case QFieldCloudProject.PackagingFinishedStatus || cloudProjectsModel.currentProject.downloadProgress > 0.0:
-                  return Theme.getThemeVectorIcon('ic_cloud_download_24dp');
-                default:
-                  return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
+                if (packagingStatus === QFieldCloudProject.PackagingBusyStatus) {
+                  return qsTr('QFieldCloud is packaging the latest data just for you; this might take some time, please hold tight');
+                } else {
+                  if (packagingStatus === QFieldCloudProject.PackagingFinishedStatus || downloadProgress > 0.0) {
+                    if (downloadBytesTotal > 0) {
+                      return qsTr('Downloading, %1% of %2 fetched').arg(Math.round(downloadProgress * 100)).arg(FileUtils.representFileSize(downloadBytesTotal));
+                    } else {
+                      return qsTr('Downloading, %1% fetched').arg(Math.round(downloadProgress * 100));
+                    }
+                  } else {
+                    return qsTr('Reaching out to QFieldCloud to download project');
+                  }
                 }
               case QFieldCloudProject.Pushing:
                 switch (deltaFilePushStatus) {
                 case QFieldCloudProject.DeltaFileLocalStatus:
-                  return Theme.getThemeVectorIcon('ic_cloud_upload_24dp');
+                  return qsTr('Pushing changes, %1%…').arg(Math.round(cloudProjectsModel.currentProject.pushDeltaProgress * 100));
                 default:
-                  return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
+                  return qsTr('QFieldCloud is applying the latest pushed changes. This might take some time, please hold tight…');
                 }
               default:
                 '';
@@ -276,275 +225,299 @@ Popup {
               return '';
             }
 
-            width: parent.width
-            height: parent.height
-            sourceSize.width: width * screen.devicePixelRatio
-            sourceSize.height: height * screen.devicePixelRatio
-            opacity: 1
-
-            SequentialAnimation {
-              OpacityAnimator {
-                from: 1
-                to: 0.2
-                duration: 2000
-                target: statusIcon
-              }
-              OpacityAnimator {
-                from: 0.2
-                to: 1
-                duration: 2000
-                target: statusIcon
-              }
-              running: cloudAnimation.visible
-              loops: Animation.Infinite
-            }
-          }
-
-          ProgressBar {
-            anchors.bottom: parent.bottom
-            anchors.horizontalCenter: parent.horizontalCenter
-            width: parent.width
-            height: 6
-            indeterminate: cloudProjectsModel.currentProject && (cloudProjectsModel.currentProject.packagingStatus !== QFieldCloudProject.PackagingFinishedStatus && cloudProjectsModel.currentProject.downloadProgress === 0.0)
-            value: cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.downloadProgress ? cloudProjectsModel.currentProject.downloadProgress : 0
-            visible: cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.ProjectStatus.Downloading
-          }
-        }
-
-        QfCollapsibleMessage {
-          id: transferError
-
-          property bool hasError: false
-
-          visible: hasError && cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle && !connectionSettings.visible
-
-          Layout.fillWidth: true
-          Layout.leftMargin: 10
-          Layout.rightMargin: 10
-
-          color: Theme.darkRed
-          detailsColor: Theme.secondaryTextColor
-          font: Theme.tipFont
-
-          externalLink: QFieldCloudUtils.documentationFromErrorString(detailsText)
-          titleText: QFieldCloudUtils.userFriendlyErrorString(detailsText)
-          detailsText: ''
-
-          Connections {
-            target: iface
-
-            function onLoadProjectEnded() {
-              transferError.hasError = false;
-            }
-          }
-        }
-
-        ColumnLayout {
-          id: localProjectGrid
-          visible: !connectionSettings.visible && !cloudProjectsModel.currentProject && !statusText.visible
-          Layout.margins: 10
-          Layout.maximumWidth: 525
-          Layout.alignment: Qt.AlignHCenter
-
-          Text {
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
             Layout.fillWidth: true
+            Layout.leftMargin: 10
+            Layout.rightMargin: 10
+            Layout.topMargin: 60
             Layout.bottomMargin: 20
-            font: Theme.tipFont
-            color: Theme.mainTextColor
-            text: cloudProjectsModel.isCreating || (cloudProjectCreationConnection.target && cloudProjectCreationConnection.target.status === QFieldCloudProject.Uploading) ? qsTr('Uploading the current project to QFieldCloud.') : qsTr('The current project is not stored on QFieldCloud.')
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-          }
-
-          QfButton {
-            id: cloudifyButton
-            Layout.fillWidth: true
-            text: {
-              if (!enabled) {
-                if (cloudProjectCreationConnection.target && cloudProjectCreationConnection.target.uploadProgress > 0) {
-                  return qsTr("Cloudifying project") + " (%1%)".arg(Math.round(cloudProjectCreationConnection.target.uploadProgress * 100));
-                } else {
-                  return qsTr("Cloudifying project");
-                }
-              }
-              return qsTr('Cloudify!');
-            }
-            enabled: !cloudProjectsModel.isCreating && !cloudProjectCreationConnection.target
-            progressValue: cloudProjectCreationConnection.target ? cloudProjectCreationConnection.target.uploadProgress : 0
-            icon.source: Theme.getThemeVectorIcon('ic_cloud_white_24dp')
-
-            onClicked: {
-              if (qgisProject.fileName != "") {
-                cloudify(ProjectUtils.title(qgisProject), FileUtils.absolutePath(qgisProject.fileName));
-              }
-            }
-          }
-
-          Text {
-            Layout.fillWidth: true
-            font: Theme.tipFont
-            color: Theme.secondaryTextColor
-            text: qsTr('Storing projects on QFieldCloud offers seamless synchronization, offline editing, and team management.<br><br>') + ' <a href="https://qfield.cloud/">' + qsTr('Learn more about QFieldCloud') + '</a>.'
-            textFormat: Text.RichText
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-
-            onLinkActivated: link => {
-              Qt.openUrlExternally(link);
-            }
-          }
-        }
-
-        ColumnLayout {
-          id: cloudProjectGrid
-          Layout.margins: 10
-          Layout.maximumWidth: 525
-          Layout.alignment: Qt.AlignHCenter
-          visible: !connectionSettings.visible && cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle
-
-          Text {
-            id: changesText
-            property bool hasError: cloudProjectsModel.layerObserver.deltaFileWrapper && cloudProjectsModel.layerObserver.deltaFileWrapper.hasError
-            property int changesCount: cloudProjectsModel.layerObserver.deltaFileWrapper ? cloudProjectsModel.layerObserver.deltaFileWrapper.count : 0
-            font: Theme.tipFont
-            color: hasError ? Theme.errorColor : Theme.mainTextColor
-            text: {
-              if (!hasError) {
-                return changesCount !== 0 ? qsTr('There is/are %n local change(s)', '', changesCount) : qsTr('There are no local changes');
-              } else {
-                return qsTr('The locally stored cloud project has been corrupted') + '\n' + cloudProjectsModel.layerObserver.deltaFileWrapper.errorString;
-              }
-            }
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-            Layout.bottomMargin: 20
-            Layout.fillWidth: true
-          }
-
-          QfButton {
-            id: syncButton
-            Layout.fillWidth: true
-            text: qsTr('Synchronize')
-            visible: cloudProjectsModel.layerObserver.deltaFileWrapper && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError
-            enabled: !!(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle) && cloudProjectsModel.layerObserver.deltaFileWrapper && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError
-            icon.source: Theme.getThemeVectorIcon('ic_cloud_synchronize_24dp')
-
-            onClicked: projectPush(true)
-          }
-
-          Text {
-            id: syncText
-            font: Theme.tipFont
-            color: Theme.secondaryTextColor
-            visible: cloudProjectsModel.layerObserver.deltaFileWrapper && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError
-            text: qsTr('Synchronize the whole project with all modified features and download the freshly updated project with all the applied changes from QFieldCloud.')
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-            Layout.bottomMargin: 20
-            Layout.fillWidth: true
-          }
-
-          QfButton {
-            id: pushButton
-            Layout.fillWidth: true
-            text: qsTr('Push changes')
-            visible: cloudProjectsModel.layerObserver.deltaFileWrapper && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError
-            enabled: !!(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle) && cloudProjectsModel.layerObserver.deltaFileWrapper && cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0 && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError
-            icon.source: Theme.getThemeVectorIcon('ic_cloud_upload_24dp')
-
-            onClicked: projectPush(false)
-          }
-
-          Text {
-            id: pushText
-            font: Theme.tipFont
-            color: Theme.secondaryTextColor
-            visible: cloudProjectsModel.layerObserver.deltaFileWrapper && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError
-            text: qsTr('Save internet bandwidth by only pushing the local features and pictures to the cloud, without updating the whole project.')
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-            Layout.bottomMargin: 20
-            Layout.fillWidth: true
-          }
-
-          QfButton {
-            id: discardButton
-            Layout.fillWidth: true
-            bgcolor: Theme.darkRed
-            text: cloudProjectsModel.layerObserver.deltaFileWrapper && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError ? qsTr('Revert local changes') : qsTr('Reset project')
-            enabled: cloudProjectsModel.layerObserver.deltaFileWrapper && (cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0 || cloudProjectsModel.layerObserver.deltaFileWrapper.hasError)
-            icon.source: Theme.getThemeVectorIcon('ic_undo_black_24dp')
-
-            onClicked: {
-              if (!cloudProjectsModel.layerObserver.deltaFileWrapper.hasError) {
-                revertDialog.open();
-              } else {
-                resetDialog.open();
-              }
-            }
-          }
-
-          Text {
-            id: discardText
-            font: Theme.tipFont
-            color: Theme.secondaryTextColor
-            text: cloudProjectsModel.layerObserver.deltaFileWrapper && !cloudProjectsModel.layerObserver.deltaFileWrapper.hasError ? qsTr('Revert all modified features in the local layers. You cannot restore those changes.') : qsTr('The local copy of this cloud project has been corrupted. Resetting the project will re-download the cloud version and will remove any local changes, make sure those were copied first if needed.\n\nWhile you can still view and use the project, it is strongly recommended to reset to avoid any accidental data loss as none of the changes made will be pushed back to the cloud.')
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-            Layout.bottomMargin: 10
-            Layout.fillWidth: true
           }
 
           Rectangle {
-            color: Theme.controlBorderColor
-            height: 1
+            id: cloudAnimation
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            Layout.margins: 10
+            width: 128
+            height: 128
+            color: 'transparent'
+            visible: statusText.visible
+
+            Image {
+              id: statusIcon
+              anchors.fill: parent
+              fillMode: Image.PreserveAspectFit
+              smooth: true
+              source: {
+                let status = QFieldCloudProject.Idle;
+                let packagingStatus = QFieldCloudProject.PackagingFinishedStatus;
+                let deltaFilePushStatus = QFieldCloudProject.DeltaFileLocalStatus;
+                if (cloudProjectsModel.currentProject) {
+                  status = cloudProjectsModel.currentProject.status;
+                  packagingStatus = cloudProjectsModel.currentProject.packagingStatus;
+                  deltaFilePushStatus = cloudProjectsModel.currentProject.deltaFilePushStatus;
+                } else if (cloudProjectCreationConnection.target) {
+                  status = cloudProjectCreationConnection.target.status;
+                  packagingStatus = cloudProjectCreationConnection.target.packagingStatus;
+                  deltaFilePushStatus = cloudProjectCreationConnection.target.deltaFilePushStatus;
+                } else {
+                  return '';
+                }
+                switch (status) {
+                case QFieldCloudProject.Downloading:
+                  switch (packagingStatus) {
+                  case QFieldCloudProject.PackagingFinishedStatus || cloudProjectsModel.currentProject.downloadProgress > 0.0:
+                    return Theme.getThemeVectorIcon('ic_cloud_download_24dp');
+                  default:
+                    return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
+                  }
+                case QFieldCloudProject.Pushing:
+                  switch (deltaFilePushStatus) {
+                  case QFieldCloudProject.DeltaFileLocalStatus:
+                    return Theme.getThemeVectorIcon('ic_cloud_upload_24dp');
+                  default:
+                    return Theme.getThemeVectorIcon('ic_cloud_active_24dp');
+                  }
+                default:
+                  '';
+                }
+                return '';
+              }
+
+              width: parent.width
+              height: parent.height
+              sourceSize.width: width * screen.devicePixelRatio
+              sourceSize.height: height * screen.devicePixelRatio
+              opacity: 1
+
+              SequentialAnimation {
+                OpacityAnimator {
+                  from: 1
+                  to: 0.2
+                  duration: 2000
+                  target: statusIcon
+                }
+                OpacityAnimator {
+                  from: 0.2
+                  to: 1
+                  duration: 2000
+                  target: statusIcon
+                }
+                running: cloudAnimation.visible
+                loops: Animation.Infinite
+              }
+            }
+
+            ProgressBar {
+              anchors.bottom: parent.bottom
+              anchors.horizontalCenter: parent.horizontalCenter
+              width: parent.width
+              height: 6
+              indeterminate: cloudProjectsModel.currentProject && (cloudProjectsModel.currentProject.packagingStatus !== QFieldCloudProject.PackagingFinishedStatus && cloudProjectsModel.currentProject.downloadProgress === 0.0)
+              value: cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.downloadProgress ? cloudProjectsModel.currentProject.downloadProgress : 0
+              visible: cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.ProjectStatus.Downloading
+            }
+          }
+
+          QfCollapsibleMessage {
+            id: transferError
+
+            property bool hasError: false
+
+            visible: hasError && cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle && !connectionSettings.visible
+
             Layout.fillWidth: true
             Layout.leftMargin: 10
             Layout.rightMargin: 10
-            Layout.bottomMargin: 5
+
+            color: Theme.darkRed
+            detailsColor: Theme.secondaryTextColor
+            font: Theme.tipFont
+            iconSource: Theme.getThemeVectorIcon('ic_error_outline_24dp')
+
+            externalLink: QFieldCloudUtils.documentationFromErrorString(detailsText)
+            titleText: QFieldCloudUtils.userFriendlyErrorString(detailsText)
+            detailsText: ''
+
+            Connections {
+              target: iface
+
+              function onLoadProjectEnded() {
+                transferError.hasError = false;
+              }
+            }
           }
 
-          RowLayout {
-            Layout.leftMargin: 10
-            Layout.rightMargin: 10
+          ColumnLayout {
+            id: localProjectGrid
+            visible: !connectionSettings.visible && !cloudProjectsModel.currentProject && !statusText.visible
+            Layout.margins: 10
+            Layout.maximumWidth: 525
+            Layout.alignment: Qt.AlignHCenter
+            spacing: 10
 
-            Label {
+            readonly property bool isCloudifying: cloudProjectsModel.isCreating || !!cloudProjectCreationConnection.target
+            readonly property real cloudifyProgress: cloudProjectCreationConnection.target ? cloudProjectCreationConnection.target.uploadProgress : 0
+
+            QfActionCard {
+              id: cloudifyCard
               Layout.fillWidth: true
-              Layout.alignment: Qt.AlignVCenter
-              topPadding: 10
-              bottomPadding: 10
+              accentColor: Theme.cloudColor
+              iconSource: Theme.getThemeVectorIcon('ic_cloud_active_24dp')
+              title: qsTr('Cloudify project')
+              description: localProjectGrid.isCloudifying ? qsTr('Uploading the current project to QFieldCloud.') : qsTr('The current project is not stored on QFieldCloud. Storing projects on QFieldCloud offers seamless synchronization, offline editing, and team management.') + '<br><a href="https://qfield.cloud/">' + qsTr('Learn more about QFieldCloud') + '</a>'
+              buttonText: localProjectGrid.isCloudifying ? (localProjectGrid.cloudifyProgress > 0 ? qsTr('Cloudifying %1%').arg(Math.round(localProjectGrid.cloudifyProgress * 100)) : qsTr('Cloudifying')) : qsTr('Cloudify project')
+              buttonColor: Theme.light
+              buttonEnabled: !localProjectGrid.isCloudifying
+              buttonShowProgress: localProjectGrid.isCloudifying
+              buttonProgressValue: localProjectGrid.cloudifyProgress
+
+              onActionClicked: {
+                if (qgisProject.fileName != "") {
+                  cloudify(ProjectUtils.title(qgisProject), FileUtils.absolutePath(qgisProject.fileName));
+                }
+              }
+            }
+          }
+
+          ColumnLayout {
+            id: cloudProjectGrid
+            Layout.margins: 10
+            Layout.maximumWidth: 525
+            Layout.alignment: Qt.AlignHCenter
+            visible: !connectionSettings.visible && cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle
+
+            readonly property bool hasDeltaFileWrapper: !!cloudProjectsModel.layerObserver.deltaFileWrapper
+            readonly property bool hasDeltaError: hasDeltaFileWrapper && cloudProjectsModel.layerObserver.deltaFileWrapper.hasError
+            readonly property int changesCount: hasDeltaFileWrapper ? cloudProjectsModel.layerObserver.deltaFileWrapper.count : 0
+            readonly property bool isProjectIdle: !!(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle)
+            readonly property bool canUpload: isProjectIdle && changesCount > 0 && !hasDeltaError
+            readonly property bool canSynchronize: isProjectIdle && hasDeltaFileWrapper && !hasDeltaError
+
+            Text {
+              id: changesText
+              visible: cloudProjectGrid.hasDeltaError
               font: Theme.tipFont
+              color: Theme.errorColor
+              text: visible ? qsTr('The locally stored cloud project has been corrupted') + '\n' + cloudProjectsModel.layerObserver.deltaFileWrapper.errorString : ''
               wrapMode: Text.WordWrap
-              color: autoPush.checked ? Theme.mainTextColor : Theme.secondaryTextColor
+              horizontalAlignment: Text.AlignHCenter
+              Layout.bottomMargin: 20
+              Layout.fillWidth: true
+            }
 
-              text: qsTr('Automatically push changes every %n minute(s)', '', 0 + (cloudProjectsModel.currentProject ? cloudProjectsModel.currentProject.autoPushIntervalMins : 0))
+            ColumnLayout {
+              id: cloudActions
+              Layout.fillWidth: true
+              Layout.bottomMargin: 10
+              spacing: 10
+              visible: cloudProjectGrid.hasDeltaFileWrapper && !cloudProjectGrid.hasDeltaError
 
-              MouseArea {
-                anchors.fill: parent
-                onClicked: {
-                  if (cloudProjectsModel.currentProject) {
-                    if (!!cloudProjectsModel.currentProject.forceAutoPush) {
-                      displayToast(qsTr('The current project does not allow for auto-push to be turned off'));
-                    } else {
-                      cloudProjectsModel.currentProject.autoPushEnabled = !autoPush.checked;
+              QfActionCard {
+                id: uploadCard
+                Layout.fillWidth: true
+                accentColor: Theme.cloudColor
+                iconSource: Theme.getThemeVectorIcon('ic_cloud_upload_24dp')
+                title: qsTr('Upload local changes')
+                badgeText: cloudProjectGrid.changesCount > 0 ? cloudProjectGrid.changesCount : ''
+                description: qsTr('Sends your edits and attachments to the cloud without downloading project updates. Fast and low on data.')
+                buttonText: qsTr('Upload')
+                buttonColor: Theme.light
+                buttonEnabled: cloudProjectGrid.canUpload
+                metaText: {
+                  if (!cloudProjectsModel.currentProject) {
+                    return '';
+                  }
+                  const uploadedAt = cloudProjectsModel.currentProject.lastLocalPushDeltas;
+                  const timeDeltaMinutes = parseInt(Math.max(new Date() - uploadedAt, 0) / (60 * 1000));
+                  if (isNaN(timeDeltaMinutes)) {
+                    return qsTr('No changes uploaded yet');
+                  } else if (timeDeltaMinutes < 1) {
+                    return qsTr('Last upload just now');
+                  } else if (timeDeltaMinutes < 60) {
+                    return qsTr('Last upload %1 minutes ago').arg(timeDeltaMinutes);
+                  } else if (uploadedAt.toLocaleDateString() === new Date().toLocaleDateString()) {
+                    return qsTr('Last upload today at %1').arg(uploadedAt.toLocaleTimeString(Qt.locale(), Locale.ShortFormat));
+                  }
+                  return qsTr('Last upload on %1').arg(uploadedAt.toLocaleString(Qt.locale(), Locale.ShortFormat));
+                }
+
+                onActionClicked: projectPush(false)
+
+                RowLayout {
+                  Layout.fillWidth: true
+
+                  Label {
+                    id: autoPushText
+                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignVCenter
+                    font: Theme.tipFont
+                    wrapMode: Text.WordWrap
+                    color: autoPush.checked ? Theme.mainTextColor : Theme.secondaryTextColor
+
+                    text: qsTr('Auto-upload every %n minute(s)', '', 0 + (cloudProjectsModel.currentProject ? cloudProjectsModel.currentProject.autoPushIntervalMins : 0))
+
+                    MouseArea {
+                      anchors.fill: parent
+                      onClicked: {
+                        if (cloudProjectsModel.currentProject) {
+                          if (!!cloudProjectsModel.currentProject.forceAutoPush) {
+                            displayToast(qsTr('The current project does not allow for auto-upload to be turned off'));
+                          } else {
+                            cloudProjectsModel.currentProject.autoPushEnabled = !autoPush.checked;
+                          }
+                        }
+                      }
+                    }
+                  }
+
+                  QfSwitch {
+                    id: autoPush
+                    verticalPadding: 0
+                    Layout.preferredWidth: implicitContentWidth
+                    Layout.alignment: Qt.AlignVCenter
+                    enabled: !(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.forceAutoPush)
+                    checked: !!(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.autoPushEnabled)
+
+                    onClicked: {
+                      if (cloudProjectsModel.currentProject) {
+                        cloudProjectsModel.currentProject.autoPushEnabled = checked;
+                      }
                     }
                   }
                 }
               }
-            }
 
-            QfSwitch {
-              id: autoPush
-              Layout.preferredWidth: implicitContentWidth
-              Layout.alignment: Qt.AlignVCenter
-              width: implicitContentWidth
-              enabled: !(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.forceAutoPush)
-              checked: !!(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.autoPushEnabled)
-
-              onClicked: {
-                if (cloudProjectsModel.currentProject) {
-                  cloudProjectsModel.currentProject.autoPushEnabled = checked;
+              QfActionCard {
+                id: synchronizeCard
+                Layout.fillWidth: true
+                accentColor: Theme.mainColor
+                iconSource: Theme.getThemeVectorIcon('ic_cloud_synchronize_24dp')
+                title: qsTr('Synchronize project')
+                indicatorVisible: !!(cloudProjectsModel.currentProject && (cloudProjectsModel.currentProject.isOutdated || cloudProjectsModel.currentProject.isProjectOutdated))
+                description: qsTr('Uploads your edits, then downloads the latest project from QFieldCloud so everything is up to date.')
+                buttonText: qsTr('Synchronize')
+                outlined: true
+                buttonEnabled: cloudProjectGrid.canSynchronize
+                metaText: {
+                  if (!cloudProjectsModel.currentProject) {
+                    return '';
+                  }
+                  const synchronizedAt = cloudProjectsModel.currentProject.lastLocalExportedAt;
+                  const timeDeltaMinutes = parseInt(Math.max(new Date() - synchronizedAt, 0) / (60 * 1000));
+                  if (isNaN(timeDeltaMinutes)) {
+                    return '';
+                  } else if (timeDeltaMinutes < 1) {
+                    return qsTr('Last sync just now');
+                  } else if (timeDeltaMinutes < 60) {
+                    return qsTr('Last sync %1 minutes ago').arg(timeDeltaMinutes);
+                  } else if (synchronizedAt.toLocaleDateString() === new Date().toLocaleDateString()) {
+                    return qsTr('Last sync today at %1').arg(synchronizedAt.toLocaleTimeString(Qt.locale(), Locale.ShortFormat));
+                  }
+                  return qsTr('Last sync on %1').arg(synchronizedAt.toLocaleString(Qt.locale(), Locale.ShortFormat));
                 }
+
+                onActionClicked: projectPush(true)
               }
             }
 
@@ -555,7 +528,7 @@ Popup {
               repeat: true
 
               onRunningChanged: {
-                if (running && pushButton.enabled && cloudProjectsModel.currentProject) {
+                if (running && cloudProjectGrid.canUpload && cloudProjectsModel.currentProject) {
                   const dtStr = cloudProjectsModel.currentProject.lastLocalPushDeltas;
                   if (dtStr) {
                     const dt = new Date(dtStr);
@@ -568,102 +541,113 @@ Popup {
               }
 
               onTriggered: {
-                if (pushButton.enabled) {
+                if (cloudProjectGrid.canUpload) {
                   projectPush(false);
                 }
               }
             }
-          }
 
-          Text {
-            id: lastExportPushText
-            font: Theme.tipFont
-            color: Theme.secondaryTextColor
-            text: {
-              if (!cloudProjectsModel.currentProject) {
-                return '';
-              }
+            RowLayout {
+              Layout.alignment: Qt.AlignHCenter
+              Layout.topMargin: 5
+              Layout.bottomMargin: 10
+              spacing: 40
 
-              let timeDeltaMinutes = 0;
-              let exportText = '';
-              let exportDt = cloudProjectsModel.currentProject.lastLocalExportedAt;
-              timeDeltaMinutes = parseInt(Math.max(new Date() - exportDt, 0) / (60 * 1000));
-              if (!isNaN(timeDeltaMinutes)) {
-                if (timeDeltaMinutes < 1) {
-                  exportText = qsTr('Last synchronized just now');
-                } else if (timeDeltaMinutes < 60) {
-                  exportText = qsTr('Last synchronized %1 minutes ago').arg(timeDeltaMinutes);
-                } else if (exportDt.toLocaleDateString() === new Date().toLocaleDateString()) {
-                  exportText = qsTr('Last synchronized at %1').arg(exportDt.toLocaleTimeString());
-                } else {
-                  exportText = qsTr('Last synchronized on %1').arg(exportDt.toLocaleString());
+              ColumnLayout {
+                spacing: 5
+
+                QfToolButton {
+                  id: uploadHistoryEntryButton
+                  Layout.alignment: Qt.AlignHCenter
+                  round: true
+                  bgcolor: Qt.rgba(Theme.cloudColor.r, Theme.cloudColor.g, Theme.cloudColor.b, 0.1)
+                  iconSource: Theme.getThemeVectorIcon('ic_baseline-list_white_24dp')
+                  iconColor: Theme.cloudColor
+
+                  onClicked: qfieldCloudDeltaHistory.open()
+                }
+
+                Text {
+                  Layout.alignment: Qt.AlignHCenter
+                  font: Theme.tipFont
+                  color: Theme.mainTextColor
+                  text: qsTr('Upload history')
+
+                  MouseArea {
+                    anchors.fill: parent
+                    onClicked: qfieldCloudDeltaHistory.open()
+                  }
                 }
               }
 
-              let pushText = '';
-              let pushDt = cloudProjectsModel.currentProject.lastLocalPushDeltas;
-              timeDeltaMinutes = parseInt(Math.max(new Date() - pushDt, 0) / (60 * 1000));
-              if (!isNaN(timeDeltaMinutes)) {
-                if (timeDeltaMinutes < 1) {
-                  pushText = qsTr('Last changes pushed just now');
-                } else if (timeDeltaMinutes < 60) {
-                  pushText = qsTr('Last changes pushed %1 minutes ago').arg(timeDeltaMinutes);
-                } else if (pushDt.toLocaleDateString() === new Date().toLocaleDateString()) {
-                  pushText = qsTr('Last changes pushed at %1').arg(pushDt.toLocaleTimeString());
-                } else {
-                  pushText = qsTr('Last changes pushed on %1').arg(pushDt.toLocaleString());
+              ColumnLayout {
+                spacing: 5
+
+                QfToolButton {
+                  id: dangerZoneEntryButton
+                  Layout.alignment: Qt.AlignHCenter
+                  round: true
+                  bgcolor: Qt.rgba(Theme.darkRed.r, Theme.darkRed.g, Theme.darkRed.b, 0.1)
+                  iconSource: Theme.getThemeVectorIcon('ic_error_outline_24dp')
+                  iconColor: Theme.darkRed
+
+                  onClicked: swipeView.currentIndex = 1
                 }
-              } else {
-                pushText = qsTr('No changes pushed yet');
-              }
-              return pushDt > exportDt ? pushText + '\n' + exportText : exportText + '\n' + pushText;
-            }
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-            Layout.fillWidth: true
 
-            MouseArea {
-              anchors.fill: parent
-              onClicked: {
-                qfieldCloudDeltaHistory.open();
+                Text {
+                  Layout.alignment: Qt.AlignHCenter
+                  font: Theme.tipFont
+                  color: Theme.mainTextColor
+                  text: qsTr('Danger zone')
+
+                  MouseArea {
+                    anchors.fill: parent
+                    onClicked: swipeView.currentIndex = 1
+                  }
+                }
               }
+            }
+          }
+
+          ColumnLayout {
+            id: connectionSettings
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.topMargin: connectionInformation.visible ? 0 : connectionInformation.childrenRect.height
+            spacing: 2
+
+            visible: (cloudProjectsModel.currentProjectId || popup.pendingAction != "") && cloudConnection.status !== QFieldCloudConnection.LoggedIn
+
+            ScrollView {
+              Layout.fillWidth: true
+              Layout.fillHeight: true
+              Layout.margins: 0
+              height: parent.height
+              ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+              ScrollBar.vertical: QfScrollBar {}
+              contentWidth: qfieldCloudLogin.width
+              contentHeight: qfieldCloudLogin.childrenRect.height
+              clip: true
+
+              QFieldCloudLogin {
+                id: qfieldCloudLogin
+                isVisible: connectionSettings.visible
+                width: parent.parent.width
+                cloudServiceStatus: popup.cloudServiceStatus
+              }
+            }
+
+            Item {
+              Layout.fillHeight: true
+              height: 15
             }
           }
         }
+      }
 
-        ColumnLayout {
-          id: connectionSettings
-          Layout.fillWidth: true
-          Layout.fillHeight: true
-          Layout.topMargin: connectionInformation.visible ? 0 : connectionInformation.childrenRect.height
-          spacing: 2
-
-          visible: (cloudProjectsModel.currentProjectId || popup.pendingAction != "") && cloudConnection.status !== QFieldCloudConnection.LoggedIn
-
-          ScrollView {
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            Layout.margins: 0
-            height: parent.height
-            ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-            ScrollBar.vertical: QfScrollBar {}
-            contentWidth: qfieldCloudLogin.width
-            contentHeight: qfieldCloudLogin.childrenRect.height
-            clip: true
-
-            QFieldCloudLogin {
-              id: qfieldCloudLogin
-              isVisible: connectionSettings.visible
-              width: parent.parent.width
-              cloudServiceStatus: popup.cloudServiceStatus
-            }
-          }
-
-          Item {
-            Layout.fillHeight: true
-            height: 15
-          }
-        }
+      QFieldCloudDangerZone {
+        onDiscardRequested: revertDialog.open()
+        onResetRequested: resetDialog.open()
       }
     }
 
@@ -835,15 +819,16 @@ Popup {
     property int selectedCount: 0
     property bool isDeleted: false
 
-    title: qsTr("Revert local changes")
+    title: qsTr("Discard local changes")
     Label {
       width: parent.width
       wrapMode: Text.WordWrap
-      text: qsTr("Should local changes be reverted?")
+      text: qsTr("Should local changes be discarded?")
     }
 
     onAccepted: {
       revertLocalChangesFromCurrentProject();
+      swipeView.currentIndex = 0;
     }
     onRejected: {
       visible = false;
@@ -867,6 +852,7 @@ Popup {
 
     onAccepted: {
       resetCurrentProject();
+      swipeView.currentIndex = 0;
     }
     onRejected: {
       visible = false;
@@ -917,12 +903,12 @@ Popup {
   function revertLocalChangesFromCurrentProject() {
     if (cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.status === QFieldCloudProject.Idle) {
       if (cloudProjectsModel.revertLocalChangesFromCurrentProject()) {
-        displayToast(qsTr('Local changes reverted'));
+        displayToast(qsTr('Local changes discarded'));
       } else {
-        displayToast(qsTr('Failed to revert changes'), 'error');
+        displayToast(qsTr('Failed to discard changes'), 'error');
       }
     } else {
-      displayToast(qsTr('No changes to revert'));
+      displayToast(qsTr('No changes to discard'));
     }
   }
 

--- a/src/qml/QFieldCloudProjectDetails.qml
+++ b/src/qml/QFieldCloudProjectDetails.qml
@@ -329,7 +329,7 @@ ColumnLayout {
       Layout.preferredWidth: 1
       enabled: cloudProject != undefined && cloudProject.deltaFileWrapper !== undefined && cloudProject.deltasCount > 0 && cloudProject.status === QFieldCloudProject.Idle && !cloudProject.deltaFileWrapper.hasError
       visible: cloudProject != undefined && cloudProject.userRole !== "reader"
-      text: qsTr('Push changes')
+      text: qsTr('Upload local changes')
 
       onClicked: {
         pushChanges();

--- a/src/qml/QFieldCloudScreen.qml
+++ b/src/qml/QFieldCloudScreen.qml
@@ -839,7 +839,7 @@ Page {
       leftPadding: Theme.menuItemLeftPadding
       enabled: projectActions.localDeltasCount > 0
 
-      text: qsTr("Push changes")
+      text: qsTr("Upload local changes")
       onTriggered: {
         cloudProjectsModel.projectPush(projectActions.projectId, false);
       }

--- a/src/qml/QFieldCloudStatusBanner.qml
+++ b/src/qml/QFieldCloudStatusBanner.qml
@@ -35,6 +35,7 @@ QfCollapsibleMessage {
 
   detailsColor: Theme.secondaryTextColor
   font: Theme.tipFont
+  iconSource: Theme.getThemeVectorIcon('ic_error_outline_24dp')
   titleText: cloudServiceStatus ? cloudServiceStatus.statusMessage : ''
   detailsText: cloudServiceStatus ? cloudServiceStatus.detailsMessage : ''
   externalLink: cloudServiceStatus ? cloudServiceStatus.statusPageUrl : ''

--- a/src/qml/imports/Theme/QfActionCard.qml
+++ b/src/qml/imports/Theme/QfActionCard.qml
@@ -1,0 +1,147 @@
+import QtQuick
+import QtQuick.Layouts
+import org.qfield
+import Theme
+
+/**
+ * A card grouping a primary action button with its title, description and
+ * status texts. Extra rows (e.g. a toggle) can be added as children and are
+ * placed below the action button.
+ *
+ * \ingroup qml
+ */
+Rectangle {
+  id: actionCard
+
+  property color accentColor: Theme.mainColor
+  property alias iconSource: cardIcon.iconSource
+  property alias title: titleLabel.text
+  property alias description: descriptionLabel.text
+  property alias badgeText: badgeLabel.text
+  property alias metaText: metaLabel.text
+  property alias indicatorVisible: indicator.visible
+  property alias buttonText: actionButton.text
+  property color buttonColor: Theme.buttonColor
+  property alias buttonEnabled: actionButton.enabled
+  property alias buttonShowProgress: actionButton.showProgress
+  property alias buttonProgressValue: actionButton.progressValue
+
+  // Draw the action button as an accent-colored outline instead of a filled background
+  property bool outlined: false
+
+  default property alias extraContent: extraContentColumn.data
+
+  signal actionClicked
+
+  implicitHeight: cardColumn.implicitHeight + 32
+  radius: 12
+  color: Theme.groupBoxBackgroundColor
+  border.width: 1
+  border.color: Theme.controlBorderColor
+
+  ColumnLayout {
+    id: cardColumn
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.verticalCenter: parent.verticalCenter
+    anchors.leftMargin: 16
+    anchors.rightMargin: 16
+    spacing: 6
+
+    RowLayout {
+      Layout.fillWidth: true
+      spacing: 8
+
+      QfToolButton {
+        id: cardIcon
+        Layout.preferredWidth: 24
+        Layout.preferredHeight: 24
+        Layout.alignment: Qt.AlignVCenter
+        padding: 0
+        icon.width: 22
+        icon.height: 22
+        visible: iconSource !== ''
+        enabled: false
+        bgcolor: "transparent"
+        iconColor: actionCard.accentColor
+      }
+
+      Text {
+        id: titleLabel
+        font: Theme.strongFont
+        color: Theme.mainTextColor
+        wrapMode: Text.WordWrap
+      }
+
+      Rectangle {
+        Layout.alignment: Qt.AlignVCenter
+        implicitWidth: Math.max(implicitHeight, badgeLabel.implicitWidth + 10)
+        implicitHeight: badgeLabel.implicitHeight + 4
+        radius: height / 2
+        color: actionCard.accentColor
+        visible: badgeLabel.text !== ""
+
+        Text {
+          id: badgeLabel
+          anchors.centerIn: parent
+          font: Theme.tinyFont
+          color: Theme.light
+        }
+      }
+
+      Rectangle {
+        id: indicator
+        Layout.alignment: Qt.AlignVCenter
+        width: 10
+        height: 10
+        radius: width / 2
+        color: actionCard.accentColor
+        visible: false
+      }
+
+      Item {
+        Layout.fillWidth: true
+      }
+    }
+
+    Text {
+      id: descriptionLabel
+      Layout.fillWidth: true
+      font: Theme.tipFont
+      color: Theme.secondaryTextColor
+      linkColor: Theme.mainColor
+      wrapMode: Text.WordWrap
+      visible: text !== ""
+      textFormat: Text.StyledText
+
+      onLinkActivated: link => Qt.openUrlExternally(link)
+    }
+
+    Text {
+      id: metaLabel
+      Layout.fillWidth: true
+      font: Theme.tipFont
+      color: Theme.secondaryTextColor
+      opacity: 0.75
+      wrapMode: Text.WordWrap
+      visible: text !== ""
+    }
+
+    QfButton {
+      id: actionButton
+      Layout.fillWidth: true
+      Layout.topMargin: 4
+      bgcolor: actionCard.outlined ? "transparent" : actionCard.accentColor
+      color: actionCard.outlined ? actionCard.accentColor : actionCard.buttonColor
+
+      onClicked: actionCard.actionClicked()
+    }
+
+    ColumnLayout {
+      id: extraContentColumn
+      Layout.fillWidth: true
+      spacing: 8
+      visible: children.length > 0
+    }
+  }
+}

--- a/src/qml/imports/Theme/QfCollapsibleMessage.qml
+++ b/src/qml/imports/Theme/QfCollapsibleMessage.qml
@@ -8,9 +8,12 @@ import org.qfield
  * \ingroup qml
  */
 Item {
+  id: collapsibleMessage
+
   property bool collapsed: true
   property string externalLink: ""
-  property alias color: titleText.color
+  property color color: Theme.mainTextColor
+  property alias iconSource: messageIcon.iconSource
   property alias detailsColor: detailsText.color
   property alias font: titleText.font
   property alias titleText: titleText.text
@@ -30,11 +33,20 @@ Item {
   Rectangle {
     id: background
     anchors.fill: parent
-    color: "transparent"
-    border.color: titleText.color
+    color: Qt.rgba(collapsibleMessage.color.r, collapsibleMessage.color.g, collapsibleMessage.color.b, 0.1)
+    border.color: collapsibleMessage.color
     border.width: 1
-    opacity: 0.25
-    radius: 12
+    radius: 8
+  }
+
+  QfToolButton {
+    id: messageIcon
+    visible: iconSource !== ''
+    anchors.left: parent.left
+    anchors.verticalCenter: titleText.verticalCenter
+    enabled: false
+    bgcolor: "transparent"
+    iconColor: collapsibleMessage.color
   }
 
   Text {
@@ -42,12 +54,12 @@ Item {
     width: parent.width - 5
     anchors.top: parent.top
     anchors.left: parent.left
-    leftPadding: 8
+    leftPadding: messageIcon.visible ? messageIcon.width + 2 : 8
     topPadding: 10
     bottomPadding: 10
     clip: true
     font: Theme.defaultFont
-    color: "black"
+    color: Theme.mainTextColor
     horizontalAlignment: Text.AlignLeft
     wrapMode: Text.WordWrap
   }
@@ -70,7 +82,7 @@ Item {
     background: Rectangle {
       implicitWidth: 30
       implicitHeight: 30
-      color: titleText.color
+      color: collapsibleMessage.color
       radius: background.radius
     }
   }
@@ -81,7 +93,8 @@ Item {
     anchors.top: titleText.bottom
     anchors.horizontalCenter: parent.horizontalCenter
     height: 1
-    color: titleText.color
+    visible: detailsText.text !== ''
+    color: collapsibleMessage.color
     opacity: 0.25
   }
 
@@ -107,7 +120,9 @@ Item {
     id: mainMouseArea
     anchors.fill: parent
     onClicked: {
-      parent.collapsed = !parent.collapsed;
+      if (detailsText.text !== '') {
+        parent.collapsed = !parent.collapsed;
+      }
     }
   }
 }

--- a/src/qml/imports/Theme/QfContainerCard.qml
+++ b/src/qml/imports/Theme/QfContainerCard.qml
@@ -83,8 +83,8 @@ Rectangle {
       Rectangle {
         id: indicator
         Layout.alignment: Qt.AlignVCenter
-        width: 10
-        height: 10
+        width: badgeLabel.implicitHeight + 4
+        height: width
         radius: width / 2
         color: containerCard.accentColor
         visible: false

--- a/src/qml/imports/Theme/QfContainerCard.qml
+++ b/src/qml/imports/Theme/QfContainerCard.qml
@@ -4,34 +4,24 @@ import org.qfield
 import Theme
 
 /**
- * A card grouping a primary action button with its title, description and
- * status texts. Extra rows (e.g. a toggle) can be added as children and are
- * placed below the action button.
+ * A card grouping a title, description and status texts. Content (e.g. an
+ * action button or a toggle) can be added as children and is placed below
+ * the texts.
  *
  * \ingroup qml
  */
 Rectangle {
-  id: actionCard
+  id: containerCard
 
   property color accentColor: Theme.mainColor
   property alias iconSource: cardIcon.iconSource
   property alias title: titleLabel.text
   property alias description: descriptionLabel.text
-  property alias badgeText: badgeLabel.text
-  property alias metaText: metaLabel.text
+  property int count: 0
+  property alias footnote: footnoteLabel.text
   property alias indicatorVisible: indicator.visible
-  property alias buttonText: actionButton.text
-  property color buttonColor: Theme.buttonColor
-  property alias buttonEnabled: actionButton.enabled
-  property alias buttonShowProgress: actionButton.showProgress
-  property alias buttonProgressValue: actionButton.progressValue
-
-  // Draw the action button as an accent-colored outline instead of a filled background
-  property bool outlined: false
 
   default property alias extraContent: extraContentColumn.data
-
-  signal actionClicked
 
   implicitHeight: cardColumn.implicitHeight + 32
   radius: 12
@@ -63,7 +53,7 @@ Rectangle {
         visible: iconSource !== ''
         enabled: false
         bgcolor: "transparent"
-        iconColor: actionCard.accentColor
+        iconColor: containerCard.accentColor
       }
 
       Text {
@@ -78,14 +68,15 @@ Rectangle {
         implicitWidth: Math.max(implicitHeight, badgeLabel.implicitWidth + 10)
         implicitHeight: badgeLabel.implicitHeight + 4
         radius: height / 2
-        color: actionCard.accentColor
-        visible: badgeLabel.text !== ""
+        color: containerCard.accentColor
+        visible: containerCard.count > 0
 
         Text {
           id: badgeLabel
           anchors.centerIn: parent
           font: Theme.tinyFont
           color: Theme.light
+          text: containerCard.count
         }
       }
 
@@ -95,7 +86,7 @@ Rectangle {
         width: 10
         height: 10
         radius: width / 2
-        color: actionCard.accentColor
+        color: containerCard.accentColor
         visible: false
       }
 
@@ -118,7 +109,7 @@ Rectangle {
     }
 
     Text {
-      id: metaLabel
+      id: footnoteLabel
       Layout.fillWidth: true
       font: Theme.tipFont
       color: Theme.secondaryTextColor
@@ -127,20 +118,10 @@ Rectangle {
       visible: text !== ""
     }
 
-    QfButton {
-      id: actionButton
-      Layout.fillWidth: true
-      Layout.topMargin: 4
-      bgcolor: actionCard.outlined ? "transparent" : actionCard.accentColor
-      color: actionCard.outlined ? actionCard.accentColor : actionCard.buttonColor
-
-      onClicked: actionCard.actionClicked()
-    }
-
     ColumnLayout {
       id: extraContentColumn
       Layout.fillWidth: true
-      spacing: 8
+      spacing: 6
       visible: children.length > 0
     }
   }

--- a/src/qml/imports/Theme/QfExpandableGroupBox.qml
+++ b/src/qml/imports/Theme/QfExpandableGroupBox.qml
@@ -10,8 +10,10 @@ Rectangle {
   id: expandableGroupBox
   implicitHeight: checked ? header.height + body.childrenRect.height + 30 : 60
 
-  radius: 8
+  radius: 12
   color: Theme.groupBoxBackgroundColor
+  border.width: 1
+  border.color: Theme.controlBorderColor
   clip: true
 
   property alias title: headerText.text
@@ -49,6 +51,8 @@ Rectangle {
         width: 24
         height: 24
         padding: 0
+        icon.width: 24
+        icon.height: 24
         anchors.verticalCenter: headerText.verticalCenter
         anchors.left: parent.left
         enabled: false
@@ -90,7 +94,7 @@ Rectangle {
     width: parent.width
     height: 1
     anchors.top: header.bottom
-    color: Theme.groupBoxSurfaceColor
+    color: Theme.controlBorderColor
   }
 
   Item {

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -1,5 +1,6 @@
 module Theme
 QfActionButton 1.0 QfActionButton.qml
+QfActionCard 1.0 QfActionCard.qml
 QfBadge 1.0 QfBadge.qml
 QfButton 1.0 QfButton.qml
 QfCalendarPanel 1.0 QfCalendarPanel.qml

--- a/src/qml/imports/Theme/qmldir
+++ b/src/qml/imports/Theme/qmldir
@@ -1,6 +1,6 @@
 module Theme
 QfActionButton 1.0 QfActionButton.qml
-QfActionCard 1.0 QfActionCard.qml
+QfContainerCard 1.0 QfContainerCard.qml
 QfBadge 1.0 QfBadge.qml
 QfButton 1.0 QfButton.qml
 QfCalendarPanel 1.0 QfCalendarPanel.qml

--- a/src/qml/qgismobileapp.qml
+++ b/src/qml/qgismobileapp.qml
@@ -5777,7 +5777,7 @@ ApplicationWindow {
       {
         "type": "information",
         "title": qsTr("QFieldCloud"),
-        "description": qsTr("Push changes, synchronize or revert changes to and from QFieldCloud when a cloud project is opened."),
+        "description": qsTr("Upload local changes, synchronize or discard changes to and from QFieldCloud when a cloud project is opened."),
         "target": () => [iface.findItemByObjectName('cloudButton')]
       },
       {

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -153,6 +153,7 @@
         <file>QFieldCloudLogin.qml</file>
         <file>QFieldCloudScreen.qml</file>
         <file>QFieldCloudPopup.qml</file>
+        <file>QFieldCloudDangerZone.qml</file>
         <file>QFieldCloudStatusBanner.qml</file>
         <file>QFieldCloudDeltaHistory.qml</file>
         <file>QFieldCloudPackageLayersFeedback.qml</file>

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -109,7 +109,7 @@
         <file>Nyuki.qml</file>
         <file>LayerLoginDialog.qml</file>
         <file>imports/Theme/QfActionButton.qml</file>
-        <file>imports/Theme/QfActionCard.qml</file>
+        <file>imports/Theme/QfContainerCard.qml</file>
         <file>imports/Theme/QfButton.qml</file>
         <file>imports/Theme/QfComboBox.qml</file>
         <file>imports/Theme/QfDropShadow.qml</file>

--- a/src/qml/qml.qrc
+++ b/src/qml/qml.qrc
@@ -109,6 +109,7 @@
         <file>Nyuki.qml</file>
         <file>LayerLoginDialog.qml</file>
         <file>imports/Theme/QfActionButton.qml</file>
+        <file>imports/Theme/QfActionCard.qml</file>
         <file>imports/Theme/QfButton.qml</file>
         <file>imports/Theme/QfComboBox.qml</file>
         <file>imports/Theme/QfDropShadow.qml</file>


### PR DESCRIPTION
### 🚀 Description

This PR reworks the QFieldCloud project popup (`QFieldCloudPopup`) into a clearer, card-based layout and moves destructive actions into a dedicated, isolated panel (Danger zone).

### ✨ Key Changes

- **Danger zone** Extracted the destructive actions (*Discard local changes*) into a  new `QFieldCloudDangerZone` component.
- `QFieldCloudDeltaHistory` uses `QfCollapsibleMessage` for entries and gains a proper loading indicator and empty state.
  
**Terminology**
- *Push changes* → **Upload local changes**
- *Revert local changes* → **Discard local changes**
- *Push History* → **Upload History**

---

_Also minor project creation icon bug fixed_

---
### Demos

**New Look**


<img width="844" height="832" alt="image" src="https://github.com/user-attachments/assets/7214ca95-47b9-4c1d-960d-698fb4db849c" />



**Same in Cloudify!**


<img width="865" height="854" alt="image" src="https://github.com/user-attachments/assets/b6970a55-21cf-45c7-89f5-e14546cf917c" />

**And Danger zone!**


https://github.com/user-attachments/assets/adac2ab4-8c4c-41c6-b3ec-500e15b082d3



**And Upload History!**


https://github.com/user-attachments/assets/135b9919-76b7-4d4a-a5ab-ed71995f06dd

