### PR TITLE
Ease upload changes visibility and cloud project control panel discoverability

### DIFF
--- a/src/app/qml/QfWelcomeScreen.qml
+++ b/src/app/qml/QfWelcomeScreen.qml
@@ -868,9 +868,44 @@ Page {
     round: true
 
     onClicked: {
+      if (mainWindow.hasLocalCloudChanges) {
+        uploadLocalChangesDialog.open();
+        return;
+      }
       mainWindow.closeAlreadyRequested = true;
       mainWindow.close();
     }
+  }
+
+  QfDialog {
+    id: uploadLocalChangesDialog
+    parent: mainWindow.contentItem
+    closePolicy: Popup.NoAutoClose
+
+    width: Math.min(mainWindow.width - QfTheme.popupScreenEdgeVerticalMargin * 2, 400)
+
+    title: qsTr("Local changes")
+
+    Column {
+      width: parent.width
+
+      Label {
+        width: parent.width
+        wrapMode: Text.WordWrap
+        text: qsTr("You are about to end your session with pending local changes, do you want to upload them now?")
+      }
+    }
+
+    onAccepted: {
+      mainWindow.openCloudPopup();
+    }
+
+    onRejected: {
+      mainWindow.closeAlreadyRequested = true;
+      mainWindow.close();
+    }
+
+    standardButtons: Dialog.Yes | Dialog.No
   }
 
   // Sparkles & unicorns

