### PR TITLE
Support embedded and remote images for photo stamping decoration

### DIFF
--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -456,19 +456,24 @@ void FileUtils::addImageStamp( const QString &imagePath, const QString &text, co
 
     if ( !imageDecoration.isEmpty() )
     {
-      const QFileInfo fi( QgsProject::instance()->pathResolver().readPath( imageDecoration ) );
-      if ( fi.exists() )
+      const bool isEmbedded = imageDecoration.startsWith( QLatin1String( "base64:" ), Qt::CaseInsensitive );
+      const bool isRemote = imageDecoration.startsWith( QLatin1String( "http" ), Qt::CaseInsensitive );
+      const QString decorationSource = ( isEmbedded || isRemote )
+                                         ? imageDecoration
+                                         : QgsProject::instance()->pathResolver().readPath( imageDecoration );
+
+      if ( isEmbedded || isRemote || QFileInfo::exists( decorationSource ) )
       {
         const double lineHeight = context.convertFromPainterUnits( format.size(), format.sizeUnit() );
-        const bool isRaster = fi.suffix().toLower() != QStringLiteral( "svg" );
+        const bool isRaster = isEmbedded || isRemote || QFileInfo( decorationSource ).suffix().toLower() != QStringLiteral( "svg" );
 
         bool fitsInCache = false;
         if ( isRaster )
         {
-          const QSizeF decorationOriginalSize = QgsApplication::instance()->imageCache()->originalSize( fi.absoluteFilePath(), true );
+          const QSizeF decorationOriginalSize = QgsApplication::instance()->imageCache()->originalSize( decorationSource, true );
           const double decorationHeight = std::min( std::min( decorationOriginalSize.height(), img.height() / 6.0 ), lineHeight * 10.0 );
           const double decorationWidth = decorationOriginalSize.width() * decorationHeight / decorationOriginalSize.height();
-          QImage decorationImage = QgsApplication::instance()->imageCache()->pathAsImage( fi.absoluteFilePath(), QSize( decorationWidth, decorationHeight ), true, 1, fitsInCache, true );
+          QImage decorationImage = QgsApplication::instance()->imageCache()->pathAsImage( decorationSource, QSize( decorationWidth, decorationHeight ), true, 1, fitsInCache, true );
           switch ( horizontalAlignment )
           {
             case Qgis::TextHorizontalAlignment::Left:
@@ -485,10 +490,10 @@ void FileUtils::addImageStamp( const QString &imagePath, const QString &text, co
         }
         else
         {
-          const QSizeF decorationOriginalSize = QgsApplication::instance()->svgCache()->svgViewboxSize( fi.absoluteFilePath(), 100, QColor( 0, 0, 0 ), QColor( 255, 0, 0 ), 10, 1, 0, true );
+          const QSizeF decorationOriginalSize = QgsApplication::instance()->svgCache()->svgViewboxSize( decorationSource, 100, QColor( 0, 0, 0 ), QColor( 255, 0, 0 ), 10, 1, 0, true );
           const double decorationHeight = std::min( img.height() / 6.0, lineHeight * 10.0 );
           const double decorationWidth = decorationOriginalSize.width() * decorationHeight / decorationOriginalSize.height();
-          QPicture decorationPicture = QgsApplication::instance()->svgCache()->svgAsPicture( fi.absoluteFilePath(), decorationWidth, QColor(), QColor(), 1.0, 1, fitsInCache, 0, true );
+          QPicture decorationPicture = QgsApplication::instance()->svgCache()->svgAsPicture( decorationSource, decorationWidth, QColor(), QColor(), 1.0, 1, fitsInCache, 0, true );
           switch ( horizontalAlignment )
           {
             case Qgis::TextHorizontalAlignment::Left:

--- a/src/core/utils/fileutils.cpp
+++ b/src/core/utils/fileutils.cpp
@@ -465,7 +465,17 @@ void FileUtils::addImageStamp( const QString &imagePath, const QString &text, co
       if ( isEmbedded || isRemote || QFileInfo::exists( decorationSource ) )
       {
         const double lineHeight = context.convertFromPainterUnits( format.size(), format.sizeUnit() );
-        const bool isRaster = isEmbedded || isRemote || QFileInfo( decorationSource ).suffix().toLower() != QStringLiteral( "svg" );
+
+        bool isRaster = true;
+        if ( isEmbedded )
+        {
+          const QByteArray decoded = QByteArray::fromBase64( decorationSource.mid( 7 ).toUtf8() );
+          isRaster = QMimeDatabase().mimeTypeForData( decoded ).name() != QLatin1String( "image/svg+xml" );
+        }
+        else
+        {
+          isRaster = QFileInfo( decorationSource ).suffix().toLower() != QStringLiteral( "svg" );
+        }
 
         bool fitsInCache = false;
         if ( isRaster )


### PR DESCRIPTION
Qfield photo stamping could only load a decoration logo from a file on disk. If the image was embedded directly in the project or pointed to a URL, it was silently ignored

It's the QField side of https://github.com/opengisch/qfieldsync/pull/819 , which adds the "Embed File" and "From URL" options to the stamping settings. 

https://github.com/user-attachments/assets/ef1053cb-3b4f-46f2-8d9b-808e47a82d01