### PR TITLE
Auto-download projects after creation from template / cloning

### DIFF
--- a/src/app/qml/QfCloudScreen.qml
+++ b/src/app/qml/QfCloudScreen.qml
@@ -17,6 +17,7 @@ Page {
 
   property string requestedProjectDetails: ""
   property QfCloudStatus cloudServiceStatus: null
+  property string pendingCreatedProjectId: ""
 
   leftPadding: mainWindow.sceneLeftMargin
   rightPadding: mainWindow.sceneRightMargin
@@ -1006,6 +1007,8 @@ Page {
     onAccepted: {
       const trimmedName = cloneProjectName.text.trim();
       if (trimmedName !== "") {
+        busyOverlay.text = qsTr("Creating project…");
+        busyOverlay.state = "visible";
         cloudProjectsModel.createProject(trimmedName, sourceProjectId);
       }
     }
@@ -1062,9 +1065,75 @@ Page {
     function onProjectCreated(projectId, fromProjectId, hasError, errorString) {
       const isClone = fromProjectId !== "";
       if (hasError) {
+        busyOverlay.state = "hidden";
         displayToast(isClone ? qsTr("Project cloning failed: %1").arg(errorString) : qsTr("Project creation failed: %1").arg(errorString));
-      } else {
-        displayToast(isClone ? qsTr("Project successfully cloned") : qsTr("Project successfully created"));
+        return;
+      }
+      pendingCreatedProjectId = projectId;
+      busyOverlay.text = qsTr("Preparing project…");
+      readinessPollTimer.attempts = 0;
+      readinessPollTimer.start();
+    }
+
+    function onProjectDownloaded(projectId, projectName, projectOwner, hasError, errorString) {
+      // Only react to the download we started as part of a create-from-source flow
+      if (projectId !== pendingCreatedProjectId) {
+        return;
+      }
+      pendingCreatedProjectId = "";
+      busyOverlay.state = "hidden";
+
+      if (hasError) {
+        displayToast(qsTr("Project created but downloading failed: %1").arg(QfCloudUtils.userFriendlyErrorString(errorString)));
+        return;
+      }
+
+      projectDetails.cloudProject = cloudProjectsModel.findProject(projectId);
+      projectsSwipeView.currentIndex = 1;
+    }
+  }
+
+  Connections {
+    target: pendingCreatedProjectId !== "" ? cloudProjectsModel.findProject(pendingCreatedProjectId) : null
+    ignoreUnknownSignals: true
+
+    function onDownloadProgressChanged() {
+      busyOverlay.progress = target.downloadProgress;
+    }
+  }
+
+  Timer {
+    id: readinessPollTimer
+    interval: 2000
+    repeat: true
+
+    property int attempts: 0
+
+    onTriggered: {
+      if (pendingCreatedProjectId === "") {
+        stop();
+        return;
+      }
+
+      const project = cloudProjectsModel.findProject(pendingCreatedProjectId);
+      if (project && project.hasValidProjectfile) {
+        stop();
+        busyOverlay.text = qsTr("Downloading project…");
+        cloudProjectsModel.projectPackageAndDownload(pendingCreatedProjectId);
+        return;
+      }
+
+      attempts++;
+      if (attempts >= 15) {
+        stop();
+        pendingCreatedProjectId = "";
+        busyOverlay.state = "hidden";
+        displayToast(qsTr("The project could not be prepared in time. Please try downloading it manually."));
+        return;
+      }
+
+      if (project) {
+        project.refreshProjectData();
       }
     }
   }

--- a/src/app/qml/QfCloudScreen.qml
+++ b/src/app/qml/QfCloudScreen.qml
@@ -17,6 +17,7 @@ Page {
 
   property string requestedProjectDetails: ""
   property string pendingCreatedProjectId: ""
+  property bool pendingCreatedDownloadStarted: false
   property QfCloudStatus cloudServiceStatus: null
 
   leftPadding: mainWindow.sceneLeftMargin
@@ -1070,16 +1071,8 @@ Page {
         return;
       }
       pendingCreatedProjectId = projectId;
+      pendingCreatedDownloadStarted = false;
       busyOverlay.text = qsTr("Preparing project…");
-    }
-
-    function onProjectReadinessFailed(projectId, errorString) {
-      if (projectId !== pendingCreatedProjectId) {
-        return;
-      }
-      pendingCreatedProjectId = "";
-      busyOverlay.state = "hidden";
-      displayToast(qsTr("The project could not be prepared: %1").arg(QfCloudUtils.userFriendlyErrorString(errorString)));
     }
 
     function onProjectDownloaded(projectId, projectName, projectOwner, hasError, errorString) {
@@ -1088,6 +1081,7 @@ Page {
         return;
       }
       pendingCreatedProjectId = "";
+      pendingCreatedDownloadStarted = false;
       busyOverlay.state = "hidden";
 
       if (hasError) {
@@ -1103,6 +1097,26 @@ Page {
   Connections {
     target: pendingCreatedProjectId !== "" ? cloudProjectsModel.findProject(pendingCreatedProjectId) : null
     ignoreUnknownSignals: true
+
+    function onStatusChanged() {
+      // The project leaves the Creating state once its create job settles.
+      // On success we start the download and on failure we surface the error and clear the overlay
+      if (target.status === QfCloudProject.ProjectStatus.Creating) {
+        return;
+      }
+      if (target.status === QfCloudProject.ProjectStatus.Failing) {
+        pendingCreatedProjectId = "";
+        pendingCreatedDownloadStarted = false;
+        busyOverlay.state = "hidden";
+        displayToast(qsTr("The project could not be prepared. Please try downloading it manually."));
+        return;
+      }
+      if (target.status === QfCloudProject.ProjectStatus.Idle && !pendingCreatedDownloadStarted) {
+        pendingCreatedDownloadStarted = true;
+        busyOverlay.text = qsTr("Downloading project…");
+        cloudProjectsModel.projectPackageAndDownload(pendingCreatedProjectId);
+      }
+    }
 
     function onDownloadProgressChanged() {
       busyOverlay.progress = target.downloadProgress;

--- a/src/app/qml/QfCloudScreen.qml
+++ b/src/app/qml/QfCloudScreen.qml
@@ -1108,7 +1108,7 @@ Page {
         pendingCreatedProjectId = "";
         pendingCreatedDownloadStarted = false;
         busyOverlay.state = "hidden";
-        displayToast(qsTr("The project could not be prepared. Please try downloading it manually."));
+        displayToast(qsTr("The newly-created project could not be prepared."), 'warning');
         return;
       }
       if (target.status === QfCloudProject.ProjectStatus.Idle && !pendingCreatedDownloadStarted) {

--- a/src/app/qml/QfCloudScreen.qml
+++ b/src/app/qml/QfCloudScreen.qml
@@ -16,8 +16,8 @@ Page {
   signal viewProjectFolder(string projectPath)
 
   property string requestedProjectDetails: ""
-  property QfCloudStatus cloudServiceStatus: null
   property string pendingCreatedProjectId: ""
+  property QfCloudStatus cloudServiceStatus: null
 
   leftPadding: mainWindow.sceneLeftMargin
   rightPadding: mainWindow.sceneRightMargin
@@ -700,7 +700,7 @@ Page {
             id: refreshProjectsListBtn
             Layout.fillWidth: true
             text: filterBar.currentIndex === 1 ? qsTr("Refresh templates list") : qsTr("Refresh projects list")
-            enabled: cloudConnection.status === QfCloudConnection.LoggedIn && cloudConnection.state === QfCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
+            enabled: cloudConnection.status === QfCloudConnection.LoggedIn && cloudConnection.state === QfCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0 && pendingCreatedProjectId === ""
             showProgress: cloudProjectsModel.isRefreshing || table.model.isSearching
             progressValue: 0
             onClicked: {
@@ -710,7 +710,7 @@ Page {
 
           QfToolButton {
             id: scanProjectBtn
-            enabled: cloudConnection.status === QfCloudConnection.LoggedIn && cloudConnection.state === QfCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0
+            enabled: cloudConnection.status === QfCloudConnection.LoggedIn && cloudConnection.state === QfCloudConnection.Idle && cloudProjectsModel.busyProjectIds.length === 0 && pendingCreatedProjectId === ""
             visible: enabled
 
             bgcolor: "transparent"
@@ -1071,12 +1071,19 @@ Page {
       }
       pendingCreatedProjectId = projectId;
       busyOverlay.text = qsTr("Preparing project…");
-      readinessPollTimer.attempts = 0;
-      readinessPollTimer.start();
+    }
+
+    function onProjectReadinessFailed(projectId, errorString) {
+      if (projectId !== pendingCreatedProjectId) {
+        return;
+      }
+      pendingCreatedProjectId = "";
+      busyOverlay.state = "hidden";
+      displayToast(qsTr("The project could not be prepared: %1").arg(QfCloudUtils.userFriendlyErrorString(errorString)));
     }
 
     function onProjectDownloaded(projectId, projectName, projectOwner, hasError, errorString) {
-      // Only react to the download we started as part of a create-from-source flow
+      // Only react to the download started as part of a create-from-source flow
       if (projectId !== pendingCreatedProjectId) {
         return;
       }
@@ -1099,42 +1106,6 @@ Page {
 
     function onDownloadProgressChanged() {
       busyOverlay.progress = target.downloadProgress;
-    }
-  }
-
-  Timer {
-    id: readinessPollTimer
-    interval: 2000
-    repeat: true
-
-    property int attempts: 0
-
-    onTriggered: {
-      if (pendingCreatedProjectId === "") {
-        stop();
-        return;
-      }
-
-      const project = cloudProjectsModel.findProject(pendingCreatedProjectId);
-      if (project && project.hasValidProjectfile) {
-        stop();
-        busyOverlay.text = qsTr("Downloading project…");
-        cloudProjectsModel.projectPackageAndDownload(pendingCreatedProjectId);
-        return;
-      }
-
-      attempts++;
-      if (attempts >= 15) {
-        stop();
-        pendingCreatedProjectId = "";
-        busyOverlay.state = "hidden";
-        displayToast(qsTr("The project could not be prepared in time. Please try downloading it manually."));
-        return;
-      }
-
-      if (project) {
-        project.refreshProjectData();
-      }
     }
   }
 

--- a/src/core/qfieldcloud/qfcloudproject.cpp
+++ b/src/core/qfieldcloud/qfcloudproject.cpp
@@ -122,19 +122,6 @@ void QfCloudProject::setDescription( const QString &description )
   emit descriptionChanged();
 }
 
-void QfCloudProject::setTheQgisFileName( const QString &theQgisFileName )
-{
-  if ( mTheQgisFileName == theQgisFileName )
-    return;
-
-  const bool wasValid = !mTheQgisFileName.isEmpty();
-  mTheQgisFileName = theQgisFileName;
-  if ( wasValid != !mTheQgisFileName.isEmpty() )
-  {
-    emit hasValidProjectfileChanged();
-  }
-}
-
 void QfCloudProject::setUserRole( const QString &userRole )
 {
   if ( mUserRole == userRole )
@@ -831,11 +818,6 @@ void QfCloudProject::packageAndDownload()
 
     emit downloaded( error );
   } );
-}
-
-void QfCloudProject::refreshProjectData()
-{
-  refreshData( ProjectRefreshReason::Generic );
 }
 
 void QfCloudProject::download()
@@ -2037,6 +2019,115 @@ void QfCloudProject::getJobStatus( const JobType type )
   } );
 }
 
+void QfCloudProject::checkProjectReadiness()
+{
+  mReadinessJobId.clear();
+  mReadinessAttempts = 0;
+  fetchReadinessJobId();
+}
+
+void QfCloudProject::fetchReadinessJobId()
+{
+  if ( !mCloudConnection )
+    return;
+
+  QVariantMap params;
+  params.insert( QStringLiteral( "project_id" ), mId );
+  params.insert( QStringLiteral( "type" ), QStringLiteral( "process_projectfile" ) );
+
+  QfNetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/jobs/" ), params );
+  connect( reply, &QfNetworkReply::finished, this, [this, reply]() {
+    reply->deleteLater();
+
+    QNetworkReply *rawReply = reply->currentRawReply();
+    if ( rawReply->error() != QNetworkReply::NoError )
+    {
+      QgsLogger::debug( QStringLiteral( "Project %1: fetching readiness job failed: %2" ).arg( mId, QfCloudConnection::errorString( rawReply ) ) );
+      emit projectReadinessChecked( false, QfCloudConnection::errorString( rawReply ) );
+      return;
+    }
+
+    const QJsonArray jobs = QJsonDocument::fromJson( rawReply->readAll() ).array();
+    if ( jobs.isEmpty() )
+    {
+      // The process_projectfile job is queued asynchronously, so its record might not exist yet.
+      mReadinessAttempts++;
+      if ( mReadinessAttempts >= sMaxReadinessAttempts )
+      {
+        emit projectReadinessChecked( false, tr( "The project could not be prepared in time." ) );
+        return;
+      }
+      QTimer::singleShot( sReadinessBaseDelay, this, [this]() { fetchReadinessJobId(); } );
+      return;
+    }
+
+    // A freshly created or cloned project has a single process_projectfile job.
+    mReadinessJobId = jobs.first().toObject().value( QStringLiteral( "id" ) ).toString();
+    if ( mReadinessJobId.isEmpty() )
+    {
+      emit projectReadinessChecked( false, tr( "Project preparation job is missing an identifier." ) );
+      return;
+    }
+
+    pollReadinessJob();
+  } );
+}
+
+void QfCloudProject::pollReadinessJob()
+{
+  if ( !mCloudConnection || mReadinessJobId.isEmpty() )
+  {
+    emit projectReadinessChecked( false, tr( "No project preparation job to poll." ) );
+    return;
+  }
+
+  QfNetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/jobs/%1/" ).arg( mReadinessJobId ) );
+  connect( reply, &QfNetworkReply::finished, this, [this, reply]() {
+    reply->deleteLater();
+
+    QNetworkReply *rawReply = reply->currentRawReply();
+    if ( rawReply->error() != QNetworkReply::NoError )
+    {
+      QgsLogger::debug( QStringLiteral( "Project %1, job %2: readiness poll failed: %3" ).arg( mId, mReadinessJobId, QfCloudConnection::errorString( rawReply ) ) );
+      emit projectReadinessChecked( false, QfCloudConnection::errorString( rawReply ) );
+      return;
+    }
+
+    const QJsonObject payload = QJsonDocument::fromJson( rawReply->readAll() ).object();
+    const QString jobStatusString = payload.value( QStringLiteral( "status" ) ).toString();
+    if ( jobStatusString.isEmpty() )
+    {
+      emit projectReadinessChecked( false, tr( "Project preparation job status response is missing required fields: status(string)." ) );
+      return;
+    }
+
+    switch ( getJobStatusFromString( jobStatusString ) )
+    {
+      case JobPendingStatus:
+      case JobQueuedStatus:
+      case JobStartedStatus:
+      case JobStoppedStatus:
+        mReadinessAttempts++;
+        if ( mReadinessAttempts >= sMaxReadinessAttempts )
+        {
+          emit projectReadinessChecked( false, tr( "The project could not be prepared in time." ) );
+          return;
+        }
+        // 2s floor with a mild backoff so a slow or worker-starved queue is not hammered.
+        QTimer::singleShot( sReadinessBaseDelay + ( mReadinessAttempts * 500 ), this, [this]() { pollReadinessJob(); } );
+        return;
+
+      case JobFinishedStatus:
+        emit projectReadinessChecked( true );
+        return;
+
+      case JobFailedStatus:
+        emit projectReadinessChecked( false, tr( "Project preparation job failed." ) );
+        return;
+    }
+  } );
+}
+
 QfCloudProject::JobStatus QfCloudProject::getJobStatusFromString( const QString &status )
 {
   const QString statusLower = status.toLower();
@@ -2136,7 +2227,6 @@ void QfCloudProject::refreshData( ProjectRefreshReason reason )
     setNeedsRepackaging( projectData.value( "needs_repackaging" ).toBool() );
     setLastRefreshedAt( QDateTime::currentDateTimeUtc() );
     setDataLastUpdatedAt( QDateTime::fromString( projectData.value( "data_last_updated_at" ).toString(), Qt::ISODate ) );
-    setTheQgisFileName( projectData.value( "the_qgis_file_name" ).toString() );
 
     QfCloudUtils::setProjectSetting( mId, QStringLiteral( "name" ), mName );
     QfCloudUtils::setProjectSetting( mId, QStringLiteral( "owner" ), mOwner );
@@ -2222,7 +2312,6 @@ QfCloudProject *QfCloudProject::fromDetails( const QVariantHash &details, QfClou
   project->mCanRepackage = details.value( "can_repackage" ).toBool();
   project->mNeedsRepackaging = details.value( "needs_repackaging" ).toBool();
   project->mSharedDatasetsProjectId = details.value( "shared_datasets_project_id" ).toString();
-  project->mTheQgisFileName = details.value( "the_qgis_file_name" ).toString();
 
   // QFieldCloud servers predating the `project_type` field still report the
   // deprecated `is_shared_datasets_project` boolean. Prefer `project_type` when

--- a/src/core/qfieldcloud/qfcloudproject.cpp
+++ b/src/core/qfieldcloud/qfcloudproject.cpp
@@ -477,7 +477,9 @@ void QfCloudProject::downloadThumbnail()
   QgsLogger::debug( QStringLiteral( "Project %1: thumbnail download initiated." ).arg( mId ) );
 
   if ( !mCloudConnection )
+  {
     return;
+  }
 
   QNetworkRequest request;
   request.setAttribute( QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::RedirectPolicy::NoLessSafeRedirectPolicy );
@@ -661,7 +663,9 @@ void QfCloudProject::packageAndDownload()
   QgsLogger::debug( QStringLiteral( "Project %1: package and download initiated." ).arg( mId ) );
 
   if ( !mCloudConnection )
+  {
     return;
+  }
 
   if ( mStatus != ProjectStatus::Idle )
   {
@@ -1072,7 +1076,9 @@ void QfCloudProject::prepareDownloadTransfer( const QString &projectId, const QS
 void QfCloudProject::updateActiveFilesToDownload()
 {
   if ( !mCloudConnection )
+  {
     return;
+  }
 
   const QStringList fileKeys = mDownloadFileTransfers.keys();
 
@@ -1126,7 +1132,9 @@ void QfCloudProject::downloadFiles()
   // calling updateActiveProjectFilesToDownload() before calling this function is mandatory
 
   if ( !mCloudConnection )
+  {
     return;
+  }
 
   // Don't call download project files, if there are no project files
   if ( mActiveFilesToDownload.isEmpty() )
@@ -2025,7 +2033,9 @@ void QfCloudProject::ensureProjectCreated()
   mCreateJobAttempts = 0;
 
   if ( !mCloudConnection )
+  {
     return;
+  }
 
   QVariantMap params;
   params.insert( QStringLiteral( "project_id" ), mId );
@@ -2045,11 +2055,11 @@ void QfCloudProject::ensureProjectCreated()
 
     const QJsonArray jobs = QJsonDocument::fromJson( rawReply->readAll() ).array();
     mCreateJobId = jobs.first().toObject().value( QStringLiteral( "id" ) ).toString();
-    pollCreateProjectJob();
+    getCreateProjectJobStatus();
   } );
 }
 
-void QfCloudProject::pollCreateProjectJob()
+void QfCloudProject::getCreateProjectJobStatus()
 {
   if ( !mCloudConnection || mCreateJobId.isEmpty() )
   {
@@ -2085,7 +2095,7 @@ void QfCloudProject::pollCreateProjectJob()
           return;
         }
         // 2s floor with a mild backoff so a slow or worker-starved queue is not hammered.
-        QTimer::singleShot( sCreateJobBaseDelay + ( mCreateJobAttempts * 500 ), this, [this]() { pollCreateProjectJob(); } );
+        QTimer::singleShot( sCreateJobBaseDelay + ( mCreateJobAttempts * 500 ), this, [this]() { getCreateProjectJobStatus(); } );
         return;
 
       case JobFinishedStatus:
@@ -2225,7 +2235,9 @@ void QfCloudProject::cancelDownload()
     QfNetworkReply *reply = mDownloadFileTransfers[fileKey].networkReply;
 
     if ( reply )
+    {
       reply->abort();
+    }
 
     mDownloadFileTransfers.remove( fileKey );
   }

--- a/src/core/qfieldcloud/qfcloudproject.cpp
+++ b/src/core/qfieldcloud/qfcloudproject.cpp
@@ -122,6 +122,19 @@ void QfCloudProject::setDescription( const QString &description )
   emit descriptionChanged();
 }
 
+void QfCloudProject::setTheQgisFileName( const QString &theQgisFileName )
+{
+  if ( mTheQgisFileName == theQgisFileName )
+    return;
+
+  const bool wasValid = !mTheQgisFileName.isEmpty();
+  mTheQgisFileName = theQgisFileName;
+  if ( wasValid != !mTheQgisFileName.isEmpty() )
+  {
+    emit hasValidProjectfileChanged();
+  }
+}
+
 void QfCloudProject::setUserRole( const QString &userRole )
 {
   if ( mUserRole == userRole )
@@ -818,6 +831,11 @@ void QfCloudProject::packageAndDownload()
 
     emit downloaded( error );
   } );
+}
+
+void QfCloudProject::refreshProjectData()
+{
+  refreshData( ProjectRefreshReason::Generic );
 }
 
 void QfCloudProject::download()
@@ -2118,6 +2136,7 @@ void QfCloudProject::refreshData( ProjectRefreshReason reason )
     setNeedsRepackaging( projectData.value( "needs_repackaging" ).toBool() );
     setLastRefreshedAt( QDateTime::currentDateTimeUtc() );
     setDataLastUpdatedAt( QDateTime::fromString( projectData.value( "data_last_updated_at" ).toString(), Qt::ISODate ) );
+    setTheQgisFileName( projectData.value( "the_qgis_file_name" ).toString() );
 
     QfCloudUtils::setProjectSetting( mId, QStringLiteral( "name" ), mName );
     QfCloudUtils::setProjectSetting( mId, QStringLiteral( "owner" ), mOwner );
@@ -2203,6 +2222,7 @@ QfCloudProject *QfCloudProject::fromDetails( const QVariantHash &details, QfClou
   project->mCanRepackage = details.value( "can_repackage" ).toBool();
   project->mNeedsRepackaging = details.value( "needs_repackaging" ).toBool();
   project->mSharedDatasetsProjectId = details.value( "shared_datasets_project_id" ).toString();
+  project->mTheQgisFileName = details.value( "the_qgis_file_name" ).toString();
 
   // QFieldCloud servers predating the `project_type` field still report the
   // deprecated `is_shared_datasets_project` boolean. Prefer `project_type` when

--- a/src/core/qfieldcloud/qfcloudproject.cpp
+++ b/src/core/qfieldcloud/qfcloudproject.cpp
@@ -2019,21 +2019,17 @@ void QfCloudProject::getJobStatus( const JobType type )
   } );
 }
 
-void QfCloudProject::checkProjectReadiness()
+void QfCloudProject::ensureProjectCreated()
 {
-  mReadinessJobId.clear();
-  mReadinessAttempts = 0;
-  fetchReadinessJobId();
-}
+  mCreateJobId.clear();
+  mCreateJobAttempts = 0;
 
-void QfCloudProject::fetchReadinessJobId()
-{
   if ( !mCloudConnection )
     return;
 
   QVariantMap params;
   params.insert( QStringLiteral( "project_id" ), mId );
-  params.insert( QStringLiteral( "type" ), QStringLiteral( "process_projectfile" ) );
+  params.insert( QStringLiteral( "type" ), QStringLiteral( "create_project" ) );
 
   QfNetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/jobs/" ), params );
   connect( reply, &QfNetworkReply::finished, this, [this, reply]() {
@@ -2042,64 +2038,39 @@ void QfCloudProject::fetchReadinessJobId()
     QNetworkReply *rawReply = reply->currentRawReply();
     if ( rawReply->error() != QNetworkReply::NoError )
     {
-      QgsLogger::debug( QStringLiteral( "Project %1: fetching readiness job failed: %2" ).arg( mId, QfCloudConnection::errorString( rawReply ) ) );
-      emit projectReadinessChecked( false, QfCloudConnection::errorString( rawReply ) );
+      QgsLogger::debug( QStringLiteral( "Project %1: fetching create job failed: %2" ).arg( mId, QfCloudConnection::errorString( rawReply ) ) );
+      setStatus( ProjectStatus::Failing );
       return;
     }
 
     const QJsonArray jobs = QJsonDocument::fromJson( rawReply->readAll() ).array();
-    if ( jobs.isEmpty() )
-    {
-      // The process_projectfile job is queued asynchronously, so its record might not exist yet.
-      mReadinessAttempts++;
-      if ( mReadinessAttempts >= sMaxReadinessAttempts )
-      {
-        emit projectReadinessChecked( false, tr( "The project could not be prepared in time." ) );
-        return;
-      }
-      QTimer::singleShot( sReadinessBaseDelay, this, [this]() { fetchReadinessJobId(); } );
-      return;
-    }
-
-    // A freshly created or cloned project has a single process_projectfile job.
-    mReadinessJobId = jobs.first().toObject().value( QStringLiteral( "id" ) ).toString();
-    if ( mReadinessJobId.isEmpty() )
-    {
-      emit projectReadinessChecked( false, tr( "Project preparation job is missing an identifier." ) );
-      return;
-    }
-
-    pollReadinessJob();
+    mCreateJobId = jobs.first().toObject().value( QStringLiteral( "id" ) ).toString();
+    pollCreateProjectJob();
   } );
 }
 
-void QfCloudProject::pollReadinessJob()
+void QfCloudProject::pollCreateProjectJob()
 {
-  if ( !mCloudConnection || mReadinessJobId.isEmpty() )
+  if ( !mCloudConnection || mCreateJobId.isEmpty() )
   {
-    emit projectReadinessChecked( false, tr( "No project preparation job to poll." ) );
+    setStatus( ProjectStatus::Failing );
     return;
   }
 
-  QfNetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/jobs/%1/" ).arg( mReadinessJobId ) );
+  QfNetworkReply *reply = mCloudConnection->get( QStringLiteral( "/api/v1/jobs/%1/" ).arg( mCreateJobId ) );
   connect( reply, &QfNetworkReply::finished, this, [this, reply]() {
     reply->deleteLater();
 
     QNetworkReply *rawReply = reply->currentRawReply();
     if ( rawReply->error() != QNetworkReply::NoError )
     {
-      QgsLogger::debug( QStringLiteral( "Project %1, job %2: readiness poll failed: %3" ).arg( mId, mReadinessJobId, QfCloudConnection::errorString( rawReply ) ) );
-      emit projectReadinessChecked( false, QfCloudConnection::errorString( rawReply ) );
+      QgsLogger::debug( QStringLiteral( "Project %1, job %2: create poll failed: %3" ).arg( mId, mCreateJobId, QfCloudConnection::errorString( rawReply ) ) );
+      setStatus( ProjectStatus::Failing );
       return;
     }
 
     const QJsonObject payload = QJsonDocument::fromJson( rawReply->readAll() ).object();
     const QString jobStatusString = payload.value( QStringLiteral( "status" ) ).toString();
-    if ( jobStatusString.isEmpty() )
-    {
-      emit projectReadinessChecked( false, tr( "Project preparation job status response is missing required fields: status(string)." ) );
-      return;
-    }
 
     switch ( getJobStatusFromString( jobStatusString ) )
     {
@@ -2107,22 +2078,22 @@ void QfCloudProject::pollReadinessJob()
       case JobQueuedStatus:
       case JobStartedStatus:
       case JobStoppedStatus:
-        mReadinessAttempts++;
-        if ( mReadinessAttempts >= sMaxReadinessAttempts )
+        mCreateJobAttempts++;
+        if ( mCreateJobAttempts >= sMaxCreateJobAttempts )
         {
-          emit projectReadinessChecked( false, tr( "The project could not be prepared in time." ) );
+          setStatus( ProjectStatus::Failing );
           return;
         }
         // 2s floor with a mild backoff so a slow or worker-starved queue is not hammered.
-        QTimer::singleShot( sReadinessBaseDelay + ( mReadinessAttempts * 500 ), this, [this]() { pollReadinessJob(); } );
+        QTimer::singleShot( sCreateJobBaseDelay + ( mCreateJobAttempts * 500 ), this, [this]() { pollCreateProjectJob(); } );
         return;
 
       case JobFinishedStatus:
-        emit projectReadinessChecked( true );
+        setStatus( ProjectStatus::Idle );
         return;
 
       case JobFailedStatus:
-        emit projectReadinessChecked( false, tr( "Project preparation job failed." ) );
+        setStatus( ProjectStatus::Failing );
         return;
     }
   } );

--- a/src/core/qfieldcloud/qfcloudproject.h
+++ b/src/core/qfieldcloud/qfcloudproject.h
@@ -499,7 +499,7 @@ class QfCloudProject : public QObject
     void startJob( JobType type );
     void getJobStatus( JobType type );
     void getDeltaStatus();
-    void pollCreateProjectJob();
+    void getCreateProjectJobStatus();
 
     void refreshData( ProjectRefreshReason reason );
 

--- a/src/core/qfieldcloud/qfcloudproject.h
+++ b/src/core/qfieldcloud/qfcloudproject.h
@@ -49,6 +49,7 @@ class QfCloudProject : public QObject
     Q_PROPERTY( qint64 remoteSizeBytes READ remoteSizeBytes NOTIFY remoteSizeBytesChanged )
     Q_PROPERTY( QDateTime dataLastUpdatedAt READ dataLastUpdatedAt NOTIFY dataLastUpdatedAtChanged )
 
+    Q_PROPERTY( bool hasValidProjectfile READ hasValidProjectfile NOTIFY hasValidProjectfileChanged )
     Q_PROPERTY( ProjectStatus status READ status NOTIFY statusChanged )
     Q_PROPERTY( PackagingStatus packagingStatus READ packagingStatus NOTIFY packagingStatusChanged )
     Q_PROPERTY( QStringList packagedLayerErrors READ packagedLayerErrors NOTIFY packagedLayerErrorsChanged )
@@ -218,7 +219,8 @@ class QfCloudProject : public QObject
     enum class ProjectRefreshReason
     {
       Package,
-      DeltaPushed
+      DeltaPushed,
+      Generic
     };
 
     Q_ENUM( ProjectRefreshReason )
@@ -251,6 +253,7 @@ class QfCloudProject : public QObject
 
     QString description() const { return mDescription; }
     void setDescription( const QString &description );
+    void setTheQgisFileName( const QString &theQgisFileName );
 
     QString userRole() const { return mUserRole; }
     void setUserRole( const QString &userRole );
@@ -282,7 +285,9 @@ class QfCloudProject : public QObject
     QDateTime restrictedDataLastUpdatedAt() const { return mRestrictedDataLastUpdatedAt; }
     void setRestrictedDataLastUpdatedAt( const QDateTime &restrictedDataLastUpdatedAt );
 
+    bool hasValidProjectfile() const { return !mTheQgisFileName.isEmpty(); }
     bool canRepackage() const { return mCanRepackage; }
+    QString theQgisFileName() const { return mTheQgisFileName; }
     void setCanRepackage( bool canRepackage );
 
     bool needsRepackaging() const { return mNeedsRepackaging; }
@@ -382,6 +387,7 @@ class QfCloudProject : public QObject
     void cancelDownload();
 
     Q_INVOKABLE void push( bool shouldDownloadUpdates );
+    Q_INVOKABLE void refreshProjectData();
     void cancelPush();
 
     void refreshDeltaList();
@@ -484,6 +490,8 @@ class QfCloudProject : public QObject
     void dataRefreshed( ProjectRefreshReason reason, const QString &error = QString() );
     void jobFinished( JobType type, const QString &error = QString() );
 
+    void hasValidProjectfileChanged();
+
   private:
     void download();
     void prepareDownloadTransfer( const QString &projectId, const QString &fileName, qint64 fileSize, const QString &cloudEtag );
@@ -537,6 +545,7 @@ class QfCloudProject : public QObject
     QString mDescription;
     QString mUserRole;
     QString mUserRoleOrigin;
+    QString mTheQgisFileName;
 
     ProjectErrorStatus mErrorStatus = ProjectErrorStatus::NoErrorStatus;
     ProjectCheckouts mCheckout = ProjectCheckout::LocalCheckout;

--- a/src/core/qfieldcloud/qfcloudproject.h
+++ b/src/core/qfieldcloud/qfcloudproject.h
@@ -114,6 +114,7 @@ class QfCloudProject : public QObject
     enum class ProjectStatus
     {
       Idle,
+      Creating,
       Downloading,
       Pushing,
       Uploading,
@@ -383,9 +384,7 @@ class QfCloudProject : public QObject
 
     Q_INVOKABLE void push( bool shouldDownloadUpdates );
 
-    //! Polls the server-side process_projectfile job of a freshly created/cloned project
-    //! until it reaches a terminal state, then emits projectReadinessChecked().
-    Q_INVOKABLE void checkProjectReadiness();
+    void ensureProjectCreated();
     void cancelPush();
 
     void refreshDeltaList();
@@ -488,8 +487,6 @@ class QfCloudProject : public QObject
     void dataRefreshed( ProjectRefreshReason reason, const QString &error = QString() );
     void jobFinished( JobType type, const QString &error = QString() );
 
-    void projectReadinessChecked( bool ready, const QString &error = QString() );
-
   private:
     void download();
     void prepareDownloadTransfer( const QString &projectId, const QString &fileName, qint64 fileSize, const QString &cloudEtag );
@@ -502,8 +499,7 @@ class QfCloudProject : public QObject
     void startJob( JobType type );
     void getJobStatus( JobType type );
     void getDeltaStatus();
-    void fetchReadinessJobId();
-    void pollReadinessJob();
+    void pollCreateProjectJob();
 
     void refreshData( ProjectRefreshReason reason );
 
@@ -620,10 +616,10 @@ class QfCloudProject : public QObject
 
     static const int sDelayBeforeStatusRetry = 1000;
 
-    QString mReadinessJobId;
-    int mReadinessAttempts = 0;
-    static const int sMaxReadinessAttempts = 20;
-    static const int sReadinessBaseDelay = 2000;
+    QString mCreateJobId;
+    int mCreateJobAttempts = 0;
+    static const int sMaxCreateJobAttempts = 20;
+    static const int sCreateJobBaseDelay = 2000;
 };
 
 Q_DECLARE_METATYPE( QfCloudProject::ProjectType )

--- a/src/core/qfieldcloud/qfcloudproject.h
+++ b/src/core/qfieldcloud/qfcloudproject.h
@@ -49,7 +49,6 @@ class QfCloudProject : public QObject
     Q_PROPERTY( qint64 remoteSizeBytes READ remoteSizeBytes NOTIFY remoteSizeBytesChanged )
     Q_PROPERTY( QDateTime dataLastUpdatedAt READ dataLastUpdatedAt NOTIFY dataLastUpdatedAtChanged )
 
-    Q_PROPERTY( bool hasValidProjectfile READ hasValidProjectfile NOTIFY hasValidProjectfileChanged )
     Q_PROPERTY( ProjectStatus status READ status NOTIFY statusChanged )
     Q_PROPERTY( PackagingStatus packagingStatus READ packagingStatus NOTIFY packagingStatusChanged )
     Q_PROPERTY( QStringList packagedLayerErrors READ packagedLayerErrors NOTIFY packagedLayerErrorsChanged )
@@ -219,8 +218,7 @@ class QfCloudProject : public QObject
     enum class ProjectRefreshReason
     {
       Package,
-      DeltaPushed,
-      Generic
+      DeltaPushed
     };
 
     Q_ENUM( ProjectRefreshReason )
@@ -253,7 +251,6 @@ class QfCloudProject : public QObject
 
     QString description() const { return mDescription; }
     void setDescription( const QString &description );
-    void setTheQgisFileName( const QString &theQgisFileName );
 
     QString userRole() const { return mUserRole; }
     void setUserRole( const QString &userRole );
@@ -285,9 +282,7 @@ class QfCloudProject : public QObject
     QDateTime restrictedDataLastUpdatedAt() const { return mRestrictedDataLastUpdatedAt; }
     void setRestrictedDataLastUpdatedAt( const QDateTime &restrictedDataLastUpdatedAt );
 
-    bool hasValidProjectfile() const { return !mTheQgisFileName.isEmpty(); }
     bool canRepackage() const { return mCanRepackage; }
-    QString theQgisFileName() const { return mTheQgisFileName; }
     void setCanRepackage( bool canRepackage );
 
     bool needsRepackaging() const { return mNeedsRepackaging; }
@@ -387,7 +382,10 @@ class QfCloudProject : public QObject
     void cancelDownload();
 
     Q_INVOKABLE void push( bool shouldDownloadUpdates );
-    Q_INVOKABLE void refreshProjectData();
+
+    //! Polls the server-side process_projectfile job of a freshly created/cloned project
+    //! until it reaches a terminal state, then emits projectReadinessChecked().
+    Q_INVOKABLE void checkProjectReadiness();
     void cancelPush();
 
     void refreshDeltaList();
@@ -490,7 +488,7 @@ class QfCloudProject : public QObject
     void dataRefreshed( ProjectRefreshReason reason, const QString &error = QString() );
     void jobFinished( JobType type, const QString &error = QString() );
 
-    void hasValidProjectfileChanged();
+    void projectReadinessChecked( bool ready, const QString &error = QString() );
 
   private:
     void download();
@@ -504,6 +502,8 @@ class QfCloudProject : public QObject
     void startJob( JobType type );
     void getJobStatus( JobType type );
     void getDeltaStatus();
+    void fetchReadinessJobId();
+    void pollReadinessJob();
 
     void refreshData( ProjectRefreshReason reason );
 
@@ -545,7 +545,6 @@ class QfCloudProject : public QObject
     QString mDescription;
     QString mUserRole;
     QString mUserRoleOrigin;
-    QString mTheQgisFileName;
 
     ProjectErrorStatus mErrorStatus = ProjectErrorStatus::NoErrorStatus;
     ProjectCheckouts mCheckout = ProjectCheckout::LocalCheckout;
@@ -620,6 +619,11 @@ class QfCloudProject : public QObject
     QgsGpkgFlusher *mGpkgFlusher = nullptr;
 
     static const int sDelayBeforeStatusRetry = 1000;
+
+    QString mReadinessJobId;
+    int mReadinessAttempts = 0;
+    static const int sMaxReadinessAttempts = 40;
+    static const int sReadinessBaseDelay = 2000;
 };
 
 Q_DECLARE_METATYPE( QfCloudProject::ProjectType )

--- a/src/core/qfieldcloud/qfcloudproject.h
+++ b/src/core/qfieldcloud/qfcloudproject.h
@@ -622,7 +622,7 @@ class QfCloudProject : public QObject
 
     QString mReadinessJobId;
     int mReadinessAttempts = 0;
-    static const int sMaxReadinessAttempts = 40;
+    static const int sMaxReadinessAttempts = 20;
     static const int sReadinessBaseDelay = 2000;
 };
 

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
@@ -1247,16 +1247,18 @@ void QfCloudProjectsModel::projectCreationReceived()
     emit projectCreated( cloudProject->id(), fromProjectId, false, QString() );
 
     const QString createdProjectId = cloudProject->id();
-    connect( cloudProject, &QfCloudProject::projectReadinessChecked, this, [this, createdProjectId]( bool ready, const QString &error ) {
-      if ( ready )
-      {
-        projectPackageAndDownload( createdProjectId );
-      }
-      else
-      {
-        emit projectReadinessFailed( createdProjectId, error );
-      }
-    } );
+    connect(
+      cloudProject, &QfCloudProject::projectReadinessChecked, this, [this, createdProjectId]( bool ready, const QString &error ) {
+        if ( ready )
+        {
+          projectPackageAndDownload( createdProjectId );
+        }
+        else
+        {
+          emit projectReadinessFailed( createdProjectId, error );
+        }
+      },
+      Qt::SingleShotConnection );
     cloudProject->checkProjectReadiness();
   }
   else

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
@@ -1246,20 +1246,11 @@ void QfCloudProjectsModel::projectCreationReceived()
     insertProjects( QList<QfCloudProject *>() << cloudProject );
     emit projectCreated( cloudProject->id(), fromProjectId, false, QString() );
 
-    const QString createdProjectId = cloudProject->id();
-    connect(
-      cloudProject, &QfCloudProject::projectReadinessChecked, this, [this, createdProjectId]( bool ready, const QString &error ) {
-        if ( ready )
-        {
-          projectPackageAndDownload( createdProjectId );
-        }
-        else
-        {
-          emit projectReadinessFailed( createdProjectId, error );
-        }
-      },
-      Qt::SingleShotConnection );
-    cloudProject->checkProjectReadiness();
+    if ( QfCloudProject *project = findProject( cloudProject->id() ) )
+    {
+      project->setStatus( QfCloudProject::ProjectStatus::Creating );
+      project->ensureProjectCreated();
+    }
   }
   else
   {

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
@@ -1245,6 +1245,19 @@ void QfCloudProjectsModel::projectCreationReceived()
   {
     insertProjects( QList<QfCloudProject *>() << cloudProject );
     emit projectCreated( cloudProject->id(), fromProjectId, false, QString() );
+
+    const QString createdProjectId = cloudProject->id();
+    connect( cloudProject, &QfCloudProject::projectReadinessChecked, this, [this, createdProjectId]( bool ready, const QString &error ) {
+      if ( ready )
+      {
+        projectPackageAndDownload( createdProjectId );
+      }
+      else
+      {
+        emit projectReadinessFailed( createdProjectId, error );
+      }
+    } );
+    cloudProject->checkProjectReadiness();
   }
   else
   {

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.h
@@ -230,6 +230,8 @@ class QfCloudProjectsModel : public QAbstractListModel
     void projectDownloaded( const QString &projectId, const QString &projectName, const QString &projectOwner, const bool hasError = false, const QString &errorString = QString() );
     void pushFinished( const QString &projectId, bool isDownloadingProject, bool hasError = false, const QString &errorString = QString() );
 
+    void projectReadinessFailed( const QString &projectId, const QString &errorString );
+
     void projectUploaded( const QString &projectId );
 
     void hasTemplatesChanged();

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.h
@@ -230,8 +230,6 @@ class QfCloudProjectsModel : public QAbstractListModel
     void projectDownloaded( const QString &projectId, const QString &projectName, const QString &projectOwner, const bool hasError = false, const QString &errorString = QString() );
     void pushFinished( const QString &projectId, bool isDownloadingProject, bool hasError = false, const QString &errorString = QString() );
 
-    void projectReadinessFailed( const QString &projectId, const QString &errorString );
-
     void projectUploaded( const QString &projectId );
 
     void hasTemplatesChanged();


### PR DESCRIPTION
After creating a project from a template (or cloning one), we now show a busy overlay and automatically download the project so it's ready to open right away. Once the download finishes, the project details view opens so you can tap to open it immediately. Previously nothing happened after creation, which wasn't very UX-friendly.

One catch: right after creation the project isn't packageable yet. Files are uploaded after the project record is created, and the server then runs a process_projectfile job to validate the QGIS project and extract metadata, until that finishes, packaging fails with no_qgis_project. So instead of downloading immediately, the client polls that job (via GET /api/v1/jobs/) until it reaches a terminal state, then downloads. The overlay shows "Preparing…" during the poll and "Downloading…" once packaging starts. Because the download only fires after the job finishes, no failed download is ever attempted.

Polling uses a 2s floor with a mild backoff (so a slow or worker-starved queue isn't hammered) and a bounded attempt cap. The busy overlay has no user-facing cancel during preparation; the bounded timeout handles the stuck-job case. A cancel affordance could be added as a follow-up if needed


https://github.com/user-attachments/assets/0d79b0ba-3be5-4afa-95f5-378594604c5c

