### PR TITLE
Restore plugin imports of 3d types and the Theme singleton

### DIFF
--- a/src/app/qfieldappqmlregistration.cpp
+++ b/src/app/qfieldappqmlregistration.cpp
@@ -36,6 +36,7 @@ namespace QFieldApp
     // registering everything twice, which would duplicate the singletons.
     qmlRegisterModule( "org.qfield", 1, 0 );
     qmlRegisterModuleImport( "org.qfield", QQmlModuleImportModuleAny, "org.qfield.core", QQmlModuleImportLatest );
+    qmlRegisterModuleImport( "org.qfield", QQmlModuleImportModuleAny, "org.qfield._3d", QQmlModuleImportLatest );
     qmlRegisterModuleImport( "org.qfield", QQmlModuleImportModuleAny, "org.qfield.gui", QQmlModuleImportLatest );
     qmlRegisterModuleImport( "org.qfield", QQmlModuleImportModuleAny, "org.qfield.app", QQmlModuleImportLatest );
 

--- a/src/app/qfieldappqmlregistration.cpp
+++ b/src/app/qfieldappqmlregistration.cpp
@@ -42,6 +42,7 @@ namespace QFieldApp
 
     // Same for Theme, which used to hold the Qf components now living in gui.
     qmlRegisterModule( "Theme", 1, 0 );
+    qmlRegisterModuleImport( "Theme", QQmlModuleImportModuleAny, "org.qfield.core", QQmlModuleImportLatest );
     qmlRegisterModuleImport( "Theme", QQmlModuleImportModuleAny, "org.qfield.gui", QQmlModuleImportLatest );
   }
 } // namespace QFieldApp


### PR DESCRIPTION
### 🚀 Description

The QML module restructuring left two gaps in the `org.qfield` / `Theme` compatibility modules that existing plugins still rely on:

- `org.qfield` re-exported core, gui and app, but not `org.qfield._3d`, so the 3d types registered there were unreachable through the old import.
- `Theme` only re-exported gui (where the Qf components moved), while the `Theme` singleton itself lives in core. A plugin doing `import Theme` and using `Theme.defaultFont` got `ReferenceError: Theme is not defined`.

Both are fixed by adding the missing module imports to the alias block.