### PR TITLE
Fix deletion of children with feature ID values going beyond range of an int32

### DIFF
--- a/src/qml/editorwidgets/RelationEditorBase.qml
+++ b/src/qml/editorwidgets/RelationEditorBase.qml
@@ -200,10 +200,10 @@ EditorWidgetBase {
     id: deleteDialog
     parent: mainWindow.contentItem
 
-    property int referencingFeatureId
+    property var referencingFeatureId
     property string referencingFeatureDisplayMessage
     property string referencingLayerName: relationEditorModel.relation.referencingLayer ? relationEditorModel.relation.referencingLayer.name : ''
-    property int nmReferencedFeatureId
+    property var nmReferencedFeatureId
     property string nmReferencedFeatureDisplayMessage
     property string nmReferencedLayerName: relationEditorModel.nmRelation.referencedLayer ? relationEditorModel.nmRelation.referencedLayer.name : ''
     property string nmReferencingLayerName


### PR DESCRIPTION
TIL, QML's int property is only holds int32, which can be a problem when passing on feature IDs (int64/longlong).

That fact broke deletion of children through our relation editor widget. This PR fixes things.