### PR TITLE
Improve Quick3DGeometry[Configuration] to enhance plugin integration capabilities

### DIFF
--- a/src/core/3d/quick3dgeometry.cpp
+++ b/src/core/3d/quick3dgeometry.cpp
@@ -181,25 +181,23 @@ void Quick3DGeometry::markDirtyAndUpdate()
   updateGeometry();
 }
 
-QVector3D Quick3DGeometry::vertexTo3D( double geoX, double geoY, double geometryZ ) const
+QVector3D Quick3DGeometry::vertexTo3D( double geoX, double geoY, double geoZ ) const
 {
   switch ( mAltitudeClamping )
   {
     case AltitudeClamping::Absolute:
     {
-      const double z = std::isnan( geometryZ ) ? 0.0 : geometryZ;
-      QVector3D pos = mTerrainProvider->geoTo3D( geoX, geoY, mHeightOffset );
+      QVector3D pos = mTerrainProvider->geoTo3D( QgsPoint( geoX, geoY, geoZ ), mHeightOffset );
       if ( std::isnan( pos.x() ) )
       {
         return pos;
       }
-      pos.setY( static_cast<float>( z ) + mHeightOffset );
       return pos;
     }
 
     case AltitudeClamping::ClampToGround:
     {
-      const float extraZ = std::isnan( geometryZ ) ? 0.0f : static_cast<float>( geometryZ );
+      const float extraZ = std::isnan( geoZ ) ? 0.0f : static_cast<float>( geoZ );
       return mTerrainProvider->geoTo3D( geoX, geoY, mHeightOffset + extraZ );
     }
 

--- a/src/core/3d/quick3dgeometry.h
+++ b/src/core/3d/quick3dgeometry.h
@@ -124,7 +124,7 @@ class Quick3DGeometry : public QQuick3DGeometry
     void updateGeometry();
 
     //! Returns the terrain-relative scene-Y for \a geoX/\a geoY honoring \a altitudeClamping and the per-vertex \a geometryZ
-    QVector3D vertexTo3D( double geoX, double geoY, double geometryZ ) const;
+    QVector3D vertexTo3D( double geoX, double geoY, double geoZ ) const;
 
     //! Walks an abstract geometry and returns its rings/lines as 3D paths
     QVector<QVector<QVector3D>> buildPaths( const QgsAbstractGeometry *geom ) const;

--- a/src/core/3d/quick3dgeometryconfiguration.cpp
+++ b/src/core/3d/quick3dgeometryconfiguration.cpp
@@ -28,6 +28,7 @@ void Quick3DGeometryConfiguration::setWkt( const QString &wkt )
   {
     return;
   }
+
   mWkt = wkt;
   emit wktChanged();
 }
@@ -38,18 +39,42 @@ void Quick3DGeometryConfiguration::setCrs( const QgsCoordinateReferenceSystem &c
   {
     return;
   }
+
   mCrs = crs;
   emit crsChanged();
 }
 
-void Quick3DGeometryConfiguration::setLineColor( const QColor &color )
+void Quick3DGeometryConfiguration::setHeightOffset( float offset )
 {
-  if ( mLineColor == color )
+  if ( mHeightOffset == offset )
   {
     return;
   }
-  mLineColor = color;
-  emit lineColorChanged();
+
+  mHeightOffset = offset;
+  emit heightOffsetChanged();
+}
+
+void Quick3DGeometryConfiguration::setAltitudeClamping( Quick3DGeometry::AltitudeClamping clamping )
+{
+  if ( mAltitudeClamping == clamping )
+  {
+    return;
+  }
+
+  mAltitudeClamping = clamping;
+  emit altitudeClampingChanged();
+}
+
+void Quick3DGeometryConfiguration::setColor( const QColor &color )
+{
+  if ( mColor == color )
+  {
+    return;
+  }
+
+  mColor = color;
+  emit colorChanged();
 }
 
 void Quick3DGeometryConfiguration::setLineWidth( float width )
@@ -58,6 +83,7 @@ void Quick3DGeometryConfiguration::setLineWidth( float width )
   {
     return;
   }
+
   mLineWidth = width;
   emit lineWidthChanged();
 }

--- a/src/core/3d/quick3dgeometryconfiguration.h
+++ b/src/core/3d/quick3dgeometryconfiguration.h
@@ -17,6 +17,8 @@
 #ifndef QUICK3DGEOMETRYCONFIGURATION_H
 #define QUICK3DGEOMETRYCONFIGURATION_H
 
