### PR TITLE
Make help locator search URL overridable and test it with a local index

### DIFF
--- a/src/core/locator/helplocatorfilter.cpp
+++ b/src/core/locator/helplocatorfilter.cpp
@@ -53,7 +53,8 @@ void HelpLocatorFilter::fetchResults( const QString &string, const QgsLocatorCon
     return;
   }
 
-  QNetworkRequest request( QUrl( "https://docs.qfield.org/search/search_index.json" ) );
+  const QUrl url( mSearchUrl );
+  QNetworkRequest request( url );
   QgsBlockingNetworkRequest blockingRequest;
   const QgsBlockingNetworkRequest::ErrorCode errorCode = blockingRequest.get( request, false, feedback );
   if ( errorCode != QgsBlockingNetworkRequest::NoError )

--- a/src/core/locator/helplocatorfilter.h
+++ b/src/core/locator/helplocatorfilter.h
@@ -47,12 +47,16 @@ class HelpLocatorFilter : public QgsLocatorFilter
     Priority priority() const override { return Medium; }
     QString prefix() const override { return QStringLiteral( "?" ); }
 
+    QString searchUrl() const { return mSearchUrl; }
+    void setSearchUrl( const QString &url ) { mSearchUrl = url; }
+
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
     void triggerResultFromAction( const QgsLocatorResult &result, const int actionId ) override;
 
   private:
     LocatorModelSuperBridge *mLocatorBridge = nullptr;
+    QString mSearchUrl = QStringLiteral( "https://docs.qfield.org/search/search_index.json" );
 };
 
 #endif // HELPLOCATORFILTER_H

--- a/test/test_locator.cpp
+++ b/test/test_locator.cpp
@@ -180,9 +180,9 @@ TEST_CASE( "ExpressionCalculatorLocatorFilter" )
     QgsProject::instance()->clear();
     addPointLayer( QStringLiteral( "memory" ) );
 
-    const QList<QgsLocatorResult> results = fetchResults( &filter, QStringLiteral( "aggregate('memory', 'concatenate', \"str\")" ) );
+    const QList<QgsLocatorResult> results = fetchResults( &filter, QStringLiteral( "aggregate(layer:='memory', aggregate:='concatenate', expression:=\"str\", concatenator:=',')" ) );
     REQUIRE( results.size() == 1 );
-    REQUIRE( results.at( 0 ).userData().toString() == QStringLiteral( "AlphaBeta" ) );
+    REQUIRE( results.at( 0 ).userData().toString() == QStringLiteral( "Alpha,Beta" ) );
 
     QgsProject::instance()->clear();
   }
@@ -361,8 +361,8 @@ TEST_CASE( "BookmarkLocatorFilter" )
 
 /*
  * HelpLocatorFilter
- * Fetching documentation hits the live docs.qfield.org index and triggering opens a
- * browser, so coverage stops at the guard that runs before any request is made
+ * The live documentation index is replaced with a local one to exercise fetching and
+ * parsing; triggering opens a browser, so it is not exercised
  */
 TEST_CASE( "HelpLocatorFilter" )
 {
@@ -389,6 +389,19 @@ TEST_CASE( "HelpLocatorFilter" )
   {
     REQUIRE( fetchResults( &filter, QStringLiteral( "ab" ) ).isEmpty() );
     REQUIRE( fetchResults( &filter, QString() ).isEmpty() );
+  }
+
+  SECTION( "MatchesAgainstLocalSearchIndex" )
+  {
+    filter.setSearchUrl( QStringLiteral( "file:%1/locator_help_index.json" ).arg( TEST_DATA_DIR ) );
+
+    const QList<QgsLocatorResult> results = fetchResults( &filter, QStringLiteral( "tracking" ) );
+    REQUIRE( results.size() == 1 );
+    REQUIRE( results.at( 0 ).displayString == QStringLiteral( "Tracking" ) );
+    REQUIRE( results.at( 0 ).userData().toString() == QStringLiteral( "https://docs.qfield.org/get-started/tracking/" ) );
+
+    REQUIRE( fetchResults( &filter, QStringLiteral( "principles" ) ).size() == 1 );
+    REQUIRE( fetchResults( &filter, QStringLiteral( "nonexistentterm" ) ).isEmpty() );
   }
 }
 

--- a/test/testdata/locator_help_index.json
+++ b/test/testdata/locator_help_index.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "lang": [
+      "en"
+    ],
+    "separator": "[\\s\\-]+",
+    "pipeline": [
+      "stopWordFilter"
+    ]
+  },
+  "docs": [
+    {
+      "location": "get-started/concepts/",
+      "title": "Principles",
+      "text": "<p>QField is designed with a few key principles in mind.</p>"
+    },
+    {
+      "location": "get-started/tracking/",
+      "title": "Tracking",
+      "text": "<p>QField can record a positioning track while you move across the field.</p>"
+    },
+    {
+      "location": "reference/settings/",
+      "title": "Settings reference",
+      "text": "<p>This tracking reference page should be skipped by the filter.</p>"
+    }
+  ]
+}


### PR DESCRIPTION
Follow-up to #7776. Adds a settable search URL on HelpLocatorFilter, defaulting to the current docs.qfield.org index, so the fetch and parse path can be tested with a local file and so custom app builds can point at their documentation

Includes a HelpLocatorFilter test that matches against a local search index fixture, following the file: fixture pattern used in test_tracking.cpp

> I have base off from helpLocatorTests pr, once that merges this will be rebased on master, for now it makes it easier to read the changes