### PR TITLE
vcpkg/qgis: make MSVC Debug builds possible

### DIFF
--- a/vcpkg/ports/qgis/bigobj.patch
+++ b/vcpkg/ports/qgis/bigobj.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 631274d..74ab83a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1168,6 +1168,17 @@ if (ENABLE_UNITY_BUILDS)
+   endif()
+ endif()
+ 
++# Debug builds emit a COMDAT section per inline function, which pushes large
++# translation units (notably src/core/qgis.cpp) past the 65535-section limit of
++# the COFF object format: "error C1128: number of sections exceeded object file
++# format limit". Upstream only tags a handful of files with /bigobj via
++# set_source_files_properties, and that list is tuned against Release builds.
++# Enable it for every MSVC translation unit instead: /bigobj only raises the
++# section limit, it has no runtime cost and does not change the emitted code.
++if(MSVC)
++  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
++endif()
++
+ 
+ #############################################################
+ # Python

--- a/vcpkg/ports/qgis/portfile.cmake
+++ b/vcpkg/ports/qgis/portfile.cmake
@@ -14,6 +14,7 @@ vcpkg_from_github(
         include-qthread.patch
         processing.patch # Needed to avoid link issue with tinygltf (ATM embedded into QGIS) and _GEOSQueryCallback defined multiple times
         mesh.patch
+        bigobj.patch # MSVC Debug: qgis.cpp exceeds the COFF section limit (C1128)
 )
 
 

--- a/vcpkg/ports/qgis/portfile.cmake
+++ b/vcpkg/ports/qgis/portfile.cmake
@@ -192,6 +192,17 @@ vcpkg_configure_cmake(
 
 vcpkg_install_cmake()
 
+if(VCPKG_TARGET_IS_WINDOWS AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    # Copy debug static libs from build output to installed debug lib dir
+    file(GLOB QGIS_DEBUG_LIBS
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src/*/Debug/*.lib"
+        "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/src/Debug/*.lib"
+    )
+    foreach(LIB_FILE IN LISTS QGIS_DEBUG_LIBS)
+        file(COPY "${LIB_FILE}" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+    endforeach()
+endif()
+
 if(VCPKG_TARGET_IS_WINDOWS)
     function(copy_path basepath targetdir)
         file(GLOB ${basepath}_PATH ${CURRENT_PACKAGES_DIR}/${basepath}/*)


### PR DESCRIPTION
Two changes to the qgis port so a debug-enabled Windows triplet can build it:

- Enable `/bigobj` for every MSVC translation unit:
`src/core/qgis.cpp` fails Debug compilation with `C1128: number of sections exceeded object file format limit`: Debug emits one COMDAT section per inline function, and the   enum/metatype machinery pulled in by `qgis.h` pushes the TU past the  65535-section COFF limit. QGIS upstream tags individual files with `/bigobj` via `set_source_files_properties`, but that list is tuned against Release builds; rather than chase the next offending TU, we set the flag globally. `/bigobj` only raises the section limit, has no runtime cost, and does not change the emitted code.
:mailbox: Will also raise this in the QGIS dev mailing list
- Copy the QGIS `*.lib` Debug outputs into the installed `debug/lib` directory   for static Windows builds. With today's release-only CI the glob matches nothing and this is a no-op; on a debug-enabled triplet it is what makes the installed tree linkable.