### PR TITLE
Add an 'attention' color highlight for toast messages, use it when a QFieldCloud project has new project data on the server

### DIFF
--- a/src/app/qml/QFieldCloudPopup.qml
+++ b/src/app/qml/QFieldCloudPopup.qml
@@ -940,7 +940,7 @@ Popup {
     if (cloudConnection.status === QFieldCloudConnection.Connecting) {
       displayToast(qsTr('Connecting cloud'));
     } else if (cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.isProjectOutdated) {
-      displayToast(qsTr('This project has an updated project file on the cloud, you are advised to synchronize.'), 'warning');
+      displayToast(qsTr('This project has an updated project file on the cloud, you are advised to synchronize.'), 'attention');
     } else if (cloudProjectsModel.currentProject && cloudProjectsModel.currentProject.isOutdated) {
       displayToast(qsTr('This project has updated data on the cloud, you should synchronize.'));
     }

--- a/src/app/qml/QFieldCloudPopup.qml
+++ b/src/app/qml/QFieldCloudPopup.qml
@@ -529,7 +529,7 @@ Popup {
                 accentColor: Theme.mainColor
                 iconSource: Theme.getThemeVectorIcon('ic_cloud_synchronize_24dp')
                 title: qsTr('Synchronize project')
-                indicatorVisible: !!(cloudProjectsModel.currentProject && (cloudProjectsModel.currentProject.isOutdated || cloudProjectsModel.currentProject.isProjectOutdated))
+                indicatorVisible: cloudProjectsModel.currentProject && (cloudProjectsModel.currentProject.isOutdated || cloudProjectsModel.currentProject.isProjectOutdated)
                 description: qsTr('Uploads your edits, then downloads the latest project from QFieldCloud so everything is up to date.')
                 footnote: {
                   if (!cloudProjectsModel.currentProject) {

--- a/src/core/qml/imports/Theme/QfContainerCard.qml
+++ b/src/core/qml/imports/Theme/QfContainerCard.qml
@@ -73,7 +73,7 @@ Rectangle {
         height: width
         radius: width / 2
         color: containerCard.accentColor
-        visible: containerCard.indicatorCount
+        visible: containerCard.indicatorVisible
 
         Text {
           id: badgeLabel

--- a/src/gui/qml/Toast.qml
+++ b/src/gui/qml/Toast.qml
@@ -119,7 +119,17 @@ Popup {
       bottomLeftRadius: toastContent.radius
       topRightRadius: 0
       bottomRightRadius: 0
-      color: toast.type === 'error' ? Theme.errorColor : Theme.warningColor
+      color: {
+        switch (toast.type) {
+        case 'attention':
+          return Theme.mainColor;
+        case 'error':
+          return Theme.errorColor;
+        case 'warning':
+        default:
+          return Theme.warningColor;
+        }
+      }
       visible: toast.type != 'info'
     }
 


### PR DESCRIPTION
Screenshot of how it looks:

<img width="497" height="790" alt="Screenshot From 2026-07-31 11-54-22" src="https://github.com/user-attachments/assets/41bb2aa4-954b-4adf-b5e3-0abef8220360" />

We were using a warning color before, which was conveying that something might be wrong. In this case, nothing is wrong, we just want to draw attention to the toast. Let's use our beautiful green color instead by adding a new 'attention' mode to the toast message.

The PR also fixes the outdated synchronization badge not showing up.