### PR TITLE
Disable QGIS missing-font downloads on iOS

### DIFF
--- a/src/app/qgismobileapp.cpp
+++ b/src/app/qgismobileapp.cpp
@@ -245,7 +245,11 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
     }
   }
 
+#if defined( Q_OS_IOS )
+  QgsFontManager::settingsDownloadMissingFonts->setValue( false );
+#else
   QgsApplication::fontManager()->enableFontDownloadsForSession();
+#endif
 
   mProject = QgsProject::instance();
   connect( mProject, &QgsProject::aboutToBeCleared, this, [this] {


### PR DESCRIPTION
Opening a project whose layout references a font not installed on the device crashes on iOS during load (affects the bundled sample projects).

Root cause is a stack overflow in QGIS `detailsForFontDownload`, mitigation only, proper fix belongs upstream in QGIS. Non-iOS platforms unchanged.