### PR TITLE
Move QgisMobileapp into src/app behind an AppController interface

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -62,6 +62,24 @@ find_package(
   COMPONENTS Core5Compat
   REQUIRED)
 
+set(QFIELD_APP_SRCS qgismobileapp.cpp)
+set(QFIELD_APP_HDRS qgismobileapp.h)
+
+add_library(qfield_app STATIC ${QFIELD_APP_SRCS} ${QFIELD_APP_HDRS})
+
+include(GenerateExportHeader)
+generate_export_header(qfield_app)
+
+target_include_directories(qfield_app SYSTEM PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+
+target_include_directories(qfield_app PUBLIC ${CMAKE_SOURCE_DIR}/src/app)
+
+target_compile_features(qfield_app PUBLIC cxx_std_20)
+
+set_target_properties(qfield_app PROPERTIES AUTOMOC TRUE)
+
+target_link_libraries(qfield_app PUBLIC qfield_core)
+
 function(create_executable)
   cmake_parse_arguments(exe "" "TARGET" "EXTRA_ARGS" "" ${ARGN})
 
@@ -100,7 +118,7 @@ function(create_executable)
     FILES
     ${QM_FILES})
 
-  target_link_libraries(${exe_TARGET} PRIVATE qfield_core qfield_qml)
+  target_link_libraries(${exe_TARGET} PRIVATE qfield_app qfield_core qfield_qml)
 
   if(ANDROID)
     target_link_libraries(${exe_TARGET} PRIVATE qfield_service)

--- a/src/app/qgismobileapp.cpp
+++ b/src/app/qgismobileapp.cpp
@@ -225,7 +225,7 @@
 
 QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   : QQmlApplicationEngine( parent )
