### PR TITLE
[Backport release-4_2] Fix BLE reconnection when returning to QField + available devices listing on Android 

### DIFF
--- a/src/core/positioning/bluetoothdevicemodel.cpp
+++ b/src/core/positioning/bluetoothdevicemodel.cpp
@@ -187,15 +187,6 @@ void BluetoothDeviceModel::deviceDiscovered( const QBluetoothDeviceInfo &info )
                .arg( info.name(), info.address().toString(), deviceAddress( info ) )
                .arg( mLocalDevice->pairingStatus( info.address() ) );
 
-#if defined( Q_OS_ANDROID )
-  // Only list paired devices users have control over it.
-  const bool paired = mLocalDevice->pairingStatus( info.address() ) != QBluetoothLocalDevice::Unpaired;
-  if ( !paired )
-  {
-    return;
-  }
-#endif
-
   const int index = static_cast<int>( mDiscoveredDevices.size() );
   beginInsertRows( QModelIndex(), index, index );
   mDiscoveredDevices.append( info );

--- a/src/core/positioning/bluetoothdevicemodel.cpp
+++ b/src/core/positioning/bluetoothdevicemodel.cpp
@@ -167,6 +167,11 @@ void BluetoothDeviceModel::stopDeviceDiscovery()
 
 void BluetoothDeviceModel::deviceDiscovered( const QBluetoothDeviceInfo &info )
 {
+  if ( info.name().isEmpty() )
+  {
+    return;
+  }
+
   for ( qsizetype i = 0; i < mDiscoveredDevices.size(); i++ )
   {
     if ( deviceAddress( mDiscoveredDevices[i] ) == deviceAddress( info ) )

--- a/src/core/positioning/bluetoothlowenergyreceiver.cpp
+++ b/src/core/positioning/bluetoothlowenergyreceiver.cpp
@@ -141,6 +141,15 @@ void BluetoothLowEnergyReceiver::deviceConnected()
 void BluetoothLowEnergyReceiver::deviceDisconnected()
 {
   qInfo() << "BluetoothLowEnergyReceiver: Received disconnected signal.";
+
+  if ( mDisconnecting )
+  {
+    mDisconnecting = false;
+    if ( mConnectOnDisconnect )
+    {
+      doConnectDevice();
+    }
+  }
 }
 
 void BluetoothLowEnergyReceiver::controllerErrorOccurred( QLowEnergyController::Error error )


### PR DESCRIPTION
Backport #7782
 **Authored by:** @nirvn