+#include "quick3dgeometry.h"
+
 #include <QColor>
 #include <QQuickItem>
 #include <qgscoordinatereferencesystem.h>
@@ -33,10 +35,15 @@ class Quick3DGeometryConfiguration : public QQuickItem
 
     //! WKT representation of the geometry to render
     Q_PROPERTY( QString wkt READ wkt WRITE setWkt NOTIFY wktChanged )
+    //! Extra vertical offset added on top of the elevation chosen by altitudeClamping
+    Q_PROPERTY( float heightOffset READ heightOffset WRITE setHeightOffset NOTIFY heightOffsetChanged )
+    //! How the geometry's Z values are combined with the terrain elevation
+    Q_PROPERTY( Quick3DGeometry::AltitudeClamping altitudeClamping READ altitudeClamping WRITE setAltitudeClamping NOTIFY altitudeClampingChanged )
     //! Coordinate reference system the geometry is expressed in
     Q_PROPERTY( QgsCoordinateReferenceSystem crs READ crs WRITE setCrs NOTIFY crsChanged )
+
     //! Color of the rendered geometry
-    Q_PROPERTY( QColor lineColor READ lineColor WRITE setLineColor NOTIFY lineColorChanged )
+    Q_PROPERTY( QColor color READ color WRITE setColor NOTIFY colorChanged )
     //! Outline tube thickness in scene units
     Q_PROPERTY( float lineWidth READ lineWidth WRITE setLineWidth NOTIFY lineWidthChanged )
 
@@ -49,8 +56,14 @@ class Quick3DGeometryConfiguration : public QQuickItem
     QgsCoordinateReferenceSystem crs() const { return mCrs; }
     void setCrs( const QgsCoordinateReferenceSystem &crs );
 
-    QColor lineColor() const { return mLineColor; }
-    void setLineColor( const QColor &color );
+    float heightOffset() const { return mHeightOffset; }
+    void setHeightOffset( float offset );
+
+    Quick3DGeometry::AltitudeClamping altitudeClamping() const { return mAltitudeClamping; }
+    void setAltitudeClamping( Quick3DGeometry::AltitudeClamping clamping );
+
+    QColor color() const { return mColor; }
+    void setColor( const QColor &color );
 
     float lineWidth() const { return mLineWidth; }
     void setLineWidth( float width );
@@ -58,13 +71,17 @@ class Quick3DGeometryConfiguration : public QQuickItem
   signals:
     void wktChanged();
     void crsChanged();
-    void lineColorChanged();
+    void heightOffsetChanged();
+    void altitudeClampingChanged();
+    void colorChanged();
     void lineWidthChanged();
 
   private:
     QString mWkt;
     QgsCoordinateReferenceSystem mCrs;
-    QColor mLineColor = QColor( 255, 102, 0 );
+    float mHeightOffset = 20.0f;
+    Quick3DGeometry::AltitudeClamping mAltitudeClamping = Quick3DGeometry::AltitudeClamping::Ignore;
+    QColor mColor = QColor( 255, 102, 0 );
     float mLineWidth = 4.0f;
 };
 

--- a/src/core/3d/quick3dterrainprovider.cpp
+++ b/src/core/3d/quick3dterrainprovider.cpp
@@ -220,7 +220,7 @@ QVector3D Quick3DTerrainProvider::geoTo3D( double geoX, double geoY, float heigh
   return geoTo3D( QgsPoint( geoX, geoY ), heightOffset );
 }
 
