### PR TITLE
Install a CMake package so QField can be consumed with find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,9 @@ file(MAKE_DIRECTORY "${SHARE_DIR}")
 
 if(WITH_SENTRY)
   add_subdirectory(src/sentry)
+else()
+  add_library(qfield_sentry INTERFACE)
+  install(TARGETS qfield_sentry EXPORT qfield-targets)
 endif()
 
 if (WITH_SPIX)
@@ -342,6 +345,7 @@ if(WITH_CORE)
           ${CMAKE_SOURCE_DIR}/cmake/FindPROJ.cmake
           ${CMAKE_SOURCE_DIR}/cmake/FindQca.cmake
           ${CMAKE_SOURCE_DIR}/cmake/FindSQLite3.cmake
+          ${CMAKE_SOURCE_DIR}/cmake/Findsentry.cmake
     DESTINATION share/qfield/cmake)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,8 +305,14 @@ endif()
 #############################################################
 # Export the libraries so QField can be consumed from another
 # CMake project (find_package(QField CONFIG)).
+#
+# Not under Xcode: the export needs the QML resource OBJECT libraries
+# installed, and Xcode cannot install the objects of OBJECT libraries, so
+# src/core/CMakeLists.txt drops them from the install there and the export
+# would fail at generate time with "Objects of target ... referenced but is
+# not one of the allowed target types".
 
-if(WITH_CORE)
+if(WITH_CORE AND NOT CMAKE_GENERATOR STREQUAL "Xcode")
   set(QFIELD_EXPORTED_QT_COMPONENTS
       Core CorePrivate Gui GuiPrivate Xml Positioning Widgets Network Qml Quick
       Svg Sensors Sql Concurrent WebView Multimedia WebSockets RemoteObjects)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,52 @@ if (WITH_APP)
   add_subdirectory(src/app)
 endif()
 
