### PR TITLE
Fix qfield_core's install rules and QT_HOST_PATH handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,13 @@ if(ANDROID)
   get_filename_component(QT_ANDROID_PATH_CMAKE_DIR_${ANDROID_ABI} "${Qt6_DIR}/.." ABSOLUTE)
   message(STATUS "QT_ANDROID_PATH_CMAKE_DIR_${ANDROID_ABI}: ${QT_ANDROID_PATH_CMAKE_DIR_${ANDROID_ABI}}")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
-  set(QT_HOST_PATH "${VCPKG_INSTALLED_DIR}/${VCPKG_HOST_TRIPLET}")
+  # A caller may already know where the host tools are and pass QT_HOST_PATH in.
+  # Deriving it unconditionally would overwrite that with
+  # "${VCPKG_INSTALLED_DIR}/" whenever VCPKG_HOST_TRIPLET is not set, and
+  # Qt6Config would then fail to find the host Qt.
+  if(NOT QT_HOST_PATH)
+    set(QT_HOST_PATH "${VCPKG_INSTALLED_DIR}/${VCPKG_HOST_TRIPLET}")
+  endif()
   set(QT_HOST_PATH_CMAKE_DIR "${QT_HOST_PATH}/share")
   # The QmlImportScanner is not discovered on the host path, it should probably be caught by
   # https://github.com/qt/qtbase/blob/8c14b0c/cmake/QtConfig.cmake.in#L104-L122

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -296,34 +296,41 @@ generate_export_header(qfield_core)
 
 configure_file(qfield.h.in ${CMAKE_CURRENT_BINARY_DIR}/qfield.h @ONLY)
 
-target_include_directories(qfield_core SYSTEM
-                           PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(
+  qfield_core SYSTEM PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "iOS")
   target_compile_options(qfield_core PRIVATE "-fobjc-arc")
 endif()
 
+# The public headers are installed flat into ${QFIELD_INCLUDE_SUBDIR}, so a
+# consumer of the installed library needs that one directory, not the source
+# tree. Without the BUILD_INTERFACE wrappers these absolute paths are baked into
+# any exported target and only resolve on the build machine.
 target_include_directories(
   qfield_core
-  PUBLIC ${CMAKE_SOURCE_DIR}/src/core
-         ${CMAKE_SOURCE_DIR}/src/core/cogo
-         ${CMAKE_SOURCE_DIR}/src/core/locator
-         ${CMAKE_SOURCE_DIR}/src/core/platforms
-         ${CMAKE_SOURCE_DIR}/src/core/qgsquick
-         ${CMAKE_SOURCE_DIR}/src/core/3d
-         ${CMAKE_SOURCE_DIR}/src/core/utils
-         ${CMAKE_SOURCE_DIR}/src/core/positioning
-         ${CMAKE_SOURCE_DIR}/src/core/processing
-         ${CMAKE_SOURCE_DIR}/src/core/qfieldcloud)
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/core>
+         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/core/cogo>
+         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/core/locator>
+         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/core/platforms>
+         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/core/qgsquick>
+         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/core/3d>
+         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/core/utils>
+         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/core/positioning>
+         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/core/processing>
+         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/core/qfieldcloud>
+         $<INSTALL_INTERFACE:${QFIELD_INCLUDE_SUBDIR}>)
 if(ANDROID)
   string(REPLACE "_" "_1" APP_PACKAGE_JNI_NAME "${APP_PACKAGE_NAME}")
   configure_file(platforms/android/qfield_android.h.in
                  ${CMAKE_CURRENT_BINARY_DIR}/qfield_android.h @ONLY)
   target_include_directories(
-    qfield_core PUBLIC ${CMAKE_SOURCE_DIR}/src/core/platforms/android)
+    qfield_core
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/core/platforms/android>)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
-  target_include_directories(qfield_core
-                             PUBLIC ${CMAKE_SOURCE_DIR}/src/core/platforms/ios)
+  target_include_directories(
+    qfield_core
+    PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/core/platforms/ios>)
 endif()
 
 target_compile_features(qfield_core PUBLIC cxx_std_20)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -420,7 +420,12 @@ if(MSVC)
            ${OPENH264_LIBRARY})
 endif()
 
-install(FILES ${QFIELD_CORE_HDRS} DESTINATION ${QFIELD_INCLUDE_DIR})
+# generate_export_header() writes qfield_core_export.h into the build tree, and
+# installed public headers (theme.h, qgsquickmapsettings.h, platformutilities.h,
+# ...) include it, so it has to ship alongside them.
+install(FILES ${QFIELD_CORE_HDRS}
+              "${CMAKE_CURRENT_BINARY_DIR}/qfield_core_export.h"
+        DESTINATION ${QFIELD_INCLUDE_DIR})
 install(
   TARGETS qfield_core
   BUNDLE DESTINATION ${QFIELD_BIN_DIR}


### PR DESCRIPTION
Three small build-system fixes, found while building `qfield_core` as a standalone library. None of them change QField's own build.

- **Scope the public include directories to the build tree.** `qfield_core`'s `PUBLIC` include directories are absolute paths into the source tree, added unconditionally, so any installed or exported target carries paths that only exist on the machine that built it. They're now wrapped in `BUILD_INTERFACE`, with one `INSTALL_INTERFACE` entry pointing at `QFIELD_INCLUDE_SUBDIR`, where `install(FILES ${QFIELD_CORE_HDRS})` already puts the headers, flat.

- **Install the generated `qfield_core_export.h`.** `generate_export_header()` writes it into the build tree, and 15 of the public headers that get installed `#include` it (`theme.h`, `platformutilities.h`, `fileutils.h`, ...) but the generated header itself was never installed, so the installed headers don't compile.

- **Don't overwrite a caller-provided `QT_HOST_PATH`.** On iOS it's derived from `VCPKG_HOST_TRIPLET` unconditionally. If a caller already knows where the host tools are and passes it in, that gets replaced with `"${VCPKG_INSTALLED_DIR}/"` whenever `VCPKG_HOST_TRIPLET` isn't set, and `Qt6Config` then fails to find the host Qt. Now only derived when unset.