### PR TITLE
Fix lack of spacing between auto-push label and its switch

### DIFF
--- a/src/qml/QFieldCloudPopup.qml
+++ b/src/qml/QFieldCloudPopup.qml
@@ -477,7 +477,7 @@ Popup {
 
                 RowLayout {
                   Layout.fillWidth: true
-                  spacing: 0
+                  spacing: 4
 
                   Label {
                     id: autoPushText


### PR DESCRIPTION
Fixes lack of space in area highlighted below (the screenshot shows the fixed version):

<img width="334" height="496" alt="image" src="https://github.com/user-attachments/assets/6fd51425-948b-4e8b-8979-e00f5ffac686" />
