### PR TITLE
Export qfield_gui and qfield_3d through the CMake package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,10 +307,10 @@ endif()
 # CMake project (find_package(QField CONFIG)).
 #
 # Not under Xcode: the export needs the QML resource OBJECT libraries
-# installed, and Xcode cannot install the objects of OBJECT libraries, so
-# src/core/CMakeLists.txt drops them from the install there and the export
-# would fail at generate time with "Objects of target ... referenced but is
-# not one of the allowed target types".
+# installed, and Xcode cannot install the objects of OBJECT libraries, so the
+# library CMakeLists drop them from the install there and the export would
+# fail at generate time with "Objects of target ... referenced but is not one
+# of the allowed target types".
 
 if(WITH_CORE AND NOT CMAKE_GENERATOR STREQUAL "Xcode")
   set(QFIELD_EXPORTED_QT_COMPONENTS
@@ -324,6 +324,9 @@ if(WITH_CORE AND NOT CMAKE_GENERATOR STREQUAL "Xcode")
   endif()
   if(WITH_NFC)
     list(APPEND QFIELD_EXPORTED_QT_COMPONENTS Nfc)
+  endif()
+  if(WITH_3D)
+    list(APPEND QFIELD_EXPORTED_QT_COMPONENTS Quick3D)
   endif()
   if(NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
     list(APPEND QFIELD_EXPORTED_QT_COMPONENTS PrintSupport)

--- a/cmake/qfield-config.cmake.in
+++ b/cmake/qfield-config.cmake.in
@@ -6,6 +6,10 @@
 # Provides:
 #   QField::qfield_core    the core library, with the org.qfield.core QML module
 #                          linked in
+#   QField::qfield_gui     the GUI library with the org.qfield.gui QML module,
+#                          when the build had WITH_GUI enabled
+#   QField::qfield_3d      the 3D library with the org.qfield._3d QML module,
+#                          when the build had WITH_3D enabled
 #   QField::qfield_sentry  the Sentry wrapper qfield_core links against; a stub
 #                          interface library when the build had Sentry disabled
 

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -25,9 +25,12 @@ add_library(qfield_3d STATIC ${QFIELD_3D_SRCS} ${QFIELD_3D_HDRS})
 include(GenerateExportHeader)
 generate_export_header(qfield_3d)
 
-target_include_directories(qfield_3d SYSTEM PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(
+  qfield_3d SYSTEM PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
-target_include_directories(qfield_3d PUBLIC ${CMAKE_SOURCE_DIR}/src/3d)
+target_include_directories(
+  qfield_3d PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/3d>
+                   $<INSTALL_INTERFACE:${QFIELD_INCLUDE_SUBDIR}>)
 
 target_compile_features(qfield_3d PUBLIC cxx_std_20)
 
@@ -36,4 +39,19 @@ set_target_properties(qfield_3d PROPERTIES AUTOMOC TRUE)
 target_link_libraries(qfield_3d PUBLIC qfield_core Qt::Core Qt::Gui Qt::Quick
                                        Qt::Quick3D)
 
+install(FILES ${QFIELD_3D_HDRS} "${CMAKE_CURRENT_BINARY_DIR}/qfield_3d_export.h"
+        DESTINATION ${QFIELD_INCLUDE_DIR})
+
 add_subdirectory(qml)
+
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  set(QFIELD_3D_QML_OUTPUT_TARGETS "")
+endif()
+
+install(
+  TARGETS qfield_3d ${QFIELD_3D_QML_OUTPUT_TARGETS}
+  EXPORT qfield-targets
+  RUNTIME DESTINATION ${QFIELD_BIN_DIR}
+  LIBRARY DESTINATION ${QFIELD_LIB_DIR}
+  ARCHIVE DESTINATION ${QFIELD_LIB_DIR}
+  OBJECTS DESTINATION ${QFIELD_LIB_DIR})

--- a/src/3d/qml/CMakeLists.txt
+++ b/src/3d/qml/CMakeLists.txt
@@ -13,8 +13,14 @@ qt_add_qml_module(
   NO_GENERATE_QMLTYPES
   RESOURCE_PREFIX
   "/qt/qml"
+  OUTPUT_TARGETS
+  qfield_3d_qml_output_targets
   QML_FILES
   ${QFIELD_3D_QML_FILES})
+
+set(QFIELD_3D_QML_OUTPUT_TARGETS
+    ${qfield_3d_qml_output_targets}
+    PARENT_SCOPE)
 
 qt_import_qml_plugins(qfield_3d)
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -55,9 +55,12 @@ add_library(qfield_gui STATIC ${QFIELD_GUI_SRCS} ${QFIELD_GUI_HDRS})
 include(GenerateExportHeader)
 generate_export_header(qfield_gui)
 
-target_include_directories(qfield_gui SYSTEM PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(
+  qfield_gui SYSTEM PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
-target_include_directories(qfield_gui PUBLIC ${CMAKE_SOURCE_DIR}/src/gui)
+target_include_directories(
+  qfield_gui PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/gui>
+                    $<INSTALL_INTERFACE:${QFIELD_INCLUDE_SUBDIR}>)
 
 target_compile_features(qfield_gui PUBLIC cxx_std_20)
 
@@ -66,4 +69,20 @@ set_target_properties(qfield_gui PROPERTIES AUTOMOC TRUE)
 target_link_libraries(qfield_gui PUBLIC qfield_core Qt::Core Qt::Gui Qt::Quick
                                         Qt::WebView Qt::Widgets)
 
+install(FILES ${QFIELD_GUI_HDRS}
+              "${CMAKE_CURRENT_BINARY_DIR}/qfield_gui_export.h"
+        DESTINATION ${QFIELD_INCLUDE_DIR})
+
 add_subdirectory(qml)
+
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  set(QFIELD_GUI_QML_OUTPUT_TARGETS "")
+endif()
+
+install(
+  TARGETS qfield_gui ${QFIELD_GUI_QML_OUTPUT_TARGETS}
+  EXPORT qfield-targets
+  RUNTIME DESTINATION ${QFIELD_BIN_DIR}
+  LIBRARY DESTINATION ${QFIELD_LIB_DIR}
+  ARCHIVE DESTINATION ${QFIELD_LIB_DIR}
+  OBJECTS DESTINATION ${QFIELD_LIB_DIR})

--- a/src/gui/qml/CMakeLists.txt
+++ b/src/gui/qml/CMakeLists.txt
@@ -135,8 +135,14 @@ qt_add_qml_module(
   NO_GENERATE_QMLTYPES
   RESOURCE_PREFIX
   "/qt/qml"
+  OUTPUT_TARGETS
+  qfield_gui_qml_output_targets
   QML_FILES
   ${QFIELD_GUI_QML_FILES})
+
+set(QFIELD_GUI_QML_OUTPUT_TARGETS
+    ${qfield_gui_qml_output_targets}
+    PARENT_SCOPE)
 
 qt_import_qml_plugins(qfield_gui)
 


### PR DESCRIPTION
Follow-up to #7845, as requested in review: `QField::qfield_gui` and `QField::qfield_3d` are now exported through `share/qfield/qfield-config.cmake` alongside `QField::qfield_core`, whenever the build enabled `WITH_GUI` / `WITH_3D`.

Same mechanics as core: QML resource OBJECT libraries join the export via `OUTPUT_TARGETS` + `OBJECTS` install destination (skipped under Xcode), headers install into `include/qfield`, and Qt Quick3D is added to the config's find_dependency(Qt6 ...) components when 3D is in.