### PR TITLE
Fix checkbox editor widget toggle

### DIFF
--- a/src/qml/editorwidgets/CheckBox.qml
+++ b/src/qml/editorwidgets/CheckBox.qml
@@ -99,8 +99,8 @@ EditorWidgetBase {
       } else {
         // Work around absence of proper configuration
         if (!isNull) {
-          // Type coercion is desired here as custom unchecked/checked states are stored as strings yet value could be integers
-          editedValue = value === checkedState ? uncheckedState : checkedState;
+          // String comparison is used here as custom unchecked/checked states are stored as strings yet value could be integers
+          editedValue = String(value) === String(checkedState) ? uncheckedState : checkedState;
         } else {
           editedValue = checkedState;
         }


### PR DESCRIPTION
Fixes the checkbox editor widget being unable to toggle back to the unchecked state on integer (and other non-string) fields.

Issue related to: #7765