### PR TITLE
ci: migrate from the deprecated microsoft/store-submission action to the MSStore CLI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -298,25 +298,33 @@ jobs:
     needs: build
 
     steps:
+      - name: Set up MSStore CLI
+        uses: microsoft/microsoft-store-apppublisher@v1.4
+
       - name: Configure Store Credentials
-        uses: microsoft/store-submission@v1
-        with:
-          command: configure
-          type: win32
-          seller-id: ${{ secrets.MICROSOFT_STORE_SELLER_ID }}
-          product-id: ${{ secrets.MICROSOFT_STORE_PRODUCT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+        shell: bash
+        env:
+          STORE_SELLER_ID: ${{ secrets.MICROSOFT_STORE_SELLER_ID }}
+          STORE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          STORE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          STORE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        run: >-
+          msstore reconfigure
+          --tenantId "$STORE_TENANT_ID"
+          --sellerId "$STORE_SELLER_ID"
+          --clientId "$STORE_CLIENT_ID"
+          --clientSecret "$STORE_CLIENT_SECRET"
 
       - name: Update Draft Submission
-        uses: microsoft/store-submission@v1
-        with:
-          command: update
+        shell: bash
+        env:
+          STORE_PRODUCT_ID: ${{ secrets.MICROSOFT_STORE_PRODUCT_ID }}
           # See documentation here https://learn.microsoft.com/en-us/windows/apps/publish/store-submission-api#update-current-draft-submission-metadata-api
-          product-update: '{"packages":[{"packageUrl":"https://sos-ch-dk-2.exo.io/qfieldapks/releases/files/${{ needs.build.outputs.artifact_name_x64 }}","languages":["en"],"architectures":["X64"],"isSilentInstall":false,"installerParameters":"/S","packageType":"exe","genericDocUrl":"https://nsis.sourceforge.io/Docs/AppendixD.html#errorlevels"}, {"packageUrl":"https://sos-ch-dk-2.exo.io/qfieldapks/releases/files/${{ needs.build.outputs.artifact_name_arm64 }}","languages":["en"],"architectures":["Arm64"],"isSilentInstall":false,"installerParameters":"/S","packageType":"exe","genericDocUrl":"https://nsis.sourceforge.io/Docs/AppendixD.html#errorlevels"}]}'
+          PRODUCT_UPDATE: '{"packages":[{"packageUrl":"https://sos-ch-dk-2.exo.io/qfieldapks/releases/files/${{ needs.build.outputs.artifact_name_x64 }}","languages":["en"],"architectures":["X64"],"isSilentInstall":false,"installerParameters":"/S","packageType":"exe","genericDocUrl":"https://nsis.sourceforge.io/Docs/AppendixD.html#errorlevels"}, {"packageUrl":"https://sos-ch-dk-2.exo.io/qfieldapks/releases/files/${{ needs.build.outputs.artifact_name_arm64 }}","languages":["en"],"architectures":["Arm64"],"isSilentInstall":false,"installerParameters":"/S","packageType":"exe","genericDocUrl":"https://nsis.sourceforge.io/Docs/AppendixD.html#errorlevels"}]}'
+        run: msstore submission update "$STORE_PRODUCT_ID" "$PRODUCT_UPDATE"
 
       - name: Publish Submission
-        uses: microsoft/store-submission@v1
-        with:
-          command: publish
+        shell: bash
+        env:
+          STORE_PRODUCT_ID: ${{ secrets.MICROSOFT_STORE_PRODUCT_ID }}
+        run: msstore submission publish "$STORE_PRODUCT_ID"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -299,7 +299,9 @@ jobs:
 
     steps:
       - name: Set up MSStore CLI
-        uses: microsoft/microsoft-store-apppublisher@v1.4
+        uses: microsoft/microsoft-store-apppublisher@cc9910a8d59f2eb55cbb83df0a3800cf3b5300e0 # v1.4
+        with:
+          version: v0.4.1
 
       - name: Configure Store Credentials
         shell: bash


### PR DESCRIPTION
## Why

[`microsoft/store-submission`](https://github.com/microsoft/store-submission) is deprecated and the repository is being archived (see [microsoft/store-submission#27](https://github.com/microsoft/store-submission/pull/27)). Archiving does **not** break anything — `uses: microsoft/store-submission@v1` will keep resolving — but there will be no further fixes, features, or security updates, and it has open issues that will never be addressed (notably [#20](https://github.com/microsoft/store-submission/issues/20): no certificate or federated/managed-identity auth).

The supported replacement is the [MSStore CLI](https://github.com/microsoft/msstore-cli), put on the runner by [`microsoft/microsoft-store-apppublisher`](https://github.com/microsoft/microsoft-store-apppublisher) (the action formerly named `microsoft/setup-msstore-cli`). It handles both packaged (MSIX) and unpackaged (MSI/EXE) apps and is actively maintained. [`microsoft/PowerToys`](https://github.com/microsoft/PowerToys/blob/main/.github/workflows/msstore-submissions.yml) already runs on it.

I'm doing a sweep of the repos still referencing the old action so nobody is caught out by the archive.

## What changed

`deploy (ms store)` in `.github/workflows/windows.yml` now sets up the MSStore CLI and calls it directly. Same job gating (`release` + `refs/tags/v`), same three steps, same secrets, same package payload for the x64/arm64 NSIS `.exe` packages.

### Worth knowing

This job currently fails on roughly 1 in 4 releases. Across the last 12 months of `release`-triggered runs: **27 success, 10 failure, 1 cancelled**. Every failure is the same one — `Update Draft Submission` polls

```
{"responseData":{"isReady":false},"isSuccess":true,"errors":[{"code":"modulenotready","message":"Package Module is not in Ready Status.","target":"packages"}]}
```

…re-printing `Waiting 10 seconds.` until the job times out. That retry loop lives in the action and was never going to be fixed. The CLI has its own polling implementation (plus `--skipInitialPolling` and a `msstore submission poll` command if you want to control it explicitly), so this migration is also the practical way off that failure mode.

## Command mapping used

| `microsoft/store-submission` | MSStore CLI |
| --- | --- |
| `command: configure` + `tenant-id`/`seller-id`/`client-id`/`client-secret` | `msstore reconfigure --tenantId … --sellerId … --clientId … --clientSecret …` |
| `command: update` + `product-update` | `msstore submission update <productId> '<json>'` |
| `command: publish` | `msstore submission publish <productId>` |
| `type: win32` / `type: packaged` | dropped — the CLI resolves the product type itself |

## Notes

- **No secrets added or renamed** — this uses exactly the same ones the workflow already referenced.
- **The JSON payload is unchanged.** `msstore submission update` deserializes into `UpdatePackagesRequest` → `{ "packages": [ { packageUrl, languages, architectures, isSilentInstall, installerParameters, packageType, genericDocUrl, … } ] }`, which is the same shape `product-update` took, so the payload carried over verbatim.
- Secret values are passed via `env:` and referenced as shell variables rather than interpolated straight into the command line — same behaviour, and it keeps them out of the process command line.
- I can't execute this pipeline against your Partner Center product, so **please sanity-check before merging.** Happy to adjust anything.
