### PR TITLE
Add navigation action to bookmark locator filter

### DIFF
--- a/src/app/qml/qgismobileapp.qml
+++ b/src/app/qml/qgismobileapp.qml
@@ -4705,6 +4705,11 @@ ApplicationWindow {
       }
     }
 
+    onRequestBookmarkNavigation: bookmarkIndex => {
+      navigation.destination = bookmarkList.model.getBookmarkPoint(bookmarkIndex);
+      bookmarkList.hide();
+    }
+
     Component.onCompleted: focusstack.addFocusTaker(this)
   }
 

--- a/src/core/bookmarkmodel.cpp
+++ b/src/core/bookmarkmodel.cpp
@@ -149,6 +149,30 @@ void BookmarkModel::setExtentFromBookmark( const QModelIndex &index )
   emit requestJumpToPoint( QgsPoint( transformedRect.center() ), scale, true );
 }
 
+QgsPoint BookmarkModel::getBookmarkPoint( int idx )
+{
+  QModelIndex sourceIndex = mapToSource( index( idx, 0 ) );
+  if ( !sourceIndex.isValid() || !mMapSettings )
+    return QgsPoint();
+
+  const QgsReferencedRectangle rect = mModel->data( sourceIndex, static_cast<int>( QgsBookmarkManagerModel::CustomRole::Extent ) ).value<QgsReferencedRectangle>();
+  QgsCoordinateTransform transform( rect.crs(), mMapSettings->destinationCrs(), QgsProject::instance()->transformContext() );
+  try
+  {
+    return QgsPoint( transform.transform( rect.center() ) );
+  }
+  catch ( const QgsException &e )
+  {
+    Q_UNUSED( e )
+    return QgsPoint();
+  }
+  catch ( ... )
+  {
+    // catch any other errors
+    return QgsPoint();
+  }
+}
+
 QString BookmarkModel::addBookmarkAtPoint( QgsPoint point, const QString &name, const QString &group )
 {
   if ( !mMapSettings )

--- a/src/core/bookmarkmodel.h
+++ b/src/core/bookmarkmodel.h
@@ -62,6 +62,9 @@ class BookmarkModel : public QSortFilterProxyModel
 
     Q_INVOKABLE void setExtentFromBookmark( const QModelIndex &index );
 
+    //! Returns the center point of the bookmark at row \a idx transformed to the map canvas CRS, or an empty point on failure.
+    Q_INVOKABLE QgsPoint getBookmarkPoint( int idx );
+
     Q_INVOKABLE QString addBookmarkAtPoint( QgsPoint point, const QString &name = QString(), const QString &group = QString() );
 
     Q_INVOKABLE void updateBookmarkDetails( const QString &id, const QString &name, const QString &group );

--- a/src/core/locator/bookmarklocatorfilter.cpp
+++ b/src/core/locator/bookmarklocatorfilter.cpp
@@ -51,6 +51,7 @@ void BookmarkLocatorFilter::fetchResults( const QString &string, const QgsLocato
     {
       result.filter = this;
       result.setUserData( i );
+      result.actions << QgsLocatorResult::ResultAction( Navigation, tr( "Navigate to bookmark" ), QStringLiteral( "qrc:/themes/qfield/nodpi/ic_navigation_flag_purple_24dp.svg" ) );
       emit resultFetched( result );
     }
   }
@@ -61,9 +62,20 @@ void BookmarkLocatorFilter::triggerResult( const QgsLocatorResult &result )
   triggerResultFromAction( result, Normal );
 }
 
