### PR TITLE
Fix two vcpkg-related CMake path resolutions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
   # The QmlImportScanner is not discovered on the host path, it should probably be caught by
   # https://github.com/qt/qtbase/blob/8c14b0c/cmake/QtConfig.cmake.in#L104-L122
   # at least we know where to find it:
-  set(Qt6QmlImportScanner_DIR "${VCPKG_INSTALLED_DIR}/share/Qt6QmlImportScanner")
+  set(Qt6QmlImportScanner_DIR "${QT_HOST_PATH}/share/Qt6QmlImportScanner")
   message(STATUS "QT_HOST_PATH: ${QT_HOST_PATH}")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,10 +190,6 @@ if(ANDROID)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
   set(QT_HOST_PATH "${VCPKG_INSTALLED_DIR}/${VCPKG_HOST_TRIPLET}")
   set(QT_HOST_PATH_CMAKE_DIR "${QT_HOST_PATH}/share")
-  # The QmlImportScanner is not discovered on the host path, it should probably be caught by
-  # https://github.com/qt/qtbase/blob/8c14b0c/cmake/QtConfig.cmake.in#L104-L122
-  # at least we know where to find it:
-  set(Qt6QmlImportScanner_DIR "${QT_HOST_PATH}/share/Qt6QmlImportScanner")
   message(STATUS "QT_HOST_PATH: ${QT_HOST_PATH}")
 endif()
 

--- a/cmake/FindQGIS.cmake
+++ b/cmake/FindQGIS.cmake
@@ -120,7 +120,9 @@ if(QGIS_FOUND)
 endif()
 
 if(WITH_VCPKG)
-  include("cmake/qgis-cmake-wrapper.cmake")
+  # The two files are siblings, so resolve the companion relative to this one.
+  # A project-relative path only works while QField is the top-level project.
+  include("${CMAKE_CURRENT_LIST_DIR}/qgis-cmake-wrapper.cmake")
 else()
   target_include_directories(QGIS::Core INTERFACE ${GDAL_INCLUDE_DIR})
 endif()


### PR DESCRIPTION
`FindQGIS.cmake` pulled in its companion with `include("cmake/qgis-cmake-wrapper.cmake")`, a project-relative path that only resolves while QField is the top-level project. The two files are siblings, so `CMAKE_CURRENT_LIST_DIR` resolves correctly either way. No change for QField's own builds.

`Qt6QmlImportScanner_DIR` was set to `${VCPKG_INSTALLED_DIR}/share/Qt6QmlImportScanner`, which omits the triplet segment. The directory actually lives at `${VCPKG_INSTALLED_DIR}/<host-triplet>/share/Qt6QmlImportScanner`, which is what `QT_HOST_PATH` holds two lines above. This is latent today (the non-existent path just makes `find_package` fall back to its normal search), so it is a correctness tidy-up rather than a fix for an observed failure.