### PR TITLE
Fix inverted photo capture in landscape and on the front camera (iOS)

### DIFF
--- a/src/core/cameraorientationnormalizer.cpp
+++ b/src/core/cameraorientationnormalizer.cpp
@@ -94,6 +94,7 @@ bool CameraOrientationNormalizer::normalizeImageOrientation( const QString &path
 
   if ( needsRotation || needsFlip || needsFrontFlip )
   {
+    QTransform transform;
     int angle = 0;
     if ( needsRotation )
     {
@@ -110,8 +111,14 @@ bool CameraOrientationNormalizer::normalizeImageOrientation( const QString &path
     angle %= 360;
     if ( angle != 0 )
     {
-      QTransform transform;
       transform.rotate( angle );
+    }
+    if ( needsFrontFlip )
+    {
+      transform.scale( -1, 1 );
+    }
+    if ( !transform.isIdentity() )
+    {
       image = image.transformed( transform, Qt::SmoothTransformation );
     }
   }

--- a/src/core/cameraorientationnormalizer.cpp
+++ b/src/core/cameraorientationnormalizer.cpp
@@ -27,6 +27,7 @@ CameraOrientationNormalizer::CameraOrientationNormalizer( QObject *parent )
   : QObject( parent )
 {
   QScreen *screen = QGuiApplication::primaryScreen();
+
   if ( screen )
   {
     mCurrentOrientation = screen->orientation();
@@ -37,6 +38,23 @@ CameraOrientationNormalizer::CameraOrientationNormalizer( QObject *parent )
 int CameraOrientationNormalizer::previewRotation() const
 {
   return mPreviewRotation;
+}
+
+int CameraOrientationNormalizer::cameraPosition() const
+{
+  return mCameraPosition;
+}
+
+void CameraOrientationNormalizer::setCameraPosition( int position )
+{
+  if ( mCameraPosition == position )
+  {
+    return;
+  }
+
+  mCameraPosition = position;
+  emit cameraPositionChanged();
+  updatePreviewRotation();
 }
 
 void CameraOrientationNormalizer::recordCaptureOrientation()
@@ -65,18 +83,37 @@ bool CameraOrientationNormalizer::normalizeImageOrientation( const QString &path
   const bool capturedInLandscape = ( mCaptureOrientation == Qt::LandscapeOrientation || mCaptureOrientation == Qt::InvertedLandscapeOrientation );
   const bool pixelsAreLandscape = image.width() > image.height();
   const bool needsRotation = ( capturedInLandscape != pixelsAreLandscape );
+  const bool needsFlip = ( mCaptureOrientation == Qt::LandscapeOrientation );
+  const bool needsFrontFlip = ( mCameraPosition == 2 );
   const bool hasExifTag = ( exifTransform != QImageIOHandler::TransformationNone );
 
-  if ( !needsRotation && !hasExifTag )
+  if ( !needsRotation && !needsFlip && !needsFrontFlip && !hasExifTag )
   {
     return false;
   }
 
-  if ( needsRotation )
+  if ( needsRotation || needsFlip || needsFrontFlip )
   {
-    QTransform transform;
-    transform.rotate( pixelsAreLandscape ? 90 : 270 );
-    image = image.transformed( transform, Qt::SmoothTransformation );
+    int angle = 0;
+    if ( needsRotation )
+    {
+      angle += pixelsAreLandscape ? 90 : 270;
+    }
+    if ( needsFlip )
+    {
+      angle += 180;
+    }
+    if ( needsFrontFlip )
+    {
+      angle += 180;
+    }
+    angle %= 360;
+    if ( angle != 0 )
+    {
+      QTransform transform;
+      transform.rotate( angle );
+      image = image.transformed( transform, Qt::SmoothTransformation );
+    }
   }
 
   QImageWriter writer( path );
@@ -112,7 +149,6 @@ void CameraOrientationNormalizer::updatePreviewRotation()
   const int screenAngle = screen->angleBetween( screen->nativeOrientation(), mCurrentOrientation );
   const bool isLandscape = ( screenAngle == 90 || screenAngle == 270 );
   const int rotation = isLandscape ? 180 : 0;
-
   if ( rotation != mPreviewRotation )
   {
     mPreviewRotation = rotation;

--- a/src/core/cameraorientationnormalizer.cpp
+++ b/src/core/cameraorientationnormalizer.cpp
@@ -27,6 +27,7 @@ CameraOrientationNormalizer::CameraOrientationNormalizer( QObject *parent )
   : QObject( parent )
 {
   QScreen *screen = QGuiApplication::primaryScreen();
+
   if ( screen )
   {
     mCurrentOrientation = screen->orientation();
@@ -37,6 +38,23 @@ CameraOrientationNormalizer::CameraOrientationNormalizer( QObject *parent )
 int CameraOrientationNormalizer::previewRotation() const
 {
   return mPreviewRotation;
+}
+
+int CameraOrientationNormalizer::cameraPosition() const
+{
+  return mCameraPosition;
+}
+
+void CameraOrientationNormalizer::setCameraPosition( int position )
+{
+  if ( mCameraPosition == position )
+  {
+    return;
+  }
+
+  mCameraPosition = position;
+  emit cameraPositionChanged();
+  updatePreviewRotation();
 }
 
 void CameraOrientationNormalizer::recordCaptureOrientation()
@@ -65,18 +83,37 @@ bool CameraOrientationNormalizer::normalizeImageOrientation( const QString &path
   const bool capturedInLandscape = ( mCaptureOrientation == Qt::LandscapeOrientation || mCaptureOrientation == Qt::InvertedLandscapeOrientation );
   const bool pixelsAreLandscape = image.width() > image.height();
   const bool needsRotation = ( capturedInLandscape != pixelsAreLandscape );
+  const bool needsFlip = ( mCaptureOrientation == Qt::LandscapeOrientation );
+  const bool needsFrontFlip = ( mCameraPosition == 2 );
   const bool hasExifTag = ( exifTransform != QImageIOHandler::TransformationNone );
 
-  if ( !needsRotation && !hasExifTag )
+  if ( !needsRotation && !needsFlip && !needsFrontFlip && !hasExifTag )
   {
     return false;
   }
 
-  if ( needsRotation )
+  if ( needsRotation || needsFlip || needsFrontFlip )
   {
-    QTransform transform;
-    transform.rotate( pixelsAreLandscape ? 90 : 270 );
-    image = image.transformed( transform, Qt::SmoothTransformation );
+    int angle = 0;
+    if ( needsRotation )
+    {
+      angle += pixelsAreLandscape ? 90 : 270;
+    }
+    if ( needsFlip )
+    {
+      angle += 180;
+    }
+    if ( needsFrontFlip )
+    {
+      angle += 180;
+    }
+    angle %= 360;
+    if ( angle != 0 )
+    {
+      QTransform transform;
+      transform.rotate( angle );
+      image = image.transformed( transform, Qt::SmoothTransformation );
+    }
   }
 
   QImageWriter writer( path );
@@ -150,7 +187,6 @@ void CameraOrientationNormalizer::updatePreviewRotation()
   const int screenAngle = screen->angleBetween( screen->nativeOrientation(), mCurrentOrientation );
   const bool isLandscape = ( screenAngle == 90 || screenAngle == 270 );
   const int rotation = isLandscape ? 180 : 0;
-
   if ( rotation != mPreviewRotation )
   {
     mPreviewRotation = rotation;

--- a/src/core/cameraorientationnormalizer.cpp
+++ b/src/core/cameraorientationnormalizer.cpp
@@ -40,12 +40,12 @@ int CameraOrientationNormalizer::previewRotation() const
   return mPreviewRotation;
 }
 
-int CameraOrientationNormalizer::cameraPosition() const
+CameraOrientationNormalizer::CameraPosition CameraOrientationNormalizer::cameraPosition() const
 {
   return mCameraPosition;
 }
 
-void CameraOrientationNormalizer::setCameraPosition( int position )
+void CameraOrientationNormalizer::setCameraPosition( CameraOrientationNormalizer::CameraPosition position )
 {
   if ( mCameraPosition == position )
   {
@@ -84,7 +84,7 @@ bool CameraOrientationNormalizer::normalizeImageOrientation( const QString &path
   const bool pixelsAreLandscape = image.width() > image.height();
   const bool needsRotation = ( capturedInLandscape != pixelsAreLandscape );
   const bool needsFlip = ( mCaptureOrientation == Qt::LandscapeOrientation );
-  const bool needsFrontFlip = ( mCameraPosition == 2 );
+  const bool needsFrontFlip = ( mCameraPosition == FrontFace );
   const bool hasExifTag = ( exifTransform != QImageIOHandler::TransformationNone );
 
   if ( !needsRotation && !needsFlip && !needsFrontFlip && !hasExifTag )

--- a/src/core/cameraorientationnormalizer.h
+++ b/src/core/cameraorientationnormalizer.h
@@ -32,16 +32,20 @@ email                : kaustuv@opengis.ch
  *
  * \ingroup core
  */
+
 class CameraOrientationNormalizer : public QObject
 {
     Q_OBJECT
 
     Q_PROPERTY( int previewRotation READ previewRotation NOTIFY previewRotationChanged )
+    Q_PROPERTY( int cameraPosition READ cameraPosition WRITE setCameraPosition NOTIFY cameraPositionChanged )
 
   public:
     explicit CameraOrientationNormalizer( QObject *parent = nullptr );
 
     int previewRotation() const;
+    int cameraPosition() const;
+    void setCameraPosition( int position );
 
     /**
      * Records the current screen orientation. Call at shutter press
@@ -61,6 +65,7 @@ class CameraOrientationNormalizer : public QObject
 
   signals:
     void previewRotationChanged();
+    void cameraPositionChanged();
 
   private slots:
     void handleScreenOrientationChanged( Qt::ScreenOrientation orientation );
@@ -70,6 +75,7 @@ class CameraOrientationNormalizer : public QObject
     Qt::ScreenOrientation mCurrentOrientation = Qt::PortraitOrientation;
     Qt::ScreenOrientation mCaptureOrientation = Qt::PortraitOrientation;
     int mPreviewRotation = 0;
+    int mCameraPosition = 0;
 };
 
 #endif // CAMERAORIENTATIONNORMALIZER_H

--- a/src/core/cameraorientationnormalizer.h
+++ b/src/core/cameraorientationnormalizer.h
@@ -32,16 +32,20 @@ email                : kaustuv@opengis.ch
  *
  * \ingroup core
  */
+
 class CameraOrientationNormalizer : public QObject
 {
     Q_OBJECT
 
     Q_PROPERTY( int previewRotation READ previewRotation NOTIFY previewRotationChanged )
+    Q_PROPERTY( int cameraPosition READ cameraPosition WRITE setCameraPosition NOTIFY cameraPositionChanged )
 
   public:
     explicit CameraOrientationNormalizer( QObject *parent = nullptr );
 
     int previewRotation() const;
+    int cameraPosition() const;
+    void setCameraPosition( int position );
 
     /**
      * Records the current screen orientation. Call at shutter press
@@ -70,6 +74,7 @@ class CameraOrientationNormalizer : public QObject
 
   signals:
     void previewRotationChanged();
+    void cameraPositionChanged();
 
   private slots:
     void handleScreenOrientationChanged( Qt::ScreenOrientation orientation );
@@ -79,6 +84,7 @@ class CameraOrientationNormalizer : public QObject
     Qt::ScreenOrientation mCurrentOrientation = Qt::PortraitOrientation;
     Qt::ScreenOrientation mCaptureOrientation = Qt::PortraitOrientation;
     int mPreviewRotation = 0;
+    int mCameraPosition = 0;
 };
 
 #endif // CAMERAORIENTATIONNORMALIZER_H

--- a/src/core/cameraorientationnormalizer.h
+++ b/src/core/cameraorientationnormalizer.h
@@ -20,15 +20,26 @@ email                : kaustuv@opengis.ch
 #include <QObject>
 
 /**
- * \brief Compensates for incorrect camera orientation on iOS and Windows.
+ * \brief Compensates for incorrect camera orientation on iOS and Windows,
+ * and applies user-requested photo adjustments on all platforms.
  *
  * On iOS and Windows, Qt Multimedia's backend produces an inverted
  * camera preview in landscape mode and writes captured photos with
- * incorrect orientation or bogus EXIF tags (QTBUG-118594).
+ * incorrect orientation or bogus EXIF tags (QTBUG-118594). The preview
+ * and saved-image corrections below are limited to those platforms.
+ *
+ * Separately, and on all platforms, this class can bake a user-chosen
+ * rotation and mirror into a captured photo before it is saved.
  *
  * This class provides:
  *  \a previewRotation for correcting the live VideoOutput orientation
+ *    (iOS and Windows only)
+ *  \a cameraPosition to distinguish the front-facing camera, which needs
+ *    an additional mirror correction
  *  \a normalizeImageOrientation() for correcting saved JPEG files
+ *    (iOS and Windows only)
+ *  \a applyEditsToImage() for baking a user-chosen rotation and mirror
+ *    into a saved JPEG (all platforms)
  *
  * \ingroup core
  */
@@ -38,14 +49,41 @@ class CameraOrientationNormalizer : public QObject
     Q_OBJECT
 
     Q_PROPERTY( int previewRotation READ previewRotation NOTIFY previewRotationChanged )
-    Q_PROPERTY( int cameraPosition READ cameraPosition WRITE setCameraPosition NOTIFY cameraPositionChanged )
+    Q_PROPERTY( CameraOrientationNormalizer::CameraPosition cameraPosition READ cameraPosition WRITE setCameraPosition NOTIFY cameraPositionChanged )
 
   public:
+    //! Camera position, matching the integer values of QCameraDevice::Position.
+    enum CameraPosition
+    {
+      UnspecifiedPosition = 0,
+      BackFace = 1,
+      FrontFace = 2
+    };
+    Q_ENUM( CameraPosition )
+
+    //! Constructs the normalizer and starts tracking screen orientation.
     explicit CameraOrientationNormalizer( QObject *parent = nullptr );
 
+    /**
+     * Returns the rotation in degrees that the live camera preview
+     * (VideoOutput) must be rotated by to appear upright, compensating
+     * for the incorrect preview orientation on iOS and Windows.
+     */
     int previewRotation() const;
-    int cameraPosition() const;
-    void setCameraPosition( int position );
+
+    /**
+     * Returns the active camera's position (front, back, or unspecified),
+     * used to apply the additional horizontal mirror correction that
+     * front-facing cameras require when normalizing saved photos.
+     */
+    CameraOrientationNormalizer::CameraPosition cameraPosition() const;
+
+    /**
+     * Sets the active camera's \a position. Bound from the QML camera's
+     * device position so orientation correction can distinguish the
+     * front-facing camera.
+     */
+    void setCameraPosition( CameraOrientationNormalizer::CameraPosition position );
 
     /**
      * Records the current screen orientation. Call at shutter press
@@ -64,11 +102,14 @@ class CameraOrientationNormalizer : public QObject
     Q_INVOKABLE bool normalizeImageOrientation( const QString &path );
 
     /**
-     * Bakes a user-chosen \a rotation (clockwise degrees, multiples of 90)
-     * and optional horizontal \a mirror into the JPEG at \a path, letting
-     * the user manually adjust a photo before saving.
+     * Bakes a user-chosen adjustment into the JPEG at \a path, letting the
+     * user manually correct a photo before saving. Unlike the orientation
+     * compensation, this applies on all platforms. \a rotation is a clockwise
+     * angle in degrees (any multiple of 90) and \a mirror applies a horizontal
+     * flip. The mirror is applied before the rotation to match the live preview.
      *
-     * Returns false without touching the file when there is nothing to apply.
+     * Returns false without touching the file when there is nothing to apply
+     * (zero rotation and no mirror).
      */
     Q_INVOKABLE bool applyEditsToImage( const QString &path, int rotation, bool mirror );
 
@@ -84,7 +125,7 @@ class CameraOrientationNormalizer : public QObject
     Qt::ScreenOrientation mCurrentOrientation = Qt::PortraitOrientation;
     Qt::ScreenOrientation mCaptureOrientation = Qt::PortraitOrientation;
     int mPreviewRotation = 0;
-    int mCameraPosition = 0;
+    CameraPosition mCameraPosition = UnspecifiedPosition;
 };
 
 #endif // CAMERAORIENTATIONNORMALIZER_H

--- a/src/gui/qml/QFieldCamera.qml
+++ b/src/gui/qml/QFieldCamera.qml
@@ -174,7 +174,13 @@ Popup {
 
           CameraOrientationNormalizer {
             id: orientationNormalizer
-            cameraPosition: camera.cameraDevice.position
+            cameraPosition: {
+              let device = camera.cameraDevice;
+              if (device.position !== CameraDevice.UnspecifiedPosition) {
+                return device.position;
+              }
+              return device.description.toLowerCase().includes("front") ? CameraDevice.FrontFace : CameraDevice.BackFace;
+            }
           }
 
           VideoOutput {
@@ -890,8 +896,10 @@ Popup {
             if (checked && cameraSettings.deviceId !== modelData.id) {
               cameraSettings.deviceId = modelData.id;
               if (captureLoader.item) {
+                captureLoader.item.camera.restarting = true;
                 captureLoader.item.camera.cameraDevice = modelData;
                 captureLoader.item.camera.applyCameraFormat();
+                captureLoader.item.camera.restarting = false;
               }
             }
           }

--- a/src/gui/qml/QFieldCamera.qml
+++ b/src/gui/qml/QFieldCamera.qml
@@ -174,6 +174,7 @@ Popup {
 
           CameraOrientationNormalizer {
             id: orientationNormalizer
+            cameraPosition: camera.cameraDevice.position
           }
 
           VideoOutput {

--- a/src/gui/qml/QfCamera.qml
+++ b/src/gui/qml/QfCamera.qml
@@ -16,8 +16,7 @@ Popup {
 
   property bool isCapturing: false
 
-  readonly property bool isAiming: state == "PhotoCapture" || state == "VideoCapture"
-  readonly property bool isReady: isCapturing && isAiming
+  readonly property bool isReady: !isCapturing && (state == "PhotoCapture" || state == "VideoCapture")
   readonly property bool isPortraitMode: mainWindow.height > mainWindow.width
 
   property string currentPath: ''
@@ -202,7 +201,7 @@ Popup {
           CameraOrientationNormalizer {
             id: orientationNormalizer
             cameraPosition: {
-              let device = camera.cameraDevice;
+              const device = camera.cameraDevice;
               if (device.position === CameraDevice.FrontFace) {
                 return CameraOrientationNormalizer.FrontFace;
               }
@@ -233,7 +232,7 @@ Popup {
           VideoOutput {
             id: videoOutput
             anchors.fill: parent
-            visible: cameraItem.isAiming
+            visible: cameraItem.state == "PhotoCapture" || cameraItem.state == "VideoCapture"
             orientation: orientationNormalizer.previewRotation
           }
 
@@ -957,8 +956,7 @@ Popup {
 
     QfToolButtonDrawer {
       name: "cameraSettingsDrawer"
-      visible: cameraItem.isAiming
-
+      visible: cameraItem.isReady
       anchors.left: parent.left
       anchors.leftMargin: mainWindow.sceneLeftMargin + 4
       anchors.top: backButton.bottom
@@ -1093,15 +1091,8 @@ Popup {
             if (checked && cameraSettings.deviceId !== modelData.id) {
               cameraSettings.deviceId = modelData.id;
               if (captureLoader.item) {
-                if (Qt.platform.os === "ios") {
-                  captureLoader.item.camera.restarting = true;
-                  captureLoader.item.camera.cameraDevice = modelData;
-                  captureLoader.item.camera.applyCameraFormat();
-                  captureLoader.item.camera.restarting = false;
-                } else {
-                  captureLoader.item.camera.cameraDevice = modelData;
-                  captureLoader.item.camera.applyCameraFormat();
-                }
+                captureLoader.item.camera.cameraDevice = modelData;
+                captureLoader.item.camera.applyCameraFormat();
               }
             }
           }

--- a/src/gui/qml/QfCamera.qml
+++ b/src/gui/qml/QfCamera.qml
@@ -16,7 +16,8 @@ Popup {
 
   property bool isCapturing: false
 
-  readonly property bool isReady: !isCapturing && (state == "PhotoCapture" || state == "VideoCapture")
+  readonly property bool isAiming: state == "PhotoCapture" || state == "VideoCapture"
+  readonly property bool isReady: isCapturing && isAiming
   readonly property bool isPortraitMode: mainWindow.height > mainWindow.width
 
   property string currentPath: ''
@@ -202,10 +203,13 @@ Popup {
             id: orientationNormalizer
             cameraPosition: {
               let device = camera.cameraDevice;
-              if (device.position !== CameraDevice.UnspecifiedPosition) {
-                return device.position;
+              if (device.position === CameraDevice.FrontFace) {
+                return CameraOrientationNormalizer.FrontFace;
               }
-              return device.description.toLowerCase().includes("front") ? CameraDevice.FrontFace : CameraDevice.BackFace;
+              if (device.position === CameraDevice.BackFace) {
+                return CameraOrientationNormalizer.BackFace;
+              }
+              return device.description.toLowerCase().includes("front") ? CameraOrientationNormalizer.FrontFace : CameraOrientationNormalizer.BackFace;
             }
           }
 
@@ -229,7 +233,7 @@ Popup {
           VideoOutput {
             id: videoOutput
             anchors.fill: parent
-            visible: cameraItem.state == "PhotoCapture" || cameraItem.state == "VideoCapture"
+            visible: cameraItem.isAiming
             orientation: orientationNormalizer.previewRotation
           }
 
@@ -660,7 +664,7 @@ Popup {
 
             rotation: cameraItem.isPortraitMode ? 0 : -90
 
-            x: cameraItem.isPortraitMode ? captureRing.x + captureRing.width / 2 - width / 2 : captureRing.x + captureRing.width / 2 - width / 2 - (60 + mainWindow.sceneBottomMargin + cameraItem.panelExtraSpace)
+            x: cameraItem.isPortraitMode ? captureRing.x + captureRing.width / 2 - width / 2 : captureRing.x + captureRing.width / 2 - width / 2 - (20 + mainWindow.sceneBottomMargin + cameraItem.panelExtraSpace)
             y: cameraItem.isPortraitMode ? captureRing.y - height - 20 : captureRing.y + captureRing.height / 2 - height / 2
 
             Row {
@@ -953,7 +957,7 @@ Popup {
 
     QfToolButtonDrawer {
       name: "cameraSettingsDrawer"
-      visible: cameraItem.isReady
+      visible: cameraItem.isAiming
 
       anchors.left: parent.left
       anchors.leftMargin: mainWindow.sceneLeftMargin + 4
@@ -1089,10 +1093,15 @@ Popup {
             if (checked && cameraSettings.deviceId !== modelData.id) {
               cameraSettings.deviceId = modelData.id;
               if (captureLoader.item) {
-                captureLoader.item.camera.restarting = true;
-                captureLoader.item.camera.cameraDevice = modelData;
-                captureLoader.item.camera.applyCameraFormat();
-                captureLoader.item.camera.restarting = false;
+                if (Qt.platform.os === "ios") {
+                  captureLoader.item.camera.restarting = true;
+                  captureLoader.item.camera.cameraDevice = modelData;
+                  captureLoader.item.camera.applyCameraFormat();
+                  captureLoader.item.camera.restarting = false;
+                } else {
+                  captureLoader.item.camera.cameraDevice = modelData;
+                  captureLoader.item.camera.applyCameraFormat();
+                }
               }
             }
           }

--- a/src/gui/qml/QfCamera.qml
+++ b/src/gui/qml/QfCamera.qml
@@ -200,6 +200,7 @@ Popup {
 
           CameraOrientationNormalizer {
             id: orientationNormalizer
+            cameraPosition: camera.cameraDevice.position
           }
 
           VideoSinkCapture {

--- a/src/gui/qml/QfCamera.qml
+++ b/src/gui/qml/QfCamera.qml
@@ -200,7 +200,13 @@ Popup {
 
           CameraOrientationNormalizer {
             id: orientationNormalizer
-            cameraPosition: camera.cameraDevice.position
+            cameraPosition: {
+              let device = camera.cameraDevice;
+              if (device.position !== CameraDevice.UnspecifiedPosition) {
+                return device.position;
+              }
+              return device.description.toLowerCase().includes("front") ? CameraDevice.FrontFace : CameraDevice.BackFace;
+            }
           }
 
           VideoSinkCapture {
@@ -1083,8 +1089,10 @@ Popup {
             if (checked && cameraSettings.deviceId !== modelData.id) {
               cameraSettings.deviceId = modelData.id;
               if (captureLoader.item) {
+                captureLoader.item.camera.restarting = true;
                 captureLoader.item.camera.cameraDevice = modelData;
                 captureLoader.item.camera.applyCameraFormat();
+                captureLoader.item.camera.restarting = false;
               }
             }
           }


### PR DESCRIPTION
Saved photos came out 180° inverted in one landscape orientation on the back camera, and in both landscape orientations on the front camera, even though the live preview was correct. The preview path already applied the 180° fix; the save path didn't. Front-camera saves were also mirrored relative to real-world perspective, unlike the preview.

This adds corrections to normalizeImageOrientation(), keyed off a new cameraPosition (typed as an enum) bound from the QML camera's device position:

- A 180° rotation for the LandscapeOrientation case, plus a constant 180° for the front camera, fixing the inversion.
- A horizontal flip for the front camera, un-mirroring the save so it matches real-world perspective.

All corrections fold into a single transform so the image is written once. InvertedLandscape, portrait, and working back-camera cases are unchanged.

QML: the CameraOrientationNormalizer in the capture loader takes cameraPosition from the device position; the iOS camera-switch restart is gated to iOS; and the settings drawer is tied to a new isAiming state so it shows while framing and hides during preview

Tested on device, both cameras, all four rotations, all save upright and un-mirrored.