### PR TITLE
CMake: Add WITH_APP / WITH_CORE / WITH_GUI / WITH_3D / WITH_EXTERNAL_VCPKG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,12 +21,44 @@ string(REGEX REPLACE "v" "" CLEAN_APP_VERSION "${APP_VERSION}")
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
+# Which layers to build. Turning WITH_APP off leaves only libraries, so QField
+# can be embedded into another application: the app, the Android service, the
+# tests, the launcher icons, the resource `deploy` target and the packaging
+# rules are all skipped. WITH_GUI and WITH_3D follow WITH_APP by default, so an
+# embedder opts into them explicitly and pays for Qt Quick 3D only on request.
+set(WITH_APP ON CACHE BOOL "Build the QField application")
+set(WITH_CORE ON CACHE BOOL "Build the qfield_core library")
+set(WITH_GUI ${WITH_APP} CACHE BOOL "Build the qfield_gui library and the org.qfield.gui QML module")
+set(WITH_3D ${WITH_APP} CACHE BOOL "Build the qfield_3d library and the org.qfield.3d QML module")
+
+if(NOT WITH_CORE AND (WITH_APP OR WITH_GUI OR WITH_3D))
+  message(FATAL_ERROR "WITH_APP, WITH_GUI and WITH_3D all require WITH_CORE.")
+endif()
+if(WITH_APP AND NOT (WITH_GUI AND WITH_3D))
+  message(FATAL_ERROR "WITH_APP requires both WITH_GUI and WITH_3D.")
+endif()
+
+# When ON, the caller supplies the vcpkg toolchain and installed tree (this is
+# the case when QField is built as a vcpkg port), so the bundled vcpkg bootstrap
+# must not run and must not override CMAKE_TOOLCHAIN_FILE.
+set(WITH_EXTERNAL_VCPKG OFF CACHE BOOL "vcpkg is provided by the caller; skip the bundled vcpkg bootstrap")
+
 # Platform specific fixes (android, macos, ...)
 include(Platform)
 # Obtain git revision
 include(GetGitRevisionDescription)
 # The vcpkg toolchain to compile dependencies
-include(VcpkgToolchain)
+if(WITH_EXTERNAL_VCPKG)
+  # Dependencies still come from vcpkg, so WITH_VCPKG must stay on: FindQGIS
+  # keys the qgis-cmake-wrapper include off it, and without that wrapper
+  # QGIS::Core carries none of its static dependencies.
+  set(WITH_VCPKG ON CACHE BOOL "Use the vcpkg submodule for dependency management." FORCE)
+  # VcpkgToolchain is also where find_package(Git) happens, and
+  # GetGitRevisionDescription needs GIT_EXECUTABLE below.
+  find_package(Git REQUIRED)
+else()
+  include(VcpkgToolchain)
+endif()
 # The default installation paths
 include(GNUInstallDirs)
 
@@ -97,7 +129,7 @@ set(WITH_SAMPLE_PROJECTS
     ON
     CACHE BOOL "Enable sample projects")
 
-if (WITH_SAMPLE_PROJECTS)
+if (WITH_SAMPLE_PROJECTS AND WITH_APP)
   install(DIRECTORY ${CMAKE_SOURCE_DIR}/resources/sample_projects DESTINATION ${CMAKE_INSTALL_DATADIR}/qfield)
 endif()
 
@@ -132,6 +164,8 @@ if (ANDROID)
   set(ANDROID_PACKAGE_SOURCE_DIR ${CMAKE_BINARY_DIR}/android-template)
   set(ANDROID_DRAWABLE_DENSITIES mdpi hdpi xhdpi xxhdpi xxxhdpi)
 
+  # Launcher icons only matter for the packaged application.
+  if (WITH_APP)
   foreach(DENSITY ${ANDROID_DRAWABLE_DENSITIES})
     set(DST_DIR "${ANDROID_PACKAGE_SOURCE_DIR}/res/drawable-${DENSITY}")
     file(MAKE_DIRECTORY "${DST_DIR}")
@@ -167,6 +201,7 @@ if (ANDROID)
         DESTINATION "${DST_DRAWABLE_DIR}"
       )
   endif()
+  endif() # WITH_APP
 
 endif()
 
@@ -238,15 +273,23 @@ endif ()
 # Keep the generated QML modules together so tests and Qt Creator find them.
 set(QT_QML_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/qml)
 
-add_subdirectory(src/core)
-add_subdirectory(src/3d)
-add_subdirectory(src/gui)
-if (ANDROID)
-  add_subdirectory(src/service)
+if (WITH_CORE)
+  add_subdirectory(src/core)
 endif()
