### PR TITLE
Add crucial expression context to the ordered feature request when gathering children of a relationship

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -69,7 +69,7 @@ jobs:
             Reply with `@qfield-fairy style please` to fix it up 🪄.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: EndBug/add-and-commit@v11
+      - uses: EndBug/add-and-commit@v10
         if: failure() && steps.run-fixes.outputs.triggered == 'true' && github.event.issue.pull_request
         with:
           author_name: Style Fairy

--- a/src/gui/qfreferencingfeaturelistmodel.h
+++ b/src/gui/qfreferencingfeaturelistmodel.h
@@ -495,6 +495,8 @@ class QfFeatureGatherer : public QThread
         mNmContext = nmRelation.referencedLayer()->createExpressionContext();
         mNmDisplayExpression = nmRelation.referencedLayer()->displayExpression();
       }
+
+      mRequest.setExpressionContext( mContext );
     }
 
     void run() override

--- a/src/gui/qfreferencingfeaturelistmodel.h
+++ b/src/gui/qfreferencingfeaturelistmodel.h
@@ -496,7 +496,7 @@ class QfFeatureGatherer : public QThread
         mNmDisplayExpression = nmRelation.referencedLayer()->displayExpression();
       }
 
-      mRequest.setExpressionContext( mContext );
+      //mRequest.setExpressionContext( mContext );
     }
 
     void run() override


### PR DESCRIPTION
Without the context, display names relying on represent_value() would crash QField when trying to order the children list by display name. 

I'll open a fix upstream too, it should never crash to begin with :)