### PR TITLE
Add UI/UX to send a compressed file(s) selection

### DIFF
--- a/src/core/platforms/platformutilities.cpp
+++ b/src/core/platforms/platformutilities.cpp
@@ -350,14 +350,30 @@ void PlatformUtilities::sendCompressedFolderTo( const QString &path ) const
     return;
   }
 
-  const QString directory = QFileDialog::getExistingDirectory( nullptr, tr( "Select Destination Folder" ) );
-  if ( !directory.isEmpty() )
+  sendDatasetTo( tempZipPath );
+}
+
+void PlatformUtilities::sendCompressedFilesTo( const QStringList &paths ) const
+{
+  const QString tempZipPath = QStringLiteral( "%1/qfield_files_%2.zip" ).arg( QDir::tempPath(), QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMddHHmmss" ) ) );
+  QFile::remove( tempZipPath );
+
+  QStringList files;
+  for ( const QString &path : paths )
   {
-    const QString destination = QStringLiteral( "%1/%2" ).arg( directory, QFileInfo( tempZipPath ).fileName() );
-    QFile::copy( tempZipPath, destination );
+    QFileInfo fi( path );
+    if ( fi.isFile() && fi.exists() )
+    {
+      files << path;
+    }
   }
 
-  QFile::remove( tempZipPath );
+  if ( files.isEmpty() || !QgsZipUtils::zip( tempZipPath, files ) )
+  {
+    return;
+  }
+
+  sendDatasetTo( tempZipPath );
 }
 
 void PlatformUtilities::removeDataset( const QString &path ) const

--- a/src/core/platforms/platformutilities.h
+++ b/src/core/platforms/platformutilities.h
@@ -162,6 +162,8 @@ class QFIELD_CORE_EXPORT PlatformUtilities : public QObject
     Q_INVOKABLE virtual void sendDatasetTo( const QString &path ) const;
     //! Compresses a folder \a path and sends it via the platform native API
     Q_INVOKABLE virtual void sendCompressedFolderTo( const QString &path ) const;
+    //! Compresses a list of file \a paths and sends it via the platform native API
+    Q_INVOKABLE virtual void sendCompressedFilesTo( const QStringList &paths ) const;
 
     //! Removes a given dataset \a path
     Q_INVOKABLE virtual void removeDataset( const QString &path ) const;

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -34,7 +34,7 @@ Page {
     showBackButton: true
     showApplyButton: false
     showCancelButton: false
-    showMenuButton: localFilesModel.inSelectionMode && (table.selectedItemsPushableToQField || table.selectedItemsWebDavConfigured || table.selectedItemsDeletable)
+    showMenuButton: localFilesModel.inSelectionMode && (table.selectedItemsPushableToQField || table.selectedItemsWebDavConfigured || table.selectedItemsDeletable || table.selectedItemsCompressible)
     backAsCancel: localFilesModel.inSelectionMode
 
     topMargin: mainWindow.sceneTopMargin
@@ -159,6 +159,7 @@ Page {
         property bool selectedItemsWebDavConfigured
         property bool selectedItemsPushableToQField
         property bool selectedItemsDeletable
+        property bool selectedItemsCompressible
 
         delegate: Rectangle {
           id: rectangle
@@ -335,12 +336,15 @@ Page {
           table.selectedItemsWebDavConfigured = true;
           table.selectedItemsPushableToQField = true;
           table.selectedItemsDeletable = true;
+          table.selectedItemsCompressible = true;
           for (let i = 0; i < table.selectedList.length; ++i) {
             const selectedItem = table.model.get(table.selectedList[i]);
-            table.selectedItemsWebDavConfigured = table.selectedItemsWebDavConfigured && webdavConnectionLoader.item.hasWebdavConfiguration(selectedItem.path);
             const itemWithinQFieldCloudProjectFolder = cloudProjectsModel.currentProjectId !== "" && selectedItem.path.search(cloudProjectsModel.currentProjectId) !== -1;
+
+            table.selectedItemsWebDavConfigured = table.selectedItemsWebDavConfigured && webdavConnectionLoader.item.hasWebdavConfiguration(selectedItem.path);
             table.selectedItemsPushableToQField = (table.selectedItemsPushableToQField && selectedItem.metaType == LocalFilesModel.Dataset && selectedItem.type == LocalFilesModel.RasterDataset && cloudProjectsModel.currentProjectId) || (selectedItem.metaType == LocalFilesModel.Folder && itemWithinQFieldCloudProjectFolder);
             table.selectedItemsDeletable = table.selectedItemsDeletable && FileUtils.isDeletable(selectedItem.path);
+            table.selectedItemsCompressible = table.selectedItemsCompressible && selectedItem.metaType == LocalFilesModel.Dataset;
           }
         }
 
@@ -937,6 +941,30 @@ Page {
             QFieldCloudUtils.addPendingAttachments(cloudConnection.userInformation.username, QFieldCloudUtils.getProjectId(table.model.currentPath), fileNames, cloudConnection, true);
           } else {
             displayToast(qsTr("Please select one or more files to push to QFieldCloud."));
+          }
+        }
+      }
+
+      MenuItem {
+        id: sendCompressedFilesTo
+
+        enabled: table.selectedItemsCompressible
+        visible: enabled
+
+        font: Theme.defaultFont
+        width: parent.width
+        height: enabled ? 48 : 0
+        leftPadding: Theme.menuItemLeftPadding
+
+        text: qsTr("Send compressed item(s) to...")
+        onTriggered: {
+          var fileNames = [];
+          for (let i = 0; i < table.selectedList.length; ++i) {
+            const item = table.model.get(table.selectedList[i]);
+            fileNames.push(item.path);
+          }
+          if (fileNames.length > 0) {
+            platformUtilities.sendCompressedFilesTo(fileNames);
           }
         }
       }

--- a/src/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/qml/QFieldLocalDataPickerScreen.qml
@@ -956,7 +956,7 @@ Page {
         height: enabled ? 48 : 0
         leftPadding: Theme.menuItemLeftPadding
 
-        text: qsTr("Send compressed item(s) to...")
+        text: qsTr("Send compressed file(s) to...")
         onTriggered: {
           var fileNames = [];
           for (let i = 0; i < table.selectedList.length; ++i) {


### PR DESCRIPTION
This PR enables people to send a compressed selection of files from their project folder view:

<img width="450" alt="Screenshot_20260727-211803~2" src="https://github.com/user-attachments/assets/c8fedb14-0313-4985-8e3f-9b3801d2b22e" />

This can be super useful when users do not want to send a whole folder worth of content when they want to select only the newly generated files / attachments from the folder.

This is a nice example of the summer of stability addressing unmet UX expectations :partying_face: 