### PR TITLE
Add a bit of distance between the upload [local changes] button and auto-push row to avoid tap mix-up

### DIFF
--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -464,8 +464,18 @@ Popup {
                   onClicked: projectPush(false)
                 }
 
+                Rectangle {
+                  Layout.fillWidth: true
+                  Layout.topMargin: 12
+                  Layout.bottomMargin: 6
+                  Layout.preferredHeight: 1
+
+                  color: Theme.controlBorderColor
+                }
+
                 RowLayout {
                   Layout.fillWidth: true
+                  spacing: 0
 
                   Label {
                     id: autoPushText
@@ -493,8 +503,11 @@ Popup {
 
                   QfSwitch {
                     id: autoPush
+
                     verticalPadding: 0
-                    Layout.preferredWidth: implicitContentWidth
+
+                    Layout.preferredWidth: 38
+                    Layout.preferredHeight: 24
                     Layout.alignment: Qt.AlignVCenter
                     enabled: !(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.forceAutoPush)
                     checked: !!(cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.autoPushEnabled)


### PR DESCRIPTION
Looks cleaner, and avoids people trying to hit upload and wrongly end up toggling the auto-upload option:

<img width="485" height="864" alt="Screenshot From 2026-07-23 16-09-13" src="https://github.com/user-attachments/assets/c94b8d15-3979-4465-afac-31394b953f3e" />
