### PR TITLE
Improve gallery relation editor for attachment-light workflows

### DIFF
--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -600,6 +600,7 @@ RelationEditorBase {
       height: relationEditor.listItemHeight
 
       property string attachmentPath: model.attachmentPath
+      readonly property bool hasAttachment: attachmentPath !== ""
       property string attachmentFullPath: ""
       Component.onCompleted: {
         attachmentFullPath = resolveAttachmentPath(attachmentPath);
@@ -690,17 +691,18 @@ RelationEditorBase {
           color: Material.rippleColor
         }
 
-        Row {
+        Item {
           id: listRow
           anchors.fill: parent
           anchors.leftMargin: 10
           anchors.rightMargin: 10
-          spacing: 10
 
           Rectangle {
             id: listThumbnail
-            width: 56
+            width: hasAttachment ? 56 : 0
             height: 56
+            visible: hasAttachment
+            anchors.left: parent.left
             anchors.verticalCenter: parent.verticalCenter
             radius: 6
             color: Theme.controlBorderColor
@@ -836,7 +838,10 @@ RelationEditorBase {
 
           Text {
             anchors.verticalCenter: parent.verticalCenter
-            width: listRow.width - listThumbnail.width - listFormButton.width - listMenuButton.width - listRow.spacing * 2
+            anchors.left: listThumbnail.right
+            anchors.leftMargin: hasAttachment ? 10 : 0
+            anchors.right: listFormButton.left
+            anchors.rightMargin: 10
             text: model.displayString
             color: Theme.mainTextColor
             font: Theme.resultFont
@@ -847,6 +852,7 @@ RelationEditorBase {
 
           QfToolButton {
             id: listFormButton
+            anchors.right: listMenuButton.left
             anchors.verticalCenter: parent.verticalCenter
             width: Theme.toolButtonSize
             height: Theme.toolButtonSize
@@ -860,6 +866,7 @@ RelationEditorBase {
 
           QfToolButton {
             id: listMenuButton
+            anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
             width: Theme.toolButtonSize
             height: Theme.toolButtonSize

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -28,7 +28,7 @@ RelationEditorBase {
     }
   }
 
-  property bool isCardView: true
+  property bool isCardView: settings.valueBool("/QField/RelationEditor/GalleryCardView", true)
   property string imagePrefix: {
     if (qgisProject == undefined)
       return "";
@@ -447,6 +447,7 @@ RelationEditorBase {
 
     onClicked: {
       isCardView = !checked;
+      settings.setValue("/QField/RelationEditor/GalleryCardView", isCardView);
     }
   }
 

--- a/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -1298,6 +1298,8 @@ RelationEditorBase {
             text: model.displayString
             color: Theme.mainTextColor
             font: Theme.tipFont
+            wrapMode: Text.WordWrap
+            maximumLineCount: 2
             elide: Text.ElideRight
           }
 


### PR DESCRIPTION
Fixes a few gallery relation editor issues raised, where the value matter more than attachments..
Here:
https://community.qfield.org/t/deactivate-gallery-editor-widget/1806/7

- The card/list toggle is now remembered across sessions instead of resetting to card view each time
- In list view, rows without a photo/video/audio no longer show an empty thumbnail box, so attachment-less entries read as a clean text row and entries with media stand out
- Fixed the card details text overlapping the menu button when the display value spans two lines

https://github.com/user-attachments/assets/7b4c86c4-b92d-47cf-ba7c-2abce4ba636a