-  , mIface( new AppInterface( this ) )
+  , mIface( new AppInterface( this, this ) )
   , mFirstRenderingFlag( true )
   , mApp( app )
 {

--- a/src/app/qgismobileapp.h
+++ b/src/app/qgismobileapp.h
@@ -29,6 +29,7 @@
 #include <qgsunittypes.h>
 
 // QField includes
+#include "appcontroller.h"
 #include "appcoordinateoperationhandlers.h"
 #include "bookmarkmodel.h"
 #include "clipboardmanager.h"
@@ -36,7 +37,7 @@
 #include "drawingtemplatemodel.h"
 #include "focusstack.h"
 #include "pluginmanager.h"
-#include "qfield_core_export.h"
+#include "qfield_app_export.h"
 #include "qfieldappauthrequesthandler.h"
 #include "qfieldurlhandler.h"
 #include "qgsgpkgflusher.h"
@@ -66,14 +67,14 @@ class QgsPrintLayout;
 #define REGISTER_SINGLETON( uri, _class, name ) qmlRegisterSingletonType<_class>( uri, 1, 0, name, []( QQmlEngine *engine, QJSEngine *scriptEngine ) -> QObject * { Q_UNUSED(engine); Q_UNUSED(scriptEngine); return new _class(); } )
 
 /**
- * \defgroup core
- * \brief QField C++ classes
+ * \defgroup app
+ * \brief QField application C++ classes
  */
 
 /**
- * \ingroup core
+ * \ingroup app
  */
-class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
+class QFIELD_APP_EXPORT QgisMobileapp : public QQmlApplicationEngine, public AppController
 {
     Q_OBJECT
   public:
@@ -87,7 +88,7 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
      * \param name The project name
      * \note The actual loading is done in readProjectFile
      */
-    bool loadProjectFile( const QString &path, const QString &name = QString() );
+    bool loadProjectFile( const QString &path, const QString &name = QString() ) override;
 
     /**
      * Reloads the current project
@@ -95,12 +96,12 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
      * \note It does not reset the Auth Request Handler.
      * \note The actual loading is done in readProjectFile
      */
-    void reloadProjectFile();
+    void reloadProjectFile() override;
 
     /**
      * Reads and opens the project file set in the loadProjectFile function
      */
-    void readProjectFile();
+    void readProjectFile() override;
 
     /**
      * Reads a string from the specified \a scope and \a key from the currently opened project
@@ -111,7 +112,7 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
      *
      * \returns entry value as string from \a scope given its \a key
      */
-    QString readProjectEntry( const QString &scope, const QString &key, const QString &def = QString() ) const;
+    QString readProjectEntry( const QString &scope, const QString &key, const QString &def = QString() ) const override;
 
     /**
      * Reads an integer from the specified \a scope and \a key from the currently opened project
@@ -122,7 +123,7 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
      *
      * \returns entry value as integer from \a scope given its \a key
      */
-    int readProjectNumEntry( const QString &scope, const QString &key, int def = 0 ) const;
+    int readProjectNumEntry( const QString &scope, const QString &key, int def = 0 ) const override;
 
     /**
      * Reads a double from the specified \a scope and \a key from the currently opened project
@@ -133,7 +134,7 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
      *
      * \returns entry value as double from \a scope given its \a key
      */
-    double readProjectDoubleEntry( const QString &scope, const QString &key, double def = 0.0 ) const;
+    double readProjectDoubleEntry( const QString &scope, const QString &key, double def = 0.0 ) const override;
 
     /**
      * Reads a boolean from the specified \a scope and \a key from the currently opened project
@@ -144,14 +145,14 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
      *
      * \returns entry value as boolean from \a scope given its \a key
      */
-    bool readProjectBoolEntry( const QString &scope, const QString &key, bool def = false ) const;
+    bool readProjectBoolEntry( const QString &scope, const QString &key, bool def = false ) const override;
 
     /**
      * Prints a given layout from the currently opened project to a PDF file
      * \param layoutName the layout name that will be printed
      * \return TRUE if the layout was successfully printed
      */
-    bool print( const QString &layoutName );
+    bool print( const QString &layoutName ) override;
 
     /**
      * Prints a given atlas-driven layout from the currently opened project to one or more PDF files
@@ -159,20 +160,20 @@ class QFIELD_CORE_EXPORT QgisMobileapp : public QQmlApplicationEngine
      * \param featureIds the features from the atlas coverage vector layer that will be used to print the layout
      * \return TRUE if the layout was successfully printed
      */
-    bool printAtlasFeatures( const QString &layoutName, const QList<long long> &featureIds );
+    bool printAtlasFeatures( const QString &layoutName, const QList<long long> &featureIds ) override;
 
     /**
      * Sets the screen dimmer timeout in seconds
      * \note setting the timeout value to 0 will disable the screen dimmer
      */
-    void setScreenDimmerTimeout( int timeoutSeconds );
+    void setScreenDimmerTimeout( int timeoutSeconds ) override;
 
     bool event( QEvent *event ) override;
 
     /**
      * Clear the currently opened project back to a blank project
      */
-    void clearProject();
+    void clearProject() override;
 
     static void initDeclarative( QQmlEngine *engine );
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -130,7 +130,6 @@ set(QFIELD_CORE_SRCS
     qfieldappauthrequesthandler.cpp
     qfieldurlhandler.cpp
     qfieldxmlhttprequest.cpp
-    qgismobileapp.cpp
     qgsgeometrywrapper.cpp
     qgsgpkgflusher.cpp
     recentprojectlistmodel.cpp
@@ -223,6 +222,7 @@ set(QFIELD_CORE_HDRS
     qfieldcloud/qfieldcloudproject.h
     qfieldcloud/qfieldcloudprojectsmodel.h
     qfieldcloud/qfieldcloudstatus.h
+    appcontroller.h
     appcoordinateoperationhandlers.h
     appexpressioncontextscopesgenerator.h
     appinterface.h
@@ -285,7 +285,6 @@ set(QFIELD_CORE_HDRS
     qfieldappauthrequesthandler.h
     qfieldurlhandler.h
     qfieldxmlhttprequest.h
-    qgismobileapp.h
     qgsgeometrywrapper.h
     qgsgpkgflusher.h
     recentprojectlistmodel.h

--- a/src/core/appcontroller.h
+++ b/src/core/appcontroller.h
@@ -1,0 +1,72 @@
+/***************************************************************************
+  appcontroller.h - AppController
+
+---------------------
+begin                : 19.7.2026
+copyright            : (C) 2026 by Mohsen Dehghanzadeh
+email                : info@opengis.ch
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef APPCONTROLLER_H
+#define APPCONTROLLER_H
+
+#include <QList>
+#include <QString>
+
+/**
+ * \defgroup core
+ * \brief QField C++ classes
+ */
+
+/**
+ * \brief Application operations that AppInterface delegates to the app.
+ *
+ * \ingroup core
+ */
+class AppController
+{
+  public:
+    virtual ~AppController() = default;
+
+    //! Loads a project file (.qgs/.qgz) or standalone dataset from \a path, labelled \a name.
+    virtual bool loadProjectFile( const QString &path, const QString &name = QString() ) = 0;
+
+    //! Reloads the currently opened project.
+    virtual void reloadProjectFile() = 0;
+
+    //! Reads the content of the loaded project.
+    virtual void readProjectFile() = 0;
+
+    //! Reads a string project entry at \a scope / \a key (\a def if absent).
+    virtual QString readProjectEntry( const QString &scope, const QString &key, const QString &def = QString() ) const = 0;
+
+    //! Reads an int project entry at \a scope / \a key (\a def if absent).
+    virtual int readProjectNumEntry( const QString &scope, const QString &key, int def = 0 ) const = 0;
+
+    //! Reads a double project entry at \a scope / \a key (\a def if absent).
+    virtual double readProjectDoubleEntry( const QString &scope, const QString &key, double def = 0.0 ) const = 0;
+
+    //! Reads a bool project entry at \a scope / \a key (\a def if absent).
+    virtual bool readProjectBoolEntry( const QString &scope, const QString &key, bool def = false ) const = 0;
+
+    //! Prints the project layout matching \a layoutName to PDF.
+    virtual bool print( const QString &layoutName ) = 0;
+
+    //! Prints the atlas-driven layout \a layoutName for \a featureIds to PDF.
+    virtual bool printAtlasFeatures( const QString &layoutName, const QList<long long> &featureIds ) = 0;
+
+    //! Sets the screen dimmer timeout in seconds (0 disables dimming).
+    virtual void setScreenDimmerTimeout( int timeoutSeconds ) = 0;
+
+    //! Clears the currently opened project.
+    virtual void clearProject() = 0;
+};
+
+#endif // APPCONTROLLER_H

--- a/src/core/appinterface.cpp
+++ b/src/core/appinterface.cpp
@@ -15,12 +15,12 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "appcontroller.h"
 #include "appinterface.h"
 #include "fileutils.h"
 #include "platformutilities.h"
 #include "qfield.h"
 #include "qfieldxmlhttprequest.h"
-#include "qgismobileapp.h"
 #include "translatormanager.h"
 #if WITH_SENTRY
 #include "sentry_wrapper.h"
@@ -47,14 +47,10 @@
 
 AppInterface *AppInterface::sAppInterface = nullptr;
 
-AppInterface::AppInterface( QQmlEngine *engine )
+AppInterface::AppInterface( QQmlEngine *engine, AppController *controller )
   : mEngine( engine )
+  , mController( controller )
 {
-}
-
-QgisMobileapp *AppInterface::app() const
-{
-  return qobject_cast<QgisMobileapp *>( mEngine );
 }
 
 QObject *AppInterface::rootObject() const
@@ -216,80 +212,70 @@ bool AppInterface::hasProjectOnLaunch() const
 bool AppInterface::loadFile( const QString &path, const QString &name )
 {
   qInfo() << QStringLiteral( "AppInterface loading file: %1" ).arg( path );
-  QgisMobileapp *mobileApp = app();
-  if ( !mobileApp )
+  if ( !mController )
   {
     return false;
   }
   if ( QFileInfo::exists( path ) )
   {
-    return mobileApp->loadProjectFile( path, name );
+    return mController->loadProjectFile( path, name );
   }
 
   const QUrl url( path );
-  return mobileApp->loadProjectFile( url.isLocalFile() ? url.toLocalFile() : url.path(), name );
+  return mController->loadProjectFile( url.isLocalFile() ? url.toLocalFile() : url.path(), name );
 }
 
 void AppInterface::reloadProject()
 {
-  QgisMobileapp *mobileApp = app();
-  if ( mobileApp )
+  if ( mController )
   {
-    mobileApp->reloadProjectFile();
+    mController->reloadProjectFile();
   }
 }
 
 void AppInterface::readProject()
 {
-  QgisMobileapp *mobileApp = app();
-  if ( mobileApp )
+  if ( mController )
   {
-    mobileApp->readProjectFile();
+    mController->readProjectFile();
   }
 }
 
 QString AppInterface::readProjectEntry( const QString &scope, const QString &key, const QString &def ) const
 {
-  const QgisMobileapp *mobileApp = app();
-  return mobileApp ? mobileApp->readProjectEntry( scope, key, def ) : def;
+  return mController ? mController->readProjectEntry( scope, key, def ) : def;
 }
 
 int AppInterface::readProjectNumEntry( const QString &scope, const QString &key, int def ) const
 {
-  const QgisMobileapp *mobileApp = app();
-  return mobileApp ? mobileApp->readProjectNumEntry( scope, key, def ) : def;
+  return mController ? mController->readProjectNumEntry( scope, key, def ) : def;
 }
 
 double AppInterface::readProjectDoubleEntry( const QString &scope, const QString &key, double def ) const
 {
-  const QgisMobileapp *mobileApp = app();
-  return mobileApp ? mobileApp->readProjectDoubleEntry( scope, key, def ) : def;
+  return mController ? mController->readProjectDoubleEntry( scope, key, def ) : def;
 }
 
 bool AppInterface::readProjectBoolEntry( const QString &scope, const QString &key, bool def ) const
 {
-  const QgisMobileapp *mobileApp = app();
-  return mobileApp ? mobileApp->readProjectBoolEntry( scope, key, def ) : def;
+  return mController ? mController->readProjectBoolEntry( scope, key, def ) : def;
 }
 
 bool AppInterface::print( const QString &layoutName )
 {
-  QgisMobileapp *mobileApp = app();
-  return mobileApp ? mobileApp->print( layoutName ) : false;
+  return mController ? mController->print( layoutName ) : false;
 }
 
 bool AppInterface::printAtlasFeatures( const QString &layoutName, const QList<long long> &featureIds )
 {
-  QgisMobileapp *mobileApp = app();
-  return mobileApp ? mobileApp->printAtlasFeatures( layoutName, featureIds ) : false;
+  return mController ? mController->printAtlasFeatures( layoutName, featureIds ) : false;
 }
 
 void AppInterface::setScreenDimmerTimeout( int timeoutSeconds )
 {
-  QgisMobileapp *mobileApp = app();
-  if ( mobileApp )
+  if ( mController )
   {
-    mobileApp->setScreenDimmerTimeout( timeoutSeconds );
+    mController->setScreenDimmerTimeout( timeoutSeconds );
   }
 }
 
@@ -376,10 +362,9 @@ void AppInterface::changeLanguage( const QString &languageCode )
     QgsApplication::setLocale( systemLocale );
   }
 
-  QgisMobileapp *mobileApp = app();
-  if ( mobileApp )
+  if ( mEngine )
   {
-    mobileApp->retranslate();
+    mEngine->retranslate();
   }
 }
 
@@ -423,10 +408,9 @@ void AppInterface::closeSentry() const
 
 void AppInterface::clearProject() const
 {
-  QgisMobileapp *mobileApp = app();
-  if ( mobileApp )
+  if ( mController )
   {
-    mobileApp->clearProject();
+    mController->clearProject();
   }
 }
 

--- a/src/core/appinterface.h
+++ b/src/core/appinterface.h
@@ -23,7 +23,7 @@
 #include <QQmlComponent>
 #include <QStandardItemModel>
 
-class QgisMobileapp;
+class AppController;
 class QgsRectangle;
 class QgsFeature;
 class QQuickItem;
@@ -39,7 +39,7 @@ class AppInterface : public QObject
     Q_OBJECT
 
   public:
-    explicit AppInterface( QQmlEngine *engine );
+    explicit AppInterface( QQmlEngine *engine, AppController *controller = nullptr );
     AppInterface()
     {
       // You shouldn't get here, this constructor only exists that we can register it as a QML type
@@ -282,11 +282,11 @@ class AppInterface : public QObject
 
   private:
     QObject *rootObject() const;
-    QgisMobileapp *app() const;
 
     static AppInterface *sAppInterface;
 
     QQmlEngine *mEngine = nullptr;
+    AppController *mController = nullptr;
 };
 
 #endif // APPINTERFACE_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,6 +99,7 @@ macro (ADD_QFIELD_QML_TEST TESTNAME TESTSRC)
 
   set_target_properties(${TESTNAME} PROPERTIES AUTOMOC TRUE)
   target_link_libraries(${TESTNAME} PRIVATE
+    qfield_app
     qfield_core
     qfield_qml
     Qt::Test


### PR DESCRIPTION
## 🚀 Description
Moves `QgisMobileapp` out of `src/core` into a new `src/app` library (`qfield_app`), removing the last `core → app` dependency.

The only obstacle was `AppInterface` (which stays in core) reaching into`QgisMobileapp` via `qobject_cast` on the QML engine. That's inverted with asmall abstract interface **`AppController`** (in core): `QgisMobileapp` implements it and is now handed to `AppInterface` explicitly, so core no longer knows the concrete app class.

### What's next
- **gui layer** — add `src/gui` (`qfield_gui`), move editing/attribute-form UX classes out of core
- **QML modules** — adopt `QML_ELEMENT` 
- **plugin** — bundle core+gui as the QField plugin; app becomes a pure consumer