### PR TITLE
Relocate projects/templates tab bar to sit next to the avatar icon, polish templates UX

### DIFF
--- a/src/app/qml/QfCloudProjectFilter.qml
+++ b/src/app/qml/QfCloudProjectFilter.qml
@@ -11,6 +11,8 @@ Pane {
   signal applyFilter
 
   property string currentUsername: ""
+  property bool isTemplateSearch: false
+
   property var organizations: []
   property bool organizationsFetched: false
   property string activePreset: ""
@@ -18,14 +20,14 @@ Pane {
     const list = [
       {
         id: "mine",
-        label: qsTr("My own projects"),
+        label: qsTr("My own"),
         query: "owner:" + filterPanel.currentUsername
       }
     ];
     for (const org of filterPanel.organizations) {
       list.push({
         id: "org_" + org,
-        label: qsTr("%1's projects").arg(org),
+        label: qsTr("Owned by %1").arg(org),
         query: "owner:" + org
       });
     }
@@ -237,7 +239,7 @@ Pane {
 
           Label {
             Layout.fillWidth: true
-            text: qsTr("Include public projects")
+            text: filterPanel.isTemplateSearch ? qsTr("Include public templates") : qsTr("Include public projects")
             font: QfTheme.tipFont
             color: QfTheme.mainTextColor
           }

--- a/src/app/qml/QfCloudScreen.qml
+++ b/src/app/qml/QfCloudScreen.qml
@@ -223,6 +223,7 @@ Page {
             visible: false
 
             currentUsername: cloudConnection.username
+            isTemplateSearch: filterBar.currentIndex === 1
 
             onQueryStringChanged: {
               if (visible) {
@@ -647,21 +648,23 @@ Page {
           Label {
             anchors.fill: parent
             anchors.margins: 20
-            visible: cloudConnection.status === QfCloudConnection.LoggedIn && filterBar.currentIndex === 0 && table.count === 0
+            visible: cloudConnection.status === QfCloudConnection.LoggedIn && table.count === 0
             text: {
+              const isTemplate = filterBar.currentIndex === 1;
               let labelText = "";
               if (cloudProjectsModel.isRefreshing) {
-                labelText = qsTr("Refreshing projects list...");
+                labelText = isTemplate ? qsTr("Refreshing templates list...") : qsTr("Refreshing projects list...");
               } else if (table.model.isSearching) {
-                labelText = qsTr("Searching for projects...");
+                labelText = isTemplate ? qsTr("Searching for templates...") : qsTr("Searching for projects...");
               } else if (searchBar.searchTerm.trim() !== "") {
-                labelText = qsTr("No cloud projects found.");
+                labelText = isTemplate ? qsTr("No templates found.") : qsTr("No cloud projects found.");
                 const parameters = projectFilter.getQueryParametersFromString(searchBar.searchTerm);
                 if (parameters["includePublic"] === false) {
+                  labelText += "\n\n";
                   if (cloudConnection.url == cloudConnection.defaultUrl) {
-                    labelText += "\n\n" + qsTr("Try to %1include public projects%2 and see what the community has to offer.").arg("<a href=\"#includePublic\">").arg("</a>");
+                    labelText += isTemplate ? qsTr("Try to %1include public templates%2 and see what the community has to offer.").arg("<a href=\"#includePublic\">").arg("</a>") : qsTr("Try to %1include public projects%2 and see what the community has to offer.").arg("<a href=\"#includePublic\">").arg("</a>");
                   } else {
-                    labelText += "\n\n" + qsTr("Try to %1include public projects%2.").arg("<a href=\"#includePublic\">").arg("</a>");
+                    labelText += isTemplate ? qsTr("Try to %1include public templates%2.").arg("<a href=\"#includePublic\">").arg("</a>") : qsTr("Try to %1include public projects%2.").arg("<a href=\"#includePublic\">").arg("</a>");
                   }
                 }
               } else {

--- a/src/app/qml/QfCloudScreen.qml
+++ b/src/app/qml/QfCloudScreen.qml
@@ -68,8 +68,21 @@ Page {
         id: filterBar
         Layout.fillWidth: true
         Layout.preferredHeight: defaultHeight
+        Layout.leftMargin: 68
         visible: !connectionSettings.visible
+        boundsBehavior: Flickable.StopAtBounds
         model: filterModel.hasTemplates ? [qsTr("Projects"), qsTr("Templates")] : [qsTr("Projects")]
+
+        Material.accent: filterModel.hasTemplates ? QfTheme.mainColor : QfTheme.mainTextColor
+        highlight: Item {
+          Rectangle {
+            height: filterModel.hasTemplates ? 2 : 0
+            color: QfTheme.mainColor
+            radius: 4
+            width: parent.width
+            anchors.bottom: parent.bottom
+          }
+        }
 
         onCurrentIndexChanged: {
           filterModel.showTemplates = currentIndex == 1;

--- a/src/app/qml/QfCloudScreen.qml
+++ b/src/app/qml/QfCloudScreen.qml
@@ -71,7 +71,7 @@ Page {
         Layout.leftMargin: 68
         visible: !connectionSettings.visible
         boundsBehavior: Flickable.StopAtBounds
-        model: filterModel.hasTemplates ? [qsTr("Projects"), qsTr("Templates")] : [qsTr("Projects")]
+        model: filterModel.hasTemplates && !filterModel.showLocalOnly ? [qsTr("Projects"), qsTr("Templates")] : [qsTr("Projects")]
 
         Material.accent: filterModel.hasTemplates ? QfTheme.mainColor : QfTheme.mainTextColor
         highlight: Item {

--- a/src/app/qml/QfCloudScreen.qml
+++ b/src/app/qml/QfCloudScreen.qml
@@ -199,7 +199,7 @@ Page {
           Layout.preferredHeight: searchHeight
           enableFilterButton: true
           filterActive: projectFilter.visible
-          placeHolderText: qsTr("Search for projects")
+          placeHolderText: filterModel.showTemplates ? qsTr("Search for templates") : qsTr("Search for projects")
           parameterKeys: ["owner", "include"]
           z: 10
 

--- a/src/app/qml/QfCloudScreen.qml
+++ b/src/app/qml/QfCloudScreen.qml
@@ -71,12 +71,12 @@ Page {
         Layout.leftMargin: 68
         visible: !connectionSettings.visible
         boundsBehavior: Flickable.StopAtBounds
-        model: filterModel.hasTemplates && !filterModel.showLocalOnly ? [qsTr("Projects"), qsTr("Templates")] : [qsTr("Projects")]
+        model: cloudProjectsModel.hasTemplates && !filterModel.showLocalOnly ? [qsTr("Projects"), qsTr("Templates")] : [qsTr("Projects")]
 
-        Material.accent: filterModel.hasTemplates ? QfTheme.mainColor : QfTheme.mainTextColor
+        Material.accent: cloudProjectsModel.hasTemplates ? QfTheme.mainColor : QfTheme.mainTextColor
         highlight: Item {
           Rectangle {
-            height: filterModel.hasTemplates ? 2 : 0
+            height: cloudProjectsModel.hasTemplates ? 2 : 0
             color: QfTheme.mainColor
             radius: 4
             width: parent.width

--- a/src/app/qml/QfCloudScreen.qml
+++ b/src/app/qml/QfCloudScreen.qml
@@ -22,7 +22,7 @@ Page {
   rightPadding: mainWindow.sceneRightMargin
 
   header: QfPageHeader {
-    title: qsTr("QFieldCloud Projects")
+    title: qsTr("QFieldCloud")
 
     showBackButton: true
     showApplyButton: false
@@ -62,34 +62,32 @@ Page {
       id: connectionInformation
       spacing: 2
       Layout.fillWidth: true
-      visible: (cloudConnection.status === QfCloudConnection.LoggedIn || table.count > 0) && projectsSwipeView.currentIndex !== 1
+      visible: projectsSwipeView.currentIndex !== 1
 
-      Label {
+      QfTabBar {
+        id: filterBar
         Layout.fillWidth: true
-        padding: 10
-        opacity: projectsSwipeView.visible ? 1 : 0
-        text: switch (cloudConnection.status) {
-        case 0:
-          qsTr('Disconnected from the cloud.');
-          break;
-        case 1:
-          qsTr('Connecting to the cloud.');
-          break;
-        case 2:
-          qsTr('Greetings <strong>%1</strong>.').arg(cloudConnection.username);
-          break;
+        Layout.preferredHeight: defaultHeight
+        visible: !connectionSettings.visible
+        model: filterModel.hasTemplates ? [qsTr("Projects"), qsTr("Templates")] : [qsTr("Projects")]
+
+        onCurrentIndexChanged: {
+          filterModel.showTemplates = currentIndex == 1;
         }
-        wrapMode: Text.WordWrap
-        font: QfTheme.tipFont
-        color: QfTheme.mainTextColor
+      }
+
+      Item {
+        id: topSpacer
+        Layout.fillWidth: true
+        visible: !filterBar.visible
       }
 
       Rectangle {
         id: cloudAvatarRect
         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
         Layout.margins: 10
-        width: 48
-        height: 48
+        Layout.preferredWidth: 48
+        Layout.preferredHeight: 48
         radius: width / 2
         color: QfTheme.controlBackgroundAlternateColor
         layer.enabled: true
@@ -193,27 +191,6 @@ Page {
 
         QfCloudStatusBanner {
           cloudServiceStatus: qfieldCloudScreen.cloudServiceStatus
-        }
-
-        QfTabBar {
-          id: filterBar
-          Layout.fillWidth: true
-          Layout.preferredHeight: defaultHeight
-          visible: filterModel.hasTemplates
-          model: [qsTr("Projects"), qsTr("Templates")]
-
-          onCurrentIndexChanged: {
-            filterModel.showTemplates = currentIndex === 1;
-          }
-        }
-
-        Connections {
-          target: filterModel
-          function onHasTemplatesChanged() {
-            if (!filterModel.hasTemplates && filterBar.currentIndex !== 0) {
-              filterBar.currentIndex = 0;
-            }
-          }
         }
 
         QfSearchBar {

--- a/src/app/qml/QfCloudScreen.qml
+++ b/src/app/qml/QfCloudScreen.qml
@@ -698,7 +698,7 @@ Page {
           QfButton {
             id: refreshProjectsListBtn
             Layout.fillWidth: true
-            text: qsTr("Refresh projects list")
+            text: filterBar.currentIndex === 1 ? qsTr("Refresh templates list") : qsTr("Refresh projects list")
             enabled: cloudConnection.status === QfCloudConnection.LoggedIn && cloudConnection.state === QfCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
             showProgress: cloudProjectsModel.isRefreshing || table.model.isSearching
             progressValue: 0

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
@@ -1162,7 +1162,7 @@ void QfCloudProjectsModel::createProject( const QString &name, const QString &fr
   mIsCreating = true;
   emit isCreatingChanged();
 
-  QString sanitizedName = name;
+  QString sanitizedName = name.normalized( QString::NormalizationForm_KD );
   sanitizedName.replace( QRegularExpression( "[^A-Za-z0-9_]" ), QStringLiteral( "_" ) );
 
   QString url = QStringLiteral( "/api/v1/projects/?owner=%1" ).arg( mUsername );

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
@@ -1362,11 +1362,7 @@ bool QfCloudProjectsFilterModel::filterAcceptsRow( int source_row, const QModelI
   }
 
   const bool isTemplate = project->type() == QfCloudProject::ProjectType::Template;
-  if ( mShowTemplates )
-  {
-    return isTemplate;
-  }
-  else if ( isTemplate )
+  if ( ( !mShowTemplates && isTemplate ) || ( mShowTemplates && !isTemplate ) )
   {
     return false;
   }

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
@@ -1356,17 +1356,17 @@ bool QfCloudProjectsFilterModel::filterAcceptsRow( int source_row, const QModelI
     return false;
   }
 
+  if ( mShowLocalOnly && project->localPath().isEmpty() )
+  {
+    return false;
+  }
+
   const bool isTemplate = project->type() == QfCloudProject::ProjectType::Template;
   if ( mShowTemplates )
   {
     return isTemplate;
   }
   else if ( isTemplate )
-  {
-    return false;
-  }
-
-  if ( mShowLocalOnly && project->localPath().isEmpty() )
   {
     return false;
   }

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
@@ -1276,6 +1276,11 @@ void QfCloudProjectsFilterModel::setProjectsModel( QfCloudProjectsModel *project
   if ( mSourceModel )
   {
     disconnect( mSourceModel, &QfCloudProjectsModel::projectsAppended, this, &QfCloudProjectsFilterModel::projectsAppended );
+
+    disconnect( mSourceModel, &QAbstractItemModel::rowsInserted, this, &QfCloudProjectsFilterModel::updateHasTemplates );
+    disconnect( mSourceModel, &QAbstractItemModel::rowsRemoved, this, &QfCloudProjectsFilterModel::updateHasTemplates );
+    disconnect( mSourceModel, &QAbstractItemModel::modelReset, this, &QfCloudProjectsFilterModel::updateHasTemplates );
+    updateHasTemplates();
   }
 
   mSourceModel = projectsModel;
@@ -1283,6 +1288,8 @@ void QfCloudProjectsFilterModel::setProjectsModel( QfCloudProjectsModel *project
 
   if ( mSourceModel )
   {
+    connect( mSourceModel, &QfCloudProjectsModel::projectsAppended, this, &QfCloudProjectsFilterModel::projectsAppended );
+
     connect( mSourceModel, &QAbstractItemModel::rowsInserted, this, &QfCloudProjectsFilterModel::updateHasTemplates );
     connect( mSourceModel, &QAbstractItemModel::rowsRemoved, this, &QfCloudProjectsFilterModel::updateHasTemplates );
     connect( mSourceModel, &QAbstractItemModel::modelReset, this, &QfCloudProjectsFilterModel::updateHasTemplates );
@@ -1421,7 +1428,7 @@ void QfCloudProjectsFilterModel::projectsAppended( const QString &owner, const Q
     return;
   }
 
-  if ( mOwnerFilter == owner && mKeywordFilter == search.split( QLatin1Char( ' ' ) ) )
+  if ( mOwnerFilter == owner && mKeywordFilter == search.split( QLatin1Char( ' ' ), Qt::SkipEmptyParts ) )
   {
     mIsSearching = false;
     emit isSearchingChanged();

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
@@ -548,6 +548,7 @@ void QfCloudProjectsModel::projectReceived()
     {
       insertProjects( QList<QfCloudProject *>() << cloudProject );
       emit projectAppended( projectId );
+      updateHasTemplates();
     }
   }
 }
@@ -574,6 +575,7 @@ void QfCloudProjectsModel::projectListReceived()
       mIsRefreshing = false;
       emit isRefreshingChanged();
     }
+    updateHasTemplates();
 
     emit warning( QfCloudConnection::errorString( rawReply ) );
     return;
@@ -634,6 +636,7 @@ void QfCloudProjectsModel::projectListReceived()
     mIsRefreshing = false;
     emit isRefreshingChanged();
   }
+  updateHasTemplates();
 }
 
 QHash<int, QByteArray> QfCloudProjectsModel::roleNames() const
@@ -1252,6 +1255,21 @@ void QfCloudProjectsModel::projectCreationReceived()
   emit isCreatingChanged();
 }
 
+bool QfCloudProjectsModel::hasTemplates() const
+{
+  return mHasTemplates;
+}
+
+void QfCloudProjectsModel::updateHasTemplates()
+{
+  const bool hasTemplates = std::any_of( mProjects.begin(), mProjects.end(), []( const QfCloudProject *project ) { return project && project->type() == QfCloudProject::ProjectType::Template; } );
+  if ( mHasTemplates != hasTemplates )
+  {
+    mHasTemplates = hasTemplates;
+    emit hasTemplatesChanged();
+  }
+}
+
 // --
 
 QfCloudProjectsFilterModel::QfCloudProjectsFilterModel( QObject *parent )
@@ -1276,11 +1294,6 @@ void QfCloudProjectsFilterModel::setProjectsModel( QfCloudProjectsModel *project
   if ( mSourceModel )
   {
     disconnect( mSourceModel, &QfCloudProjectsModel::projectsAppended, this, &QfCloudProjectsFilterModel::projectsAppended );
-
-    disconnect( mSourceModel, &QAbstractItemModel::rowsInserted, this, &QfCloudProjectsFilterModel::updateHasTemplates );
-    disconnect( mSourceModel, &QAbstractItemModel::rowsRemoved, this, &QfCloudProjectsFilterModel::updateHasTemplates );
-    disconnect( mSourceModel, &QAbstractItemModel::modelReset, this, &QfCloudProjectsFilterModel::updateHasTemplates );
-    updateHasTemplates();
   }
 
   mSourceModel = projectsModel;
@@ -1289,11 +1302,6 @@ void QfCloudProjectsFilterModel::setProjectsModel( QfCloudProjectsModel *project
   if ( mSourceModel )
   {
     connect( mSourceModel, &QfCloudProjectsModel::projectsAppended, this, &QfCloudProjectsFilterModel::projectsAppended );
-
-    connect( mSourceModel, &QAbstractItemModel::rowsInserted, this, &QfCloudProjectsFilterModel::updateHasTemplates );
-    connect( mSourceModel, &QAbstractItemModel::rowsRemoved, this, &QfCloudProjectsFilterModel::updateHasTemplates );
-    connect( mSourceModel, &QAbstractItemModel::modelReset, this, &QfCloudProjectsFilterModel::updateHasTemplates );
-    updateHasTemplates();
   }
 
   emit projectsModelChanged();
@@ -1541,36 +1549,6 @@ void QfCloudProjectsFilterModel::setShowTemplates( bool showTemplates )
 bool QfCloudProjectsFilterModel::showTemplates() const
 {
   return mShowTemplates;
-}
-
-bool QfCloudProjectsFilterModel::hasTemplates() const
-{
-  return mHasTemplates;
-}
-
-void QfCloudProjectsFilterModel::updateHasTemplates()
-{
-  bool hasTemplates = false;
-  if ( mSourceModel )
-  {
-    const int rows = mSourceModel->rowCount( QModelIndex() );
-    for ( int i = 0; i < rows; ++i )
-    {
-      const QModelIndex idx = mSourceModel->index( i, 0 );
-      const QfCloudProject *project = mSourceModel->findProject( mSourceModel->data( idx, QfCloudProjectsModel::IdRole ).toString() );
-      if ( project && project->type() == QfCloudProject::ProjectType::Template )
-      {
-        hasTemplates = true;
-        break;
-      }
-    }
-  }
-
-  if ( mHasTemplates != hasTemplates )
-  {
-    mHasTemplates = hasTemplates;
-    emit hasTemplatesChanged();
-  }
 }
 
 bool QfCloudProjectsFilterModel::showInValidProjects() const

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.h
@@ -55,6 +55,8 @@ class QfCloudProjectsModel : public QAbstractListModel
     //! Returns TRUE whether the model is creating a project
     Q_PROPERTY( bool isCreating READ isCreating NOTIFY isCreatingChanged )
 
+    Q_PROPERTY( bool hasTemplates READ hasTemplates NOTIFY hasTemplatesChanged )
+
     //! Currently busy project ids.
     Q_PROPERTY( QSet<QString> busyProjectIds READ busyProjectIds NOTIFY busyProjectIdsChanged )
 
@@ -205,6 +207,12 @@ class QfCloudProjectsModel : public QAbstractListModel
      */
     Q_INVOKABLE void createProject( const QString &name, const QString &fromProjectId = QString() );
 
+    /**
+     * Returns TRUE if the source model contains at least one template project,
+     * regardless of the currently applied filters.
+     */
+    bool hasTemplates() const;
+
   signals:
     void cloudConnectionChanged();
     void layerObserverChanged();
@@ -223,6 +231,8 @@ class QfCloudProjectsModel : public QAbstractListModel
     void pushFinished( const QString &projectId, bool isDownloadingProject, bool hasError = false, const QString &errorString = QString() );
 
     void projectUploaded( const QString &projectId );
+
+    void hasTemplatesChanged();
 
   private slots:
     void connectionStatusChanged();
@@ -243,6 +253,9 @@ class QfCloudProjectsModel : public QAbstractListModel
     void resetProjects();
 
     inline QString layerFileName( const QgsMapLayer *layer ) const;
+
+    void updateHasTemplates();
+    bool mHasTemplates = false;
 
     QList<QfCloudProject *> mProjects;
     QfCloudConnection *mCloudConnection = nullptr;
@@ -275,7 +288,6 @@ class QfCloudProjectsFilterModel : public QSortFilterProxyModel
     Q_PROPERTY( bool showFeaturedOnTop READ showFeaturedOnTop WRITE setShowFeaturedOnTop NOTIFY showFeaturedOnTopChanged )
     Q_PROPERTY( bool isSearching READ isSearching NOTIFY isSearchingChanged )
     Q_PROPERTY( bool showTemplates READ showTemplates WRITE setShowTemplates NOTIFY showTemplatesChanged )
-    Q_PROPERTY( bool hasTemplates READ hasTemplates NOTIFY hasTemplatesChanged )
 
   public:
     explicit QfCloudProjectsFilterModel( QObject *parent = nullptr );
@@ -340,12 +352,6 @@ class QfCloudProjectsFilterModel : public QSortFilterProxyModel
     void setShowTemplates( bool showTemplates );
 
     /**
-     * Returns TRUE if the source model contains at least one template project,
-     * regardless of the currently applied filters.
-     */
-    bool hasTemplates() const;
-
-    /**
      * Sets whether featured projects will be shown on top of the list.
      */
     void setShowFeaturedOnTop( bool showFeaturedOnTop );
@@ -370,11 +376,9 @@ class QfCloudProjectsFilterModel : public QSortFilterProxyModel
     void showFeaturedOnTopChanged();
     void isSearchingChanged();
     void showTemplatesChanged();
-    void hasTemplatesChanged();
 
   private slots:
     void triggerProjectsAppending();
-    void updateHasTemplates();
     void projectsAppended( const QString &owner, const QString &search, const bool hasError = false, const QString &errorString = QString() );
 
   protected:
@@ -392,7 +396,6 @@ class QfCloudProjectsFilterModel : public QSortFilterProxyModel
     bool mIncludePublic = false;
     bool mIsSearching = false;
     bool mShowTemplates = false;
-    bool mHasTemplates = false;
 
     QTimer mProjectsAppendingTimer;
 };

--- a/src/gui/qml/QfTabBar.qml
+++ b/src/gui/qml/QfTabBar.qml
@@ -28,7 +28,7 @@ ListView {
   delegate: TabButton {
     text: modelData
     height: tabRow.defaultHeight
-    width: tabRow.parent.width / tabRow.count
+    width: tabRow.width / tabRow.count
     font: QfTheme.defaultFont
     checked: tabRow.currentIndex === index
     onClicked: {

--- a/src/gui/qml/QfTabBar.qml
+++ b/src/gui/qml/QfTabBar.qml
@@ -13,6 +13,7 @@ ListView {
 
   orientation: Qt.Horizontal
   highlightFollowsCurrentItem: true
+  highlightResizeDuration: 0
   currentIndex: 0
 
   highlight: Item {

--- a/test/qml/tst_qfieldCloudScreenUI.qml
+++ b/test/qml/tst_qfieldCloudScreenUI.qml
@@ -75,12 +75,12 @@ TestCase {
   property var connectionSettings: mainColumnLayout.children[1]
   property var projectsSwipeView: mainColumnLayout.children[2]
   property var projectsColumnLayout: projectsSwipeView.contentChildren[0]
-  property var filterBar: projectsColumnLayout.children[1]
+  property var filterBar: mainColumnLayout.children[0].children[0]
   property var searchBarTextArea: projectsColumnLayout.children[2].children[0].children[3]
-  property var tableContainer: projectsColumnLayout.children[3]
+  property var tableContainer: projectsColumnLayout.children[2]
   property var table: tableContainer.children[0]
   property var projectDetails: projectsSwipeView.contentChildren[1]
-  property var searchBar: projectsColumnLayout.children[2]
+  property var searchBar: projectsColumnLayout.children[1]
 
   SignalSpy {
     id: connectionStatusSpy


### PR DESCRIPTION
This PR relocates the (re)introduced cloud projects / templates tab bar to sit on top of the page to the left of the user avatar icon. This is how it looks:

<img width="412" height="563" alt="Screenshot From 2026-08-15 13-46-51" src="https://github.com/user-attachments/assets/5cabd8c2-5d63-4506-97c6-518194b87fb2" />

This regains the vertical space we had lost when adding the tab bar, and gets rid of the 'greetings' label, which never quite felt right there to begin with.

When switching to templates, the search bar placeholder label switches to 'search for templates':

<img width="412" height="563" alt="Screenshot From 2026-08-15 13-46-56" src="https://github.com/user-attachments/assets/af723698-b67c-4a79-aa5a-12667490034a" />

Finally, if the logged in user account has no templates (i.e. none owned directly by the account or their affiliated organizations), the page looks like this:

<img width="412" height="563" alt="Screenshot From 2026-08-15 13-52-05" src="https://github.com/user-attachments/assets/645fc483-ba56-4bd3-be94-218f7a366ba1" />

An additional fix on how templates are handled when users log out is included in the PR.