### PR TITLE
On mobile devices where memory isn't as plenty, reduce memory cost of preview tiles by half

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -907,6 +907,12 @@ void QgsQuickMapCanvasMap::startPreviewJob( int number )
   QgsMapSettings jobSettings = mImageMapSettings;
   jobSettings.setExtent( jobExtent );
 
+#if defined( Q_OS_ANDROID ) || defined( Q_OS_IOS )
+  //reduce quality of preview tiles to cut memory usage (by half)
+  jobSettings.setOutputSize( mapSettings.outputSize() * ( 0.5 / mQuality ) );
+  jobSettings.setOutputDpi( mapSettings.outputDpi() * ( 0.5 / mQuality ) );
+#endif
+
   jobSettings.setFlag( Qgis::MapSettingsFlag::DrawLabeling, false );
   jobSettings.setFlag( Qgis::MapSettingsFlag::RenderPreviewJob, true );
   jobSettings.setFlag( Qgis::MapSettingsFlag::RecordProfile, false );


### PR DESCRIPTION
Let's consider merging this to reduce memory saturation crashes _if_ the visual cost isn't that bad.