### PR TITLE
qTriangulate crash debugging

### DIFF
--- a/src/3d/qml/QfFeatureListSelectionHighlight3D.qml
+++ b/src/3d/qml/QfFeatureListSelectionHighlight3D.qml
@@ -31,8 +31,8 @@ Node {
 
       Model {
         geometry: Qf3DGeometry {
-          qgsGeometry: model.geometry
           crs: model.crs
+          qgsGeometry: model.geometry
           terrainProvider: featureListSelectionHighlight3D.terrainProvider
           lineWidth: featureListSelectionHighlight3D.lineWidth
           heightOffset: featureListSelectionHighlight3D.heightOffset

--- a/src/3d/qml/QfMapCanvas3D.qml
+++ b/src/3d/qml/QfMapCanvas3D.qml
@@ -268,8 +268,8 @@ Item {
 
         Model {
           geometry: Qf3DGeometry {
-            qgsGeometry: QfGeometryUtils.createGeometryFromWkt(modelData.wkt)
             crs: modelData.crs
+            qgsGeometry: QfGeometryUtils.createGeometryFromWkt(modelData.wkt)
             lineWidth: modelData.lineWidth
             heightOffset: modelData.heightOffset
             altitudeClamping: modelData.altitudeClamping

--- a/src/app/qml/QfFeatureListSelectionHighlight.qml
+++ b/src/app/qml/QfFeatureListSelectionHighlight.qml
@@ -26,8 +26,8 @@ Repeater {
 
   delegate: QfGeometryRenderer {
     mapSettings: featureListSelectionHighlight.mapSettings
-    geometryWrapper.qgsGeometry: model.geometry
     geometryWrapper.crs: model.crs
+    geometryWrapper.qgsGeometry: model.geometry
 
     visible: featureListSelectionHighlight.visible && (!showSelectedOnly || model.featureSelected)
     color: model.featureSelected ? featureListSelectionHighlight.selectedColor : selectionModel.model.selectedCount === 0 && selectionModel && model.index === selectionModel.focusedItem ? featureListSelectionHighlight.focusedColor : featureListSelectionHighlight.color

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -1221,8 +1221,8 @@ ApplicationWindow {
       visible: informationDrawer.elevationProfile.visible
       mapSettings: mapCanvas.mapSettings
       geometry: QfGeometryWrapper {
-        qgsGeometry: informationDrawer.elevationProfile.profileCurve
         crs: informationDrawer.elevationProfile.crs
+        qgsGeometry: informationDrawer.elevationProfile.profileCurve
       }
       color: "#FFFFFF"
       lineWidth: 4

--- a/src/core/qflinepolygonshape.cpp
+++ b/src/core/qflinepolygonshape.cpp
@@ -230,20 +230,37 @@ void QfLinePolygonShape::setGeometry( QfGeometryWrapper *geometry )
 
   if ( mGeometry )
   {
-    disconnect( mGeometry, &QfGeometryWrapper::qgsGeometryChanged, this, &QfLinePolygonShape::makeDirty );
-    disconnect( mGeometry, &QfGeometryWrapper::crsChanged, this, &QfLinePolygonShape::makeDirty );
+    disconnect( mGeometry, &QfGeometryWrapper::qgsGeometryChanged, this, &QfLinePolygonShape::catchGeometryWrapperChange );
+    disconnect( mGeometry, &QfGeometryWrapper::crsChanged, this, &QfLinePolygonShape::catchGeometryWrapperChange );
   }
 
   mGeometry = geometry;
 
   if ( mGeometry )
   {
-    connect( mGeometry, &QfGeometryWrapper::qgsGeometryChanged, this, &QfLinePolygonShape::makeDirty );
-    connect( mGeometry, &QfGeometryWrapper::crsChanged, this, &QfLinePolygonShape::makeDirty );
+    connect( mGeometry, &QfGeometryWrapper::qgsGeometryChanged, this, &QfLinePolygonShape::catchGeometryWrapperChange );
+    connect( mGeometry, &QfGeometryWrapper::crsChanged, this, &QfLinePolygonShape::catchGeometryWrapperChange );
+
+    if ( mGeometry->crs().isValid() && !mGeometry->qgsGeometry().isEmpty() )
+    {
+      qInfo() << "QfLinePolygonShape::setGeometry crs:" << mGeometry->crs().authid();
+      qInfo() << "QfLinePolygonShape::setGeometry geometry:" << mGeometry->qgsGeometry().asWkt();
+    }
   }
 
   mDirty = true;
-  emit qgsGeometryChanged();
+  emit geometryChanged();
 
   updateTransform();
+}
+
+void QfLinePolygonShape::catchGeometryWrapperChange()
+{
+  if ( mGeometry->crs().isValid() && !mGeometry->qgsGeometry().isEmpty() )
+  {
+    qInfo() << "QfLinePolygonShape::catchGeometryWrapperChange crs:" << mGeometry->crs().authid();
+    qInfo() << "QfLinePolygonShape::catchGeometryWrapperChange geometry:" << mGeometry->qgsGeometry().asWkt();
+  }
+
+  makeDirty();
 }

--- a/src/core/qflinepolygonshape.cpp
+++ b/src/core/qflinepolygonshape.cpp
@@ -36,10 +36,27 @@ void QfLinePolygonShape::createPolylines()
   const QgsRectangle visibleExtent = mMapSettings->visibleExtent();
   const double scaleFactor = 1.0 / mMapSettings->mapUnitsPerPoint();
 
+  if ( !mGeometry || !mGeometry->crs().isValid() || mGeometry->qgsGeometry().isNull() )
+  {
+    if ( mPolylinesType != Qgis::GeometryType::Null )
+    {
+      mPolylinesType = Qgis::GeometryType::Null;
+      emit polylinesTypeChanged();
+    }
+
+    if ( !mPolylines.isEmpty() )
+    {
+      mPolylines.clear();
+      emit polylinesChanged();
+    }
+
+    return;
+  }
+
   mPolylines.clear();
 
-  QgsGeometry geometry( mGeometry ? mGeometry->qgsGeometry() : QgsGeometry() );
-  if ( mGeometry && mGeometry->crs() != mMapSettings->destinationCrs() )
+  QgsGeometry geometry( mGeometry->qgsGeometry() );
+  if ( mGeometry->crs() != mMapSettings->destinationCrs() )
   {
     QgsCoordinateTransform ct( mGeometry->crs(), mMapSettings->destinationCrs(), QgsProject::instance()->transformContext() );
     try
@@ -53,11 +70,10 @@ void QfLinePolygonShape::createPolylines()
   }
 
   Qgis::GeometryType geomType = Qgis::GeometryType::Null;
-  if ( mGeometry && !geometry.isEmpty() && geometry.type() != Qgis::GeometryType::Point )
+  if ( !geometry.isEmpty() && geometry.type() != Qgis::GeometryType::Point )
   {
     geometry = geometry.simplify( mMapSettings->mapUnitsPerPoint() );
     geometry = geometry.makeValid();
-
     geomType = geometry.type();
     switch ( geomType )
     {

--- a/src/core/qflinepolygonshape.h
+++ b/src/core/qflinepolygonshape.h
@@ -35,7 +35,7 @@ class QfLinePolygonShape : public QQuickItem
     Q_PROPERTY( QColor color READ color WRITE setColor NOTIFY colorChanged )
     Q_PROPERTY( float lineWidth READ lineWidth WRITE setLineWidth NOTIFY lineWidthChanged )
     Q_PROPERTY( QgsQuickMapSettings *mapSettings READ mapSettings WRITE setMapSettings NOTIFY mapSettingsChanged )
-    Q_PROPERTY( QfGeometryWrapper *geometry READ geometry WRITE setGeometry NOTIFY qgsGeometryChanged )
+    Q_PROPERTY( QfGeometryWrapper *geometry READ geometry WRITE setGeometry NOTIFY geometryChanged )
 
     //! List of polylines representing the geometry
     Q_PROPERTY( QList<QPolygonF> polylines READ polylines NOTIFY polylinesChanged )
@@ -67,7 +67,7 @@ class QfLinePolygonShape : public QQuickItem
     void colorChanged();
     void lineWidthChanged();
     void mapSettingsChanged();
-    void qgsGeometryChanged();
+    void geometryChanged();
     void updated();
     //! \copydoc polylines
     void polylinesChanged();
@@ -79,6 +79,7 @@ class QfLinePolygonShape : public QQuickItem
     void mapCrsChanged();
     void visibleExtentChanged();
     void makeDirty();
+    void catchGeometryWrapperChange();
 
   private:
     void updateTransform();

--- a/src/gui/qml/QfBookmarkHighlight.qml
+++ b/src/gui/qml/QfBookmarkHighlight.qml
@@ -15,8 +15,8 @@ Repeater {
 
   delegate: QfBookmarkRenderer {
     mapSettings: bookmarkHighlight.mapSettings
-    geometryWrapper.qgsGeometry: model.BookmarkPoint
     geometryWrapper.crs: model.BookmarkCrs
+    geometryWrapper.qgsGeometry: model.BookmarkPoint
 
     bookmarkIndex: model.index
     bookmarkId: model.BookmarkId

--- a/src/gui/qml/QfNavigationHighlight.qml
+++ b/src/gui/qml/QfNavigationHighlight.qml
@@ -14,8 +14,8 @@ Item {
     visible: positionSource.active
     mapSettings: navigation.mapSettings
     geometry: QfGeometryWrapper {
-      qgsGeometry: navigation.path
       crs: navigation.mapSettings.crs ? navigation.mapSettings.crs : QfCoordinateReferenceSystemUtils.invalidCrs()
+      qgsGeometry: navigation.path
     }
     color: QfTheme.navigationColorSemiOpaque
     lineWidth: positionSource.active && positionSource.positionInformation && positionSource.positionInformation.latitudeValid ? 5 : 1
@@ -26,8 +26,8 @@ Item {
 
     delegate: QfNavigationRenderer {
       mapSettings: navigation.mapSettings
-      geometryWrapper.qgsGeometry: model.Point
       geometryWrapper.crs: navigation.mapSettings.destinationCrs
+      geometryWrapper.qgsGeometry: model.Point
       pointIndex: model.index
       pointType: model.PointType
     }

--- a/src/gui/qml/QfProcessingAlgorithmPreview.qml
+++ b/src/gui/qml/QfProcessingAlgorithmPreview.qml
@@ -18,8 +18,8 @@ Repeater {
 
   delegate: QfGeometryRenderer {
     mapSettings: processingAlgorithmPreview.mapSettings
-    geometryWrapper.qgsGeometry: modelData
     geometryWrapper.crs: processingAlgorithmPreview.algorithm.inPlaceLayer.crs
+    geometryWrapper.qgsGeometry: modelData
 
     color: processingAlgorithmPreview.color
     z: 1


### PR DESCRIPTION
This PR cleans up the QfLineGeometryShape class and its various uses in our QML scene. 

It also adds some qInfo() lines to try and catch any geometry that would lead to triangulation crash (the primary source of crash these days).