-void BookmarkLocatorFilter::triggerResultFromAction( const QgsLocatorResult &result, const int )
+void BookmarkLocatorFilter::triggerResultFromAction( const QgsLocatorResult &result, const int actionId )
 {
   const int row = result.userData().toInt();
+
+  if ( actionId == Navigation )
+  {
+    if ( !mLocatorBridge->navigation() )
+      return;
+
+    const QgsPoint point = mLocatorBridge->bookmarks()->getBookmarkPoint( row );
+    if ( !point.isEmpty() )
+      mLocatorBridge->navigation()->setDestination( point );
+    return;
+  }
 
   mLocatorBridge->bookmarks()->setExtentFromBookmark( mLocatorBridge->bookmarks()->index( row, 0 ) );
 

--- a/src/core/locator/bookmarklocatorfilter.h
+++ b/src/core/locator/bookmarklocatorfilter.h
@@ -37,6 +37,7 @@ class BookmarkLocatorFilter : public QgsLocatorFilter
     enum ActionOrigin
     {
       Normal,
+      Navigation,
     };
 
     explicit BookmarkLocatorFilter( LocatorModelSuperBridge *locatorBridge, QObject *parent = nullptr );

--- a/src/gui/qml/BookmarkList.qml
+++ b/src/gui/qml/BookmarkList.qml
@@ -16,6 +16,7 @@ QfPaneDrawer {
   property bool multiSelection: false
 
   signal requestBookmarkProperties(string bookmarkId, string bookmarkName, string bookmarkGroup)
+  signal requestBookmarkNavigation(int bookmarkIndex)
 
   contentVisible: props.isVisible
   freezeKey: 'bookmarkresize'
@@ -256,6 +257,7 @@ QfPaneDrawer {
     property string itemId: ''
     property string itemName: ''
     property string itemGroup: ''
+    property int itemIndex: -1
 
     topMargin: mainWindow.sceneTopMargin
     bottomMargin: mainWindow.sceneBottomMargin
@@ -270,6 +272,19 @@ QfPaneDrawer {
 
       onTriggered: {
         bookmarkList.requestBookmarkProperties(itemMenu.itemId, itemMenu.itemName, itemMenu.itemGroup);
+      }
+    }
+
+    MenuItem {
+      text: qsTr("Navigate to bookmark")
+      icon.source: Theme.getThemeVectorIcon("ic_navigation_flag_purple_24dp")
+
+      font: Theme.defaultFont
+      height: 48
+      leftPadding: Theme.menuItemLeftPadding
+
+      onTriggered: {
+        bookmarkList.requestBookmarkNavigation(itemMenu.itemIndex);
       }
     }
 
@@ -475,6 +490,7 @@ QfPaneDrawer {
           const gc = mapToItem(bookmarkList, 0, 0);
           itemMenu.itemId = BookmarkId;
           itemMenu.itemName = BookmarkName;
+          itemMenu.itemIndex = index;
           // BookmarkGroup surfaces empty groups as "green"; restore empty so edits don't persist a color onto an ungrouped bookmark.
           itemMenu.itemGroup = BookmarkGroup === 'green' ? '' : BookmarkGroup;
           itemMenu.popup(gc.x + width - itemMenu.width, gc.y - height);

--- a/test/test_locator.cpp
+++ b/test/test_locator.cpp
@@ -29,6 +29,7 @@
 #include "helplocatorfilter.h"
 #include "locatormodelsuperbridge.h"
 #include "multifeaturelistmodel.h"
+#include "navigation.h"
 #include "qfieldlocatorfilter.h"
 #include "qgsquickmapsettings.h"
 
@@ -356,6 +357,48 @@ TEST_CASE( "BookmarkLocatorFilter" )
     REQUIRE( results.at( 0 ).userData().toInt() == 0 );
 
     REQUIRE( fetchResults( &filter, QStringLiteral( "zzzzz" ) ).isEmpty() );
+  }
+
+  SECTION( "ProvidesNavigationAction" )
+  {
+    QgsBookmarkManager manager;
+    manager.addBookmark( makeBookmark( QStringLiteral( "Alpha" ) ) );
+    BookmarkModel model( &manager, QgsApplication::bookmarkManager() );
+    bridge.setBookmarks( &model );
+
+    const QList<QgsLocatorResult> results = fetchResults( &filter, QStringLiteral( "Alpha" ) );
+    REQUIRE( results.size() == 1 );
+    REQUIRE( hasAction( results.at( 0 ), BookmarkLocatorFilter::Navigation ) );
+  }
+
+  SECTION( "NavigationActionSetsDestinationInMapCrs" )
+  {
+    QgsQuickMapSettings mapSettings;
+    mapSettings.setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3857" ) ) );
+    mapSettings.setOutputSize( QSize( 1000, 500 ) );
+    mapSettings.setExtent( QgsRectangle( -20000000.0, -20000000.0, 20000000.0, 20000000.0 ) );
+    bridge.setMapSettings( &mapSettings );
+
+    Navigation navigation;
+    navigation.setMapSettings( &mapSettings );
+    bridge.setNavigation( &navigation );
+
+    QgsBookmarkManager manager;
+    manager.addBookmark( makeBookmark( QStringLiteral( "Alpha" ) ) );
+    BookmarkModel model( &manager, QgsApplication::bookmarkManager() );
+    model.setMapSettings( &mapSettings );
+    bridge.setBookmarks( &model );
+
+    const QList<QgsLocatorResult> results = fetchResults( &filter, QStringLiteral( "Alpha" ) );
+    REQUIRE( results.size() == 1 );
+
+    filter.triggerResultFromAction( results.at( 0 ), BookmarkLocatorFilter::Navigation );
+
+    REQUIRE( navigation.isActive() );
+
+    const QgsPoint destination = navigation.destination();
+    REQUIRE( destination.x() == Approx( 556597.5 ).margin( 1.0 ) );
+    REQUIRE( destination.y() == Approx( 557305.3 ).margin( 1.0 ) );
   }
 }
 


### PR DESCRIPTION
Adds a "Set navigation point" action to bookmark results in the locator, mirroring the goto and features filters. Selecting it sets the bookmark's extent center as the navigation destination.

Adds BookmarkModel::getMapCrsBookmarkPoint() to return the extent center transformed to the map CRS, so the destination is correct when the bookmark and map CRS differ