-QVector3D Quick3DTerrainProvider::geoTo3D( QgsPoint geoPoint, float heightOffset ) const
+QVector3D Quick3DTerrainProvider::geoTo3D( const QgsPoint &geoPoint, float heightOffset ) const
 {
   const double extW = mExtent.width();
   const double extH = mExtent.height();

--- a/src/core/3d/quick3dterrainprovider.cpp
+++ b/src/core/3d/quick3dterrainprovider.cpp
@@ -217,6 +217,11 @@ double Quick3DTerrainProvider::normalizedHeightAt( double x, double y ) const
 
 QVector3D Quick3DTerrainProvider::geoTo3D( double geoX, double geoY, float heightOffset ) const
 {
+  return geoTo3D( QgsPoint( geoX, geoY ), heightOffset );
+}
+
+QVector3D Quick3DTerrainProvider::geoTo3D( QgsPoint geoPoint, float heightOffset ) const
+{
   const double extW = mExtent.width();
   const double extH = mExtent.height();
 
@@ -225,8 +230,8 @@ QVector3D Quick3DTerrainProvider::geoTo3D( double geoX, double geoY, float heigh
     return QVector3D( std::numeric_limits<float>::quiet_NaN(), 0, 0 );
   }
 
-  const double nx = ( geoX - mExtent.xMinimum() ) / extW;
-  const double nz = ( geoY - mExtent.yMinimum() ) / extH;
+  const double nx = ( geoPoint.x() - mExtent.xMinimum() ) / extW;
+  const double nz = ( geoPoint.y() - mExtent.yMinimum() ) / extH;
 
   if ( nx < 0 || nx > 1 || nz < 0 || nz > 1 )
   {
@@ -235,8 +240,17 @@ QVector3D Quick3DTerrainProvider::geoTo3D( double geoX, double geoY, float heigh
 
   const float x3d = static_cast<float>( ( nx - 0.5 ) * mSize.width() );
   const float z3d = static_cast<float>( ( 0.5 - nz ) * mSize.height() );
-
-  float y3d = static_cast<float>( normalizedHeightAt( geoX, geoY ) );
+  float y3d = 0.0;
+  if ( std::isnan( geoPoint.z() ) )
+  {
+    y3d = static_cast<float>( normalizedHeightAt( geoPoint.x(), geoPoint.y() ) );
+  }
+  else
+  {
+    const double extentSize = std::max( mNormalizedDataExtent.width(), mNormalizedDataExtent.height() );
+    const double scale = ( mBaseSize / extentSize );
+    y3d = ( geoPoint.z() - mMinRealHeight ) * scale / mOffsetScale;
+  }
   y3d += heightOffset;
 
   return QVector3D( x3d, y3d, z3d );

--- a/src/core/3d/quick3dterrainprovider.h
+++ b/src/core/3d/quick3dterrainprovider.h
@@ -159,6 +159,13 @@ class Quick3DTerrainProvider : public QObject
     Q_INVOKABLE QVector3D geoTo3D( double geoX, double geoY, float heightOffset = 0.0f ) const;
 
     /**
+     * Converts geographic coordinates to a 3D scene position.
+     * \param geoPoint Point coordinate in map CRS
+     * \returns 3D position in scene space, or a null vector if the extent is invalid
+     */
+    Q_INVOKABLE QVector3D geoTo3D( QgsPoint geoPoint, float heightOffset = 0.0f ) const;
+
+    /**
      * Converts a 3D scene position back to geographic coordinates in map CRS.
      * Inverse of geoTo3D(); returns an empty QgsPoint when the extent is invalid.
      */

--- a/src/core/3d/quick3dterrainprovider.h
+++ b/src/core/3d/quick3dterrainprovider.h
@@ -163,7 +163,7 @@ class Quick3DTerrainProvider : public QObject
      * \param geoPoint Point coordinate in map CRS
      * \returns 3D position in scene space, or a null vector if the extent is invalid
      */
-    Q_INVOKABLE QVector3D geoTo3D( QgsPoint geoPoint, float heightOffset = 0.0f ) const;
+    Q_INVOKABLE QVector3D geoTo3D( const QgsPoint &geoPoint, float heightOffset = 0.0f ) const;
 
     /**
      * Converts a 3D scene position back to geographic coordinates in map CRS.

--- a/src/qml/3d/MapCanvas3D.qml
+++ b/src/qml/3d/MapCanvas3D.qml
@@ -269,11 +269,11 @@ Item {
           geometry: Quick3DGeometry {
             qgsGeometry: GeometryUtils.createGeometryFromWkt(modelData.wkt)
             crs: modelData.crs
-            terrainProvider: mapTerrainProvider
             lineWidth: modelData.lineWidth
-            heightOffset: 20.0
-            altitudeClamping: Quick3DGeometry.ClampToGround
-            color: modelData.lineColor
+            heightOffset: modelData.heightOffset
+            altitudeClamping: modelData.altitudeClamping
+            color: modelData.color
+            terrainProvider: mapTerrainProvider
           }
           materials: PrincipledMaterial {
             vertexColorsEnabled: true


### PR DESCRIPTION
Fixes erroneous handling of absolute geometry's Z value, and avoids hard coded logic on geometry properties.

@MidnightCoder-m , building on top of your work.