### PR TITLE
Fix use-after-free crash when the map canvas is destroyed mid-render

### DIFF
--- a/src/core/qgsquick/qgsquickmapcanvasmap.cpp
+++ b/src/core/qgsquick/qgsquickmapcanvasmap.cpp
@@ -63,7 +63,26 @@ QgsQuickMapCanvasMap::QgsQuickMapCanvasMap( QQuickItem *parent )
 
 QgsQuickMapCanvasMap::~QgsQuickMapCanvasMap()
 {
-  stopRendering();
+  // Cancel render jobs blocking and delete them synchronously (mirrors
+  // QgsMapCanvas::cancelJobs()). The non-blocking stopRendering() path would
+  // let a still-active job outlive this canvas and dereference the freed
+  // mCache from its QFutureWatcher slots once the workers wind down.
+  if ( mJob )
+  {
+    whileBlocking( mJob )->cancel();
+    delete mJob;
+    mJob = nullptr;
+  }
+
+  for ( QgsMapRendererQImageJob *job : std::as_const( mPreviewJobs ) )
+  {
+    if ( job )
+    {
+      whileBlocking( job )->cancel();
+      delete job;
+    }
+  }
+  mPreviewJobs.clear();
 }
 
 QgsQuickMapSettings *QgsQuickMapCanvasMap::mapSettings() const


### PR DESCRIPTION
`~QgsQuickMapCanvasMap` used the non-blocking `stopRendering()`, so a still-active `QgsMapRendererParallelJob` could outlive the canvas and dereference the freed `mCache` from its `QFutureWatcher::finished` slot (`composeImage()` → `QPainter::drawImage` → SIGSEGV at 0x0).

This mirrors `QgsMapCanvas::cancelJobs()`: blocking `whileBlocking( job )->cancel()` plus synchronous delete for the render job and any preview jobs, so no job can outlive the canvas.