--- a/src/app/qml/QfWelcomeScreen.qml
+++ b/src/app/qml/QfWelcomeScreen.qml
@@ -868,10 +868,13 @@ Page {
     round: true
 
     onClicked: {
-      const deltaFileWrapper = cloudProjectsModel.layerObserver.deltaFileWrapper;
-      if (cloudConnection.isReachable && settings.valueBool("/QField/showPendingChangesDialog", true) && deltaFileWrapper && deltaFileWrapper.count > 0) {
-        uploadLocalChangesDialog.open();
-        return;
+      if (cloudConnection.isReachable) {
+        const deltaFileWrapper = cloudProjectsModel.layerObserver.deltaFileWrapper;
+        const showPendingChangesDialog = settings.valueBool("/QField/showPendingChangesDialog", true);
+        if (showPendingChangesDialog && deltaFileWrapper && deltaFileWrapper.count > 0) {
+          uploadLocalChangesDialog.open();
+          return;
+        }
       }
       mainWindow.closeAlreadyRequested = true;
       mainWindow.close();
@@ -883,7 +886,7 @@ Page {
     parent: mainWindow.contentItem
     closePolicy: Popup.NoAutoClose
 
-    width: Math.min(mainWindow.width - QfTheme.popupScreenEdgeVerticalMargin * 2, 400)
+    width: Math.min(mainWindow.width - QfTheme.popupScreenEdgeVerticalMargin * 2, 300)
 
     title: qsTr("Local changes")
 

--- a/src/app/qml/QfWelcomeScreen.qml
+++ b/src/app/qml/QfWelcomeScreen.qml
@@ -868,7 +868,8 @@ Page {
     round: true
 
     onClicked: {
-      if (mainWindow.hasLocalCloudChanges) {
+      const deltaFileWrapper = cloudProjectsModel.layerObserver.deltaFileWrapper;
+      if (cloudConnection.isReachable && settings.valueBool("/QField/showPendingChangesDialog", true) && deltaFileWrapper && deltaFileWrapper.count > 0) {
         uploadLocalChangesDialog.open();
         return;
       }
@@ -888,19 +889,34 @@ Page {
 
     Column {
       width: parent.width
+      spacing: 20
 
       Label {
         width: parent.width
         wrapMode: Text.WordWrap
-        text: qsTr("You are about to end your session with pending local changes, do you want to upload them now?")
+        text: qsTr("Pending changes are present, do you want to upload them now or keep them pending and close the cloud project and app?")
+      }
+
+      CheckBox {
+        id: dontShowAgainCheckBox
+        text: qsTr("Don't show this again")
+        font: QfTheme.defaultFont
       }
     }
 
+    onAboutToShow: {
+      dontShowAgainCheckBox.checked = true;
+      standardButton(Dialog.Yes).text = qsTr("Upload now");
+      standardButton(Dialog.No).text = qsTr("Close");
+    }
+
     onAccepted: {
+      settings.setValue("/QField/showPendingChangesDialog", !dontShowAgainCheckBox.checked);
       mainWindow.openCloudPopup();
     }
 
     onRejected: {
+      settings.setValue("/QField/showPendingChangesDialog", !dontShowAgainCheckBox.checked);
       mainWindow.closeAlreadyRequested = true;
       mainWindow.close();
     }

--- a/src/app/qml/QfWelcomeScreen.qml
+++ b/src/app/qml/QfWelcomeScreen.qml
@@ -868,9 +868,8 @@ Page {
     round: true
 
     onClicked: {
-      if (cloudConnection.isReachable) {
+      if (cloudConnection.isReachable && settings.valueBool("/QField/showPendingChangesDialog", true)) {
         const deltaFileWrapper = cloudProjectsModel.layerObserver.deltaFileWrapper;
-        const showPendingChangesDialog = settings.valueBool("/QField/showPendingChangesDialog", true);
         if (showPendingChangesDialog && deltaFileWrapper && deltaFileWrapper.count > 0) {
           uploadLocalChangesDialog.open();
           return;

--- a/src/app/qml/QfWelcomeScreen.qml
+++ b/src/app/qml/QfWelcomeScreen.qml
@@ -1047,15 +1047,19 @@ Page {
 
   Component.onCompleted: {
     adjustWelcomeScreen();
-    var runCount = settings.value("/QField/RunCount", 0) * 1;
-    var feedbackFormShown = settings.value("/QField/FeedbackFormShown", false);
+    const runCount = settings.value("/QField/RunCount", 0) * 1;
+    if (runCount > 0) {
+      // Avoid throwing new guides to pre-existing users upgrading
+      settings.setValue("/QField/showCloudButtonGuide", false);
+    }
+    const feedbackFormShown = settings.value("/QField/FeedbackFormShown", false);
     if (!feedbackFormShown) {
-      var now = new Date();
-      var dt = settings.value("/QField/FirstRunDate", "");
+      let now = new Date();
+      let dt = settings.value("/QField/FirstRunDate", "");
       if (dt != "") {
         dt = new Date(dt);
-        var daysToPrompt = 30;
-        var runsToPrompt = 5;
+        let daysToPrompt = 30;
+        let runsToPrompt = 5;
         if (runCount >= runsToPrompt && (now - dt) >= (daysToPrompt * 24 * 60 * 60 * 1000)) {
           if (Qfield.name === "QField") {
             feedbackView.visible = true;

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -59,6 +59,8 @@ ApplicationWindow {
   property double sceneLeftMargin: SafeArea.margins.left
   property double sceneRightMargin: SafeArea.margins.right
 
+  readonly property bool hasLocalCloudChanges: cloudProjectsModel.layerObserver.deltaFileWrapper ? cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0 : false
+
   onSceneLoadedChanged: {
     // This requires the scene to be fully loaded not to crash due to possibility of
     // a thread blocking permission request being thrown
@@ -3599,9 +3601,7 @@ ApplicationWindow {
     }
 
     onShowCloudPopup: {
-      qfieldCloudStatus.refresh();
-      dashBoard.close();
-      qfieldCloudPopup.show();
+      mainWindow.openCloudPopup();
     }
 
     onToggleMeasurementTool: {
@@ -5430,6 +5430,13 @@ ApplicationWindow {
     }
   }
 
+  function openCloudPopup() {
+    qfieldCloudStatus.refresh();
+    dashBoard.close();
+    welcomeScreen.visible = false;
+    qfieldCloudPopup.show();
+  }
+
   QfCloudPopup {
     id: qfieldCloudPopup
     objectName: "qfieldCloudPopup"
@@ -5602,7 +5609,15 @@ ApplicationWindow {
     if (!closeAlreadyRequested) {
       close.accepted = false;
       closeAlreadyRequested = true;
-      displayToast(qsTr("Press back again to close project and app"));
+      if (hasLocalCloudChanges) {
+        displayToast(qsTr("Press back again to close project and app. Local changes have not yet been uploaded to the cloud."), 'warning', qsTr("Upload local changes"), () => {
+          closeAlreadyRequested = false;
+          closingTimer.stop();
+          openCloudPopup();
+        });
+      } else {
+        displayToast(qsTr("Press back again to close project and app"));
+      }
       closingTimer.start();
     } else {
       close.accepted = true;

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -3589,11 +3589,13 @@ ApplicationWindow {
         settings.setValue("/QField/showDashboardGuide", false);
         return;
       }
-      const deltaFileWrapper = cloudProjectsModel.layerObserver.deltaFileWrapper;
-      if (cloudConnection.isReachable && settings.valueBool("/QField/showCloudButtonGuide", true) && deltaFileWrapper && deltaFileWrapper.count > 0) {
-        cloudButtonTour.index = 0;
-        cloudButtonTour.runTour();
-        settings.setValue("/QField/showCloudButtonGuide", false);
+      if (cloudConnection.isReachable && settings.valueBool("/QField/showCloudButtonGuide", true)) {
+        const deltaFileWrapper = cloudProjectsModel.layerObserver.deltaFileWrapper;
+        if (deltaFileWrapper && deltaFileWrapper.count > 0) {
+          cloudButtonTour.index = 0;
+          cloudButtonTour.runTour();
+          settings.setValue("/QField/showCloudButtonGuide", false);
+        }
       }
     }
 

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -4984,9 +4984,7 @@ ApplicationWindow {
         } else {
           projectInfo.restoreCloudUserInformation();
         }
-        if (!qfieldCloudPopup.visible) {
-          cloudMenuTour.startOnProjectWithLocalChanges();
-        }
+        cloudMenuTour.startOnProjectWithLocalChanges();
       } else {
         projectInfo.hasInsertRights = true;
         projectInfo.hasEditRights = true;
@@ -5891,7 +5889,9 @@ ApplicationWindow {
       target: dashBoard
 
       function onOpened() {
-        if (!mainWindow.hasLocalCloudChanges || dashboardTour.visible || !settings.valueBool("/QField/showCloudButtonGuide", true)) {
+        // The dashboard tour walks through the cloud button on its own, let it have this opening
+        const isDashboardTourDue = dashboardTour.visible || settings.valueBool("/QField/showDashboardGuide", true);
+        if (!mainWindow.hasLocalCloudChanges || isDashboardTourDue || !settings.valueBool("/QField/showCloudButtonGuide", true)) {
           return;
         }
         cloudButtonTour.index = 0;
@@ -5935,6 +5935,18 @@ ApplicationWindow {
       settings.setValue("/QField/showDashBoardGuide", false);
       settings.setValue("/QField/showCloudButtonGuide", false);
       settings.setValue("/QField/showCloudMenuGuide", false);
+    }
+
+    // Whoever made it to the cloud panel needs no pointer towards it anymore
+    Connections {
+      target: qfieldCloudPopup
+
+      function onAboutToShow() {
+        cloudButtonTour.blockGuide();
+        cloudMenuTour.blockGuide();
+        settings.setValue("/QField/showCloudButtonGuide", false);
+        settings.setValue("/QField/showCloudMenuGuide", false);
+      }
     }
   }
 

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -3589,9 +3589,8 @@ ApplicationWindow {
         settings.setValue("/QField/showDashboardGuide", false);
         return;
       }
-      // The dashboard tour walks through the cloud button on its own, leave that opening to it
       const deltaFileWrapper = cloudProjectsModel.layerObserver.deltaFileWrapper;
-      if (settings.valueBool("/QField/showCloudButtonGuide", true) && deltaFileWrapper && deltaFileWrapper.count > 0) {
+      if (cloudConnection.isReachable && settings.valueBool("/QField/showCloudButtonGuide", true) && deltaFileWrapper && deltaFileWrapper.count > 0) {
         cloudButtonTour.index = 0;
         cloudButtonTour.runTour();
         settings.setValue("/QField/showCloudButtonGuide", false);
@@ -4998,7 +4997,7 @@ ApplicationWindow {
         } else {
           projectInfo.restoreCloudUserInformation();
         }
-        if (settings.valueBool("/QField/showCloudMenuGuide", true) && cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0) {
+        if (cloudConnection.isReachable && settings.valueBool("/QField/showCloudMenuGuide", true) && cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0) {
           cloudMenuTour.runTour();
           settings.setValue("/QField/showCloudMenuGuide", false);
         }
@@ -5470,7 +5469,6 @@ ApplicationWindow {
 
     Component.onCompleted: focusstack.addFocusTaker(this)
 
-    // Whoever made it to the cloud panel needs no pointer towards it anymore
     onAboutToShow: {
       cloudButtonTour.blockGuide();
       cloudMenuTour.blockGuide();

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -4999,9 +4999,9 @@ ApplicationWindow {
         } else {
           projectInfo.restoreCloudUserInformation();
         }
-        if (cloudConnection.isReachable && settings.valueBool("/QField/showCloudMenuGuide", true) && cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0) {
+        if (cloudConnection.isReachable && settings.valueBool("/QField/showCloudButtonGuide", true) && cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0) {
           cloudMenuTour.runTour();
-          settings.setValue("/QField/showCloudMenuGuide", false);
+          settings.setValue("/QField/showCloudButtonGuide", false);
         }
       } else {
         projectInfo.hasInsertRights = true;
@@ -5475,7 +5475,6 @@ ApplicationWindow {
       cloudButtonTour.blockGuide();
       cloudMenuTour.blockGuide();
       settings.setValue("/QField/showCloudButtonGuide", false);
-      settings.setValue("/QField/showCloudMenuGuide", false);
     }
   }
 
@@ -5924,7 +5923,6 @@ ApplicationWindow {
       settings.setValue("/QField/showMapCanvasGuide", false);
       settings.setValue("/QField/showDashBoardGuide", false);
       settings.setValue("/QField/showCloudButtonGuide", false);
-      settings.setValue("/QField/showCloudMenuGuide", false);
     }
   }
 

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -59,8 +59,6 @@ ApplicationWindow {
   property double sceneLeftMargin: SafeArea.margins.left
   property double sceneRightMargin: SafeArea.margins.right
 
-  readonly property bool hasLocalCloudChanges: cloudProjectsModel.layerObserver.deltaFileWrapper ? cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0 : false
-
   onSceneLoadedChanged: {
     // This requires the scene to be fully loaded not to crash due to possibility of
     // a thread blocking permission request being thrown
@@ -3584,6 +3582,22 @@ ApplicationWindow {
 
     Component.onCompleted: focusstack.addFocusTaker(this)
 
+    onOpened: {
+      if (settings.valueBool("/QField/showDashboardGuide", true)) {
+        dashboardTour.index = 0;
+        dashboardTour.runTour();
+        settings.setValue("/QField/showDashboardGuide", false);
+        return;
+      }
+      // The dashboard tour walks through the cloud button on its own, leave that opening to it
+      const deltaFileWrapper = cloudProjectsModel.layerObserver.deltaFileWrapper;
+      if (settings.valueBool("/QField/showCloudButtonGuide", true) && deltaFileWrapper && deltaFileWrapper.count > 0) {
+        cloudButtonTour.index = 0;
+        cloudButtonTour.runTour();
+        settings.setValue("/QField/showCloudButtonGuide", false);
+      }
+    }
+
     onReturnHome: {
       if (currentRubberband && currentRubberband.model.vertexCount > 1) {
         digitizingToolbar.cancelDialog.open();
@@ -4984,7 +4998,10 @@ ApplicationWindow {
         } else {
           projectInfo.restoreCloudUserInformation();
         }
-        cloudMenuTour.startOnProjectWithLocalChanges();
+        if (settings.valueBool("/QField/showCloudMenuGuide", true) && cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0) {
+          cloudMenuTour.runTour();
+          settings.setValue("/QField/showCloudMenuGuide", false);
+        }
       } else {
         projectInfo.hasInsertRights = true;
         projectInfo.hasEditRights = true;
@@ -5452,6 +5469,14 @@ ApplicationWindow {
     cloudServiceStatus: qfieldCloudStatus
 
     Component.onCompleted: focusstack.addFocusTaker(this)
+
+    // Whoever made it to the cloud panel needs no pointer towards it anymore
+    onAboutToShow: {
+      cloudButtonTour.blockGuide();
+      cloudMenuTour.blockGuide();
+      settings.setValue("/QField/showCloudButtonGuide", false);
+      settings.setValue("/QField/showCloudMenuGuide", false);
+    }
   }
 
   QfCloudPackageLayersFeedback {
@@ -5610,8 +5635,9 @@ ApplicationWindow {
     if (!closeAlreadyRequested) {
       close.accepted = false;
       closeAlreadyRequested = true;
-      if (hasLocalCloudChanges) {
-        displayToast(qsTr("Press back again to close project and app. Local changes have not yet been uploaded to the cloud."), 'warning', qsTr("Upload local changes"), () => {
+      const deltaFileWrapper = cloudProjectsModel.layerObserver.deltaFileWrapper;
+      if (cloudConnection.isReachable && deltaFileWrapper && deltaFileWrapper.count > 0) {
+        displayToast(qsTr("Pending changes are present. Upload these now or press back again to keep them pending and close the cloud project and app."), 'attention', qsTr("Upload local changes"), () => {
           closeAlreadyRequested = false;
           closingTimer.stop();
           openCloudPopup();
@@ -5854,19 +5880,6 @@ ApplicationWindow {
         "target": () => [iface.findItemByObjectName('projectFolderButton')]
       }
     ]
-
-    Connections {
-      id: dashBoardConnections
-      target: dashBoard
-      enabled: settings ? settings.valueBool("/QField/showDashboardGuide", true) : false
-
-      function onOpened() {
-        dashBoardConnections.enabled = false;
-        dashboardTour.index = 0;
-        dashboardTour.runTour();
-        settings.setValue("/QField/showDashboardGuide", false);
-      }
-    }
   }
 
   QfGuide {
@@ -5880,25 +5893,10 @@ ApplicationWindow {
       {
         "type": "information",
         "title": qsTr("Local changes"),
-        "description": qsTr("This project has local changes which have not been uploaded yet. Tap the blue cloud button to open the cloud project panel and send them to QFieldCloud."),
+        "description": qsTr("This project has pending changes which have not been uploaded yet. Tap the blue cloud button to open the cloud project panel and send them to QFieldCloud."),
         "target": () => [iface.findItemByObjectName('cloudButton')]
       }
     ]
-
-    Connections {
-      target: dashBoard
-
-      function onOpened() {
-        // The dashboard tour walks through the cloud button on its own, let it have this opening
-        const isDashboardTourDue = dashboardTour.visible || settings.valueBool("/QField/showDashboardGuide", true);
-        if (!mainWindow.hasLocalCloudChanges || isDashboardTourDue || !settings.valueBool("/QField/showCloudButtonGuide", true)) {
-          return;
-        }
-        cloudButtonTour.index = 0;
-        cloudButtonTour.runTour();
-        settings.setValue("/QField/showCloudButtonGuide", false);
-      }
-    }
   }
 
   QfGuide {
@@ -5910,18 +5908,10 @@ ApplicationWindow {
       {
         "type": "information",
         "title": qsTr("Local changes"),
-        "description": qsTr("This project has local changes which have not been uploaded yet. Open the dashboard using this button, then tap the blue cloud icon to send them to QFieldCloud."),
+        "description": qsTr("This cloud project has pending changes which have not been uploaded yet. Open the dashboard using this button, then tap the blue cloud icon to send them to QFieldCloud."),
         "target": () => [menuButton]
       }
     ]
-
-    function startOnProjectWithLocalChanges() {
-      if (!mainWindow.hasLocalCloudChanges || !settings.valueBool("/QField/showCloudMenuGuide", true)) {
-        return;
-      }
-      runTour();
-      settings.setValue("/QField/showCloudMenuGuide", false);
-    }
   }
 
   Item {
@@ -5935,18 +5925,6 @@ ApplicationWindow {
       settings.setValue("/QField/showDashBoardGuide", false);
       settings.setValue("/QField/showCloudButtonGuide", false);
       settings.setValue("/QField/showCloudMenuGuide", false);
-    }
-
-    // Whoever made it to the cloud panel needs no pointer towards it anymore
-    Connections {
-      target: qfieldCloudPopup
-
-      function onAboutToShow() {
-        cloudButtonTour.blockGuide();
-        cloudMenuTour.blockGuide();
-        settings.setValue("/QField/showCloudButtonGuide", false);
-        settings.setValue("/QField/showCloudMenuGuide", false);
-      }
     }
   }
 

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -4984,6 +4984,9 @@ ApplicationWindow {
         } else {
           projectInfo.restoreCloudUserInformation();
         }
+        if (!qfieldCloudPopup.visible) {
+          cloudMenuTour.startOnProjectWithLocalChanges();
+        }
       } else {
         projectInfo.hasInsertRights = true;
         projectInfo.hasEditRights = true;
@@ -5868,13 +5871,70 @@ ApplicationWindow {
     }
   }
 
+  QfGuide {
+    id: cloudButtonTour
+    baseRoot: mainWindow
+    objectName: 'cloudButtonTour'
+    z: dashBoard.z + 1
+    index: -1
+
+    steps: [
+      {
+        "type": "information",
+        "title": qsTr("Local changes"),
+        "description": qsTr("This project has local changes which have not been uploaded yet. Tap the blue cloud button to open the cloud project panel and send them to QFieldCloud."),
+        "target": () => [iface.findItemByObjectName('cloudButton')]
+      }
+    ]
+
+    Connections {
+      target: dashBoard
+
+      function onOpened() {
+        if (!mainWindow.hasLocalCloudChanges || dashboardTour.visible || !settings.valueBool("/QField/showCloudButtonGuide", true)) {
+          return;
+        }
+        cloudButtonTour.index = 0;
+        cloudButtonTour.runTour();
+        settings.setValue("/QField/showCloudButtonGuide", false);
+      }
+    }
+  }
+
+  QfGuide {
+    id: cloudMenuTour
+    baseRoot: mainWindow
+    objectName: 'cloudMenuTour'
+
+    steps: [
+      {
+        "type": "information",
+        "title": qsTr("Local changes"),
+        "description": qsTr("This project has local changes which have not been uploaded yet. Open the dashboard using this button, then tap the blue cloud icon to send them to QFieldCloud."),
+        "target": () => [menuButton]
+      }
+    ]
+
+    function startOnProjectWithLocalChanges() {
+      if (!mainWindow.hasLocalCloudChanges || !settings.valueBool("/QField/showCloudMenuGuide", true)) {
+        return;
+      }
+      runTour();
+      settings.setValue("/QField/showCloudMenuGuide", false);
+    }
+  }
+
   Item {
     objectName: 'toursController'
 
     function blockGuides() {
       mapCanvasTour.blockGuide();
+      cloudButtonTour.blockGuide();
+      cloudMenuTour.blockGuide();
       settings.setValue("/QField/showMapCanvasGuide", false);
       settings.setValue("/QField/showDashBoardGuide", false);
+      settings.setValue("/QField/showCloudButtonGuide", false);
+      settings.setValue("/QField/showCloudMenuGuide", false);
     }
   }
 


### PR DESCRIPTION
### 🚀 Description

This PR Ease upload changes visibility and cloud project control panel discoverability.

| Guide | Back key | Guide | Welcome screen |
| :-: | :-: | :-: | :-: |
| <img src="https://github.com/user-attachments/assets/31955641-6f16-4e80-af49-b05a5f550373" width="250"> | <img src="https://github.com/user-attachments/assets/b74a2640-b8bc-4a92-af92-612804680dc9" width="250"> | <img src="https://github.com/user-attachments/assets/05c885f5-f940-4d18-8cac-c6d1c262649e" width="250"> | <img src="https://github.com/user-attachments/assets/d1e75663-9c43-4689-bab0-261ab135b3ee" width="250"> |
### ✨ Key changes
* The back key toast now mentions the pending local changes and carries an *Upload local changes* button leading to the control panel.
* Quitting from the welcome screen power button with pending changes asks whether to upload them first.
* A guide highlights the cloud button the first time the dashboard is opened on a project holding local changes; another highlights the main menu button, and the blue cloud icon, when such a project is loaded.
* Both guides fire once, and are dropped for good as soon as the control panel is opened by any route.
