### PR TITLE
Fix harmless console warning when shutting down QField with gallery editor widget(s) instantiated

### DIFF
--- a/src/gui/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/gui/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -28,7 +28,7 @@ RelationEditorBase {
     }
   }
 
-  property bool isCardView: settings.valueBool("/QField/RelationEditor/GalleryCardView", true)
+  property bool isCardView: !settings || settings.valueBool("/QField/RelationEditor/GalleryCardView", true)
   property string imagePrefix: {
     if (qgisProject == undefined)
       return "";


### PR DESCRIPTION
The warning is harmless but the less noisy our console is, the easier it is to pay attention to harmful output being printed.