### PR TITLE
Fix two compile errors (in configurations CI does not build)

### DIFF
--- a/src/core/platforms/ios/iosprojectsource.mm
+++ b/src/core/platforms/ios/iosprojectsource.mm
@@ -217,7 +217,7 @@ QString IosProjectSource::projectFromFolder(const QString &folder) const {
   folderPath.remove(QStringLiteral("file://"));
   QDir directory(folderPath);
   if (!directory.exists()) {
-    return;
+    return QString();
   }
   const QStringList projects = directory.entryList(QStringList() << "*.qgs"
                                                                  << "*.QGS"

--- a/src/core/positioning/positioningdevicemodel.cpp
+++ b/src/core/positioning/positioningdevicemodel.cpp
@@ -169,10 +169,12 @@ const QString PositioningDeviceModel::deviceId( const Device &device ) const
       return QString();
 
     case BluetoothDevice:
+#ifdef WITH_BLUETOOTH
       if ( device.settings.value( QStringLiteral( "ble" ) ).toBool() )
       {
         return QStringLiteral( "%1:%2" ).arg( BluetoothLowEnergyReceiver::identifier, device.settings.value( QStringLiteral( "address" ) ).toString() );
       }
+#endif
       return QStringLiteral( "%1" ).arg( device.settings.value( QStringLiteral( "address" ) ).toString() );
 
     case TcpDevice:


### PR DESCRIPTION
`positioningdevicemodel.cpp` is compiled unconditionally, but the `BluetoothDevice` branch of `PositioningDeviceModel::deviceId()` referenced `BluetoothLowEnergyReceiver::identifier` without a guard, while the header include and the `SerialPortDevice` branch below both have one. Building with `-DWITH_BLUETOOTH=OFF` fails with use of undeclared identifier `BluetoothLowEnergyReceiver`. This guards only the BLE sub-branch, mirroring the `WITH_SERIALPORT` treatment; the plain Bluetooth address path references no Bluetooth class and stays. Behaviour with `WITH_BLUETOOTH=ON` is unchanged.

In `iosprojectsource.mm`, the non-existent-directory early exit used a bare `return`; in a function returning `QString`, which recent clang rejects as an error under `-Wreturn-mismatch`. It now returns a default-constructed `QString`, matching the function's own fall-through. The other bare returns in the iOS platform sources are all in void functions.

Found while building QField's core as a library for iOS (see #7831)