-add_subdirectory(src/app)
+if (WITH_3D)
+  add_subdirectory(src/3d)
+endif()
+if (WITH_GUI)
+  add_subdirectory(src/gui)
+endif()
+if (WITH_APP)
+  if (ANDROID)
+    add_subdirectory(src/service)
+  endif()
+  add_subdirectory(src/app)
+endif()
 
-if (ENABLE_TESTS)
+if (ENABLE_TESTS AND WITH_APP)
   set (TEST_DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/test/testdata")
 
   find_package(Qt6 COMPONENTS Test QuickTest)
@@ -254,7 +297,9 @@ if (ENABLE_TESTS)
   add_subdirectory(test)
 endif()
 
-if(WITH_VCPKG)
+# Runtime resources (proj/gdal/qgis data, CA bundle) are only staged for the
+# application; an embedding host stages them from its own vcpkg tree.
+if(WITH_VCPKG AND WITH_APP)
   # Copy files from the install dir to where it
   # will be bundled
   add_custom_target(deploy)
@@ -352,10 +397,12 @@ if(WITH_VCPKG)
   add_dependencies(qfield deploy)
 endif()
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND WITH_APP)
   install(FILES ${CMAKE_SOURCE_DIR}/images/icons/qfield_logo.svg DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/128x128/apps RENAME qfield.svg)
   install(FILES ${CMAKE_SOURCE_DIR}/platform/linux/qfield.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/qfield)
   install(FILES ${CMAKE_SOURCE_DIR}/platform/linux/qfield.metainfo.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
 endif()
 
-include(Package)
+if(WITH_APP)
+  include(Package)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,17 +205,27 @@ if (ANDROID)
 
 endif()
 
-find_package(Qt6 COMPONENTS Concurrent Core Qml Gui Xml Positioning Widgets Network Quick Svg Sql Sensors WebView Multimedia Bluetooth Nfc RemoteObjects WebSockets Quick3D REQUIRED)
+if(WITH_CORE)
+  find_package(Qt6 COMPONENTS Concurrent Core Qml Gui Xml Positioning Widgets Network Quick Svg Sql Sensors Multimedia RemoteObjects WebSockets REQUIRED)
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
-  find_package(Qt6 COMPONENTS PrintSupport REQUIRED)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    find_package(Qt6 COMPONENTS PrintSupport REQUIRED)
+  endif()
+
+  find_package(QGIS COMPONENTS Core Analysis REQUIRED)
+  find_package(PROJ REQUIRED)
+  find_package(GDAL REQUIRED)
+  find_package(Qca REQUIRED)
+  find_package(LibZip REQUIRED)
 endif()
 
-find_package(QGIS COMPONENTS Core Analysis REQUIRED)
-find_package(PROJ REQUIRED)
-find_package(GDAL REQUIRED)
-find_package(Qca REQUIRED)
-find_package(LibZip REQUIRED)
+if(WITH_GUI)
+  find_package(Qt6 COMPONENTS WebView REQUIRED)
+endif()
+
+if(WITH_3D)
+  find_package(Qt6 COMPONENTS Quick3D REQUIRED)
+endif()
 
 if(ANDROID)
   # Qt by default assumes that cmake files live in `lib/cmake`. Point to `share` instead.


### PR DESCRIPTION
Lets QField be configured as libraries only, so it can be embedded into another application. Names follow the `WITH_` convention already used for `WITH_BLUETOOTH`, `WITH_SAMPLE_PROJECTS` and friends.

| Option | Default | Gates |
| --- | --- | --- |
| `WITH_APP` | `ON` | app, Android service, tests, deploy target, launcher icons, packaging |
| `WITH_CORE` | `ON` | `qfield_core` |
| `WITH_GUI` | `${WITH_APP}` | `qfield_gui` + `org.qfield.gui` |
| `WITH_3D` | `${WITH_APP}` | `qfield_3d` + `org.qfield.3d` |
| `WITH_EXTERNAL_VCPKG` | `OFF` | skips the bundled vcpkg bootstrap |

`WITH_GUI` and `WITH_3D` default to `WITH_APP` rather than `ON`, so an ordinary build is unchanged while an embedder turning `WITH_APP` off gets core alone and opts into the rest — notably it then doesn't pay for Qt Quick 3D. The dependency direction allows this: `qfield_3d` and `qfield_gui` both link `qfield_core`, and `qfield_app` links all three. Two guards reject the combinations that violate it.

With `WITH_EXTERNAL_VCPKG` the dependencies still come from vcpkg, so `WITH_VCPKG` is forced on — `FindQGIS` keys the `qgis-cmake-wrapper` include off it, and without that wrapper `QGIS::Core` carries none of its static dependencies. `find_package(Git)` moves out of `VcpkgToolchain` since `GetGitRevisionDescription` needs it.