+#############################################################
+# Export the libraries so QField can be consumed from another
+# CMake project (find_package(QField CONFIG)).
+
+if(WITH_CORE)
+  set(QFIELD_EXPORTED_QT_COMPONENTS
+      Core CorePrivate Gui GuiPrivate Xml Positioning Widgets Network Qml Quick
+      Svg Sensors Sql Concurrent WebView Multimedia WebSockets RemoteObjects)
+  if(WITH_BLUETOOTH)
+    list(APPEND QFIELD_EXPORTED_QT_COMPONENTS Bluetooth)
+  endif()
+  if(WITH_SERIALPORT)
+    list(APPEND QFIELD_EXPORTED_QT_COMPONENTS SerialPort)
+  endif()
+  if(WITH_NFC)
+    list(APPEND QFIELD_EXPORTED_QT_COMPONENTS Nfc)
+  endif()
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    list(APPEND QFIELD_EXPORTED_QT_COMPONENTS PrintSupport)
+  endif()
+  string(REPLACE ";" " " QFIELD_EXPORTED_QT_COMPONENTS "${QFIELD_EXPORTED_QT_COMPONENTS}")
+
+  install(
+    EXPORT qfield-targets
+    FILE qfield-targets.cmake
+    NAMESPACE QField::
+    DESTINATION share/qfield)
+
+  include(CMakePackageConfigHelpers)
+  configure_package_config_file(
+    ${CMAKE_SOURCE_DIR}/cmake/qfield-config.cmake.in
+    ${CMAKE_BINARY_DIR}/cmake/qfield-config.cmake
+    INSTALL_DESTINATION share/qfield)
+  install(FILES ${CMAKE_BINARY_DIR}/cmake/qfield-config.cmake
+          DESTINATION share/qfield)
+
+  # The find modules the config file depends on.
+  install(
+    FILES ${CMAKE_SOURCE_DIR}/cmake/FindQGIS.cmake
+          ${CMAKE_SOURCE_DIR}/cmake/qgis-cmake-wrapper.cmake
+          ${CMAKE_SOURCE_DIR}/cmake/FindPROJ.cmake
+          ${CMAKE_SOURCE_DIR}/cmake/FindQca.cmake
+          ${CMAKE_SOURCE_DIR}/cmake/FindSQLite3.cmake
+    DESTINATION share/qfield/cmake)
+endif()
+
 if (ENABLE_TESTS AND WITH_APP)
   set (TEST_DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/test/testdata")
 

--- a/cmake/qfield-config.cmake.in
+++ b/cmake/qfield-config.cmake.in
@@ -1,0 +1,32 @@
+@PACKAGE_INIT@
+
+# CMake package for the QField libraries, so QField can be embedded into another
+# application.
+#
+# Provides:
+#   QField::qfield_core    the core library, with the org.qfield.core QML module
+#                          linked in
+
+include(CMakeFindDependencyMacro)
+
+# FindQGIS.cmake and its qgis-cmake-wrapper.cmake companion are installed
+# alongside this file; the wrapper is what attaches QGIS::Core's own
+# dependencies, which static builds cannot link without.
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+if(NOT DEFINED WITH_VCPKG)
+  set(WITH_VCPKG ON)
+endif()
+
+find_dependency(Qt6 COMPONENTS @QFIELD_EXPORTED_QT_COMPONENTS@)
+find_dependency(QGIS COMPONENTS Core Analysis)
+find_dependency(PROJ)
+find_dependency(GDAL)
+find_dependency(Qca)
+find_dependency(LibZip)
+find_dependency(SQLite3)
+find_dependency(ZXing)
+find_dependency(QtWebDAV)
+
+include("${CMAKE_CURRENT_LIST_DIR}/qfield-targets.cmake")
+
+check_required_components(qfield)

--- a/cmake/qfield-config.cmake.in
+++ b/cmake/qfield-config.cmake.in
@@ -6,6 +6,8 @@
 # Provides:
 #   QField::qfield_core    the core library, with the org.qfield.core QML module
 #                          linked in
+#   QField::qfield_sentry  the Sentry wrapper qfield_core links against; a stub
+#                          interface library when the build had Sentry disabled
 
 include(CMakeFindDependencyMacro)
 
@@ -26,6 +28,16 @@ find_dependency(LibZip)
 find_dependency(SQLite3)
 find_dependency(ZXing)
 find_dependency(QtWebDAV)
+
+# When the installed build had Sentry enabled, QField::qfield_sentry links the
+# underlying Sentry SDK, so consumers need its imported target too.
+if(@WITH_SENTRY@)
+  if(APPLE)
+    find_dependency(SentryCocoa)
+  else()
+    find_dependency(sentry)
+  endif()
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/qfield-targets.cmake")
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -425,13 +425,22 @@ endif()
 install(FILES ${QFIELD_CORE_HDRS}
               "${CMAKE_CURRENT_BINARY_DIR}/qfield_core_export.h"
         DESTINATION ${QFIELD_INCLUDE_DIR})
+# Before the install() below, so QFIELD_CORE_QML_OUTPUT_TARGETS is set.
+add_subdirectory(qml)
+
+# The OBJECTS destination is required: the QML module's generated *_resources_N
+# targets are OBJECT libraries that qfield_core references as
+# $<TARGET_OBJECTS:...>. Without it install(EXPORT) emits them as INTERFACE
+# IMPORTED libraries with no object files, and consumers then fail at generate
+# time with "Objects of target ... referenced but is not one of the allowed
+# target types".
 install(
-  TARGETS qfield_core
+  TARGETS qfield_core ${QFIELD_CORE_QML_OUTPUT_TARGETS}
+  EXPORT qfield-targets
   BUNDLE DESTINATION ${QFIELD_BIN_DIR}
   RUNTIME DESTINATION ${QFIELD_BIN_DIR}
   LIBRARY DESTINATION ${QFIELD_LIB_DIR}
   ARCHIVE DESTINATION ${QFIELD_LIB_DIR}
+  OBJECTS DESTINATION ${QFIELD_LIB_DIR}
   FRAMEWORK DESTINATION ${QFIELD_FW_SUBDIR}
   PUBLIC_HEADER DESTINATION ${QFIELD_INCLUDE_DIR})
-
-add_subdirectory(qml)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -428,6 +428,14 @@ install(FILES ${QFIELD_CORE_HDRS}
 # Before the install() below, so QFIELD_CORE_QML_OUTPUT_TARGETS is set.
 add_subdirectory(qml)
 
+# Xcode cannot install the objects of OBJECT libraries ("may not be installed
+# under Xcode with multiple architectures"), so the QML resource targets stay
+# out of the install there; the package export is skipped for Xcode in the
+# top-level CMakeLists.txt for the same reason.
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  set(QFIELD_CORE_QML_OUTPUT_TARGETS "")
+endif()
+
 # The OBJECTS destination is required: the QML module's generated *_resources_N
 # targets are OBJECT libraries that qfield_core references as
 # $<TARGET_OBJECTS:...>. Without it install(EXPORT) emits them as INTERFACE

--- a/src/core/qml/CMakeLists.txt
+++ b/src/core/qml/CMakeLists.txt
@@ -34,8 +34,14 @@ qt_add_qml_module(
   NO_GENERATE_QMLTYPES
   RESOURCE_PREFIX
   "/qt/qml"
+  OUTPUT_TARGETS
+  qfield_core_qml_output_targets
   QML_FILES
   ${QFIELD_CORE_QML_FILES})
+
+set(QFIELD_CORE_QML_OUTPUT_TARGETS
+    ${qfield_core_qml_output_targets}
+    PARENT_SCOPE)
 
 qt_import_qml_plugins(qfield_core)
 

--- a/src/sentry/CMakeLists.txt
+++ b/src/sentry/CMakeLists.txt
@@ -23,7 +23,17 @@ if(ANDROID)
   target_link_libraries(qfield_sentry PRIVATE Qt::CorePrivate android log)
 endif()
 
-target_include_directories(qfield_sentry PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-                                                ${CMAKE_CURRENT_BINARY_DIR}/)
+target_include_directories(
+  qfield_sentry PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 target_compile_features(qfield_sentry PUBLIC cxx_std_17)
+
+# qfield_core is a static library, so its private qfield_sentry linkage stays in
+# the exported link interface as $<LINK_ONLY:qfield_sentry>; install(EXPORT)
+# therefore requires qfield_sentry in the same export set.
+install(
+  TARGETS qfield_sentry
+  EXPORT qfield-targets
+  LIBRARY DESTINATION ${QFIELD_LIB_DIR}
+  ARCHIVE DESTINATION ${QFIELD_LIB_DIR})


### PR DESCRIPTION
Exports `qfield_core` as `QField::qfield_core` through `share/qfield/qfield-config.cmake`, together with the find modules that config depends on (`FindQGIS` and its `qgis-cmake-wrapper` companion, `FindPROJ`, `FindQca`, `FindSQLite3`).

```cmake
find_package(QField CONFIG REQUIRED)
target_link_libraries(myapp PRIVATE QField::qfield_core)
```

Two build-system details make that work:

- `qt_add_qml_module()` gains `OUTPUT_TARGETS` so the generated resource targets join the export set.
- `install(TARGETS)` gains an `OBJECTS` destination. Those targets are OBJECT libraries that `qfield_core` references as `$<TARGET_OBJECTS:...>`; without it `install(EXPORT)` emits them as INTERFACE IMPORTED libraries with no object files, and consumers fail at generate time with *"Objects of target ... referenced but is not one of the allowed target types"*.

`add_subdirectory(qml)` moves above `install()` so the variable is set in time.

Only `qfield_core` is exported for now, which is self-consistent since `qfield_3d` and `qfield_gui` both link it rather than the other way round. Extending the export set to those two could come with a follow up PR?