### PR TITLE
Fix local data picker row height and spacing in selection mode

### DIFF
--- a/src/app/qml/QFieldLocalDataPickerScreen.qml
+++ b/src/app/qml/QFieldLocalDataPickerScreen.qml
@@ -189,9 +189,17 @@ Page {
             anchors.verticalCenter: parent.verticalCenter
             spacing: 2
 
-            CheckBox {
-              checked: itemChecked
+            Item {
+              Layout.preferredWidth: Theme.toolButtonSize
+              Layout.preferredHeight: Theme.toolButtonSize
+              Layout.alignment: Qt.AlignVCenter
               visible: localFilesModel.inSelectionMode
+
+              CheckBox {
+                anchors.centerIn: parent
+                checked: itemChecked
+                padding: 0
+              }
             }
 
             Image {
@@ -250,7 +258,7 @@ Page {
               Layout.preferredHeight: childrenRect.height
               Layout.topMargin: 5
               Layout.bottomMargin: 5
-              Layout.leftMargin: 2
+              Layout.leftMargin: 12
               Layout.rightMargin: 4
               spacing: 1
               Text {
@@ -263,7 +271,8 @@ Page {
 
                 font.pointSize: Theme.defaultFont.pointSize
                 color: Theme.mainTextColor
-                wrapMode: Text.Wrap
+                elide: Text.ElideRight
+                wrapMode: Text.NoWrap
               }
               Text {
                 id: itemInfo
@@ -299,6 +308,9 @@ Page {
 
               Layout.topMargin: 5
               Layout.bottomMargin: 5
+              Layout.preferredWidth: Theme.toolButtonSize
+              Layout.preferredHeight: Theme.toolButtonSize
+              Layout.alignment: Qt.AlignVCenter
 
               bgcolor: "transparent"
               iconSource: Theme.getThemeVectorIcon("ic_dot_menu_black_24dp")
@@ -314,6 +326,12 @@ Page {
                 itemMenu.itemHasWebdavConfiguration = ItemHasWebdavConfiguration;
                 itemMenu.popup(gc.x + width - itemMenu.width, gc.y - height);
               }
+            }
+
+            Item {
+              visible: !itemMenuVisible && !localFilesModel.inSelectionMode
+              Layout.preferredWidth: Theme.toolButtonSize
+              Layout.preferredHeight: 1
             }
           }
         }


### PR DESCRIPTION
Stabilizes row height in the local data picker's selection mode. The selection checkbox now reserves the same width as the 3-dot menu button, and a spacer reserves that width on the right when the menu button is hidden, so the text column width stays constant and titles wrap identically across states. Also adds spacing between the thumbnail and text.


https://github.com/user-attachments/assets/665cc390-55d6-458f-88e4-f60da78b15a5

