### PR TITLE
Improve the looks of the return to project when QField uses the light theme

### DIFF
--- a/src/app/qml/WelcomeScreen.qml
+++ b/src/app/qml/WelcomeScreen.qml
@@ -830,7 +830,8 @@ Page {
     QfActionButton {
       id: currentProjectButton
       toolImage: Theme.getThemeVectorIcon('ic_arrow_left_white_24dp')
-      toolText: welcomeScreen.width > 420 ? qsTr('Return to map') : ""
+      toolText: qsTr('Return to map')
+      backgroundless: true
       visible: qgisProject && !!qgisProject.homePath
       innerActionIcon.visible: false
 

--- a/src/gui/qml/QfActionButton.qml
+++ b/src/gui/qml/QfActionButton.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls
 import QtQuick.Controls.Material
 import QtQuick.Controls.Material.impl
 import org.qfield.core
-import org.qfield.gui
 
 /**
  * \ingroup qml
@@ -13,6 +12,7 @@ ToolButton {
 
   property string toolImage: ''
   property string toolText: qsTr("close")
+  property bool backgroundless: false
   property alias innerActionIcon: innerAction
 
   height: Theme.toolButtonSize
@@ -28,7 +28,7 @@ ToolButton {
   background: Rectangle {
     width: parent.width
     height: Theme.toolButtonSize
-    color: Theme.toolButtonBackgroundSemiOpaqueColor
+    color: backgroundless ? "transparent" : Theme.toolButtonBackgroundSemiOpaqueColor
     radius: height / 2
 
     QfToolButton {
@@ -39,8 +39,8 @@ ToolButton {
       enabled: false
       round: true
       iconSource: button.toolImage
-      iconColor: Theme.toolButtonColor
-      bgcolor: Theme.toolButtonBackgroundColor
+      iconColor: button.backgroundless ? Theme.mainTextColor : Theme.toolButtonColor
+      bgcolor: button.backgroundless ? "transparent" : Theme.toolButtonBackgroundColor
     }
 
     Ripple {
@@ -68,7 +68,7 @@ ToolButton {
       anchors.verticalCenter: parent.verticalCenter
       verticalAlignment: Text.AlignVCenter
       text: button.toolText
-      color: Theme.toolButtonColor
+      color: button.backgroundless ? Theme.mainTextColor : Theme.toolButtonColor
       font: Theme.strongFont
     }
 

--- a/src/gui/qml/editorwidgets/QfEditorWidgetDateTime.qml
+++ b/src/gui/qml/editorwidgets/QfEditorWidgetDateTime.qml
@@ -157,12 +157,10 @@ QfEditorWidgetBase {
       QfToolButton {
         id: clearButton
         anchors.right: parent.right
-        anchors.rightMargin: 4
-        anchors.verticalCenter: parent.verticalCenter
-        width: 24
-        height: 24
+        width: 40
+        height: label.height
         padding: 0
-        iconSource: Theme.getThemeVectorIcon("ic_clear_black_18dp")
+        iconSource: Theme.getThemeVectorIcon('ic_clear_white_24dp')
         iconColor: Theme.mainTextColor
         visible: (value !== undefined) && enabled && (config['allow_null'] === undefined || config['allow_null'])
 


### PR DESCRIPTION
This PR harmonizes the top-left return to project action button matches the looks of the other tool button on the welcome screen. 

It makes a world of difference when using the light theme.