### PR TITLE
Add attribute form model base test coverage

### DIFF
--- a/test/test_attributeformmodel.cpp
+++ b/test/test_attributeformmodel.cpp
@@ -25,6 +25,7 @@
 #include <qgsattributeeditorfield.h>
 #include <qgseditformconfig.h>
 #include <qgsfieldconstraints.h>
+#include <qgsoptionalexpression.h>
 
 static QModelIndex indexForField( QfAttributeFormModel *model, int fieldIndex )
 {
@@ -236,6 +237,43 @@ TEST_CASE( "AttributeFormModel" )
     model->setData( strItems.at( 0 ), QStringLiteral( "synced" ), QfAttributeFormModel::AttributeValue );
     REQUIRE( model->data( strItems.at( 0 ), QfAttributeFormModel::AttributeValue ) == QStringLiteral( "synced" ) );
     REQUIRE( model->data( strItems.at( 1 ), QfAttributeFormModel::AttributeValue ) == QStringLiteral( "synced" ) );
+  }
+
+  SECTION( "Visibility" )
+  {
+    QgsEditFormConfig config = layer->editFormConfig();
+    config.clearTabs();
+    config.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
+
+    QgsAttributeEditorContainer *tab1 = new QgsAttributeEditorContainer( QStringLiteral( "Driver" ), nullptr );
+    tab1->addChildElement( new QgsAttributeEditorField( QStringLiteral( "str" ), 1, tab1 ) );
+    config.addTab( tab1 );
+
+    QgsAttributeEditorContainer *tab2 = new QgsAttributeEditorContainer( QStringLiteral( "Conditional" ), nullptr );
+    tab2->addChildElement( new QgsAttributeEditorField( QStringLiteral( "str2" ), 2, tab2 ) );
+    tab2->setVisibilityExpression( QgsOptionalExpression( QgsExpression( QStringLiteral( "\"str\" = 'show'" ) ) ) );
+    config.addTab( tab2 );
+
+    layer->setEditFormConfig( config );
+
+    std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
+    std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
+    model->setFeatureModel( fModel.get() );
+    fModel->setCurrentLayer( layer.get() );
+
+    fModel->resetFeature();
+    fModel->resetAttributes();
+
+    const QModelIndex driverField = indexForField( model.get(), 1 );
+    REQUIRE( driverField.isValid() );
+
+    // The conditional tab is filtered out of the proxy when its expression fails,
+    // so it drops from the root row count rather than staying with a false flag.
+    model->setData( driverField, QStringLiteral( "hide" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( model->rowCount() == 1 );
+
+    model->setData( driverField, QStringLiteral( "show" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( model->rowCount() == 2 );
   }
 
   SECTION( "QAbstractItemModelTester" )

--- a/test/test_attributeformmodel.cpp
+++ b/test/test_attributeformmodel.cpp
@@ -21,6 +21,9 @@
 #include "qffeaturemodel.h"
 
 #include <QAbstractItemModelTester>
+#include <qgsattributeeditorcontainer.h>
+#include <qgsattributeeditorfield.h>
+#include <qgseditformconfig.h>
 #include <qgsfieldconstraints.h>
 
 static QModelIndex indexForField( QfAttributeFormModel *model, int fieldIndex )
@@ -174,6 +177,65 @@ TEST_CASE( "AttributeFormModel" )
     const QModelIndex strField = indexForField( model.get(), 1 );
     REQUIRE( strField.isValid() );
     REQUIRE( !model->data( strField, QfAttributeFormModel::ConstraintDescription ).toString().isEmpty() );
+  }
+
+  SECTION( "TabLayout" )
+  {
+    QgsEditFormConfig config = layer->editFormConfig();
+    config.clearTabs();
+    config.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
+
+    QgsAttributeEditorContainer *tab1 = new QgsAttributeEditorContainer( QStringLiteral( "First" ), nullptr );
+    tab1->addChildElement( new QgsAttributeEditorField( QStringLiteral( "str" ), 1, tab1 ) );
+    config.addTab( tab1 );
+
+    QgsAttributeEditorContainer *tab2 = new QgsAttributeEditorContainer( QStringLiteral( "Second" ), nullptr );
+    tab2->addChildElement( new QgsAttributeEditorField( QStringLiteral( "str2" ), 2, tab2 ) );
+    config.addTab( tab2 );
+
+    layer->setEditFormConfig( config );
+
+    std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
+    std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
+    model->setFeatureModel( fModel.get() );
+    fModel->setCurrentLayer( layer.get() );
+
+    REQUIRE( model->hasTabs() );
+    REQUIRE( model->rowCount() == 2 );
+    REQUIRE( model->data( model->index( 0, 0 ), QfAttributeFormModel::ElementType ) == QStringLiteral( "container" ) );
+    REQUIRE( model->data( model->index( 1, 0 ), QfAttributeFormModel::ElementType ) == QStringLiteral( "container" ) );
+  }
+
+  SECTION( "FieldSynchronization" )
+  {
+    QgsEditFormConfig config = layer->editFormConfig();
+    config.clearTabs();
+    config.setLayout( Qgis::AttributeFormLayout::DragAndDrop );
+
+    QgsAttributeEditorContainer *tab1 = new QgsAttributeEditorContainer( QStringLiteral( "Tab1" ), nullptr );
+    tab1->addChildElement( new QgsAttributeEditorField( QStringLiteral( "str" ), 1, tab1 ) );
+    config.addTab( tab1 );
+
+    QgsAttributeEditorContainer *tab2 = new QgsAttributeEditorContainer( QStringLiteral( "Tab2" ), nullptr );
+    tab2->addChildElement( new QgsAttributeEditorField( QStringLiteral( "str" ), 1, tab2 ) );
+    config.addTab( tab2 );
+
+    layer->setEditFormConfig( config );
+
+    std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
+    std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
+    model->setFeatureModel( fModel.get() );
+    fModel->setCurrentLayer( layer.get() );
+
+    REQUIRE( model->hasTabs() );
+    fModel->setFeature( layer->getFeature( 1 ) );
+
+    const QModelIndexList strItems = model->match( model->index( 0, 0 ), QfAttributeFormModel::FieldIndex, 1, -1, Qt::MatchExactly | Qt::MatchRecursive );
+    REQUIRE( strItems.size() == 2 );
+
+    model->setData( strItems.at( 0 ), QStringLiteral( "synced" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( model->data( strItems.at( 0 ), QfAttributeFormModel::AttributeValue ) == QStringLiteral( "synced" ) );
+    REQUIRE( model->data( strItems.at( 1 ), QfAttributeFormModel::AttributeValue ) == QStringLiteral( "synced" ) );
   }
 
   SECTION( "QAbstractItemModelTester" )

--- a/test/test_attributeformmodel.cpp
+++ b/test/test_attributeformmodel.cpp
@@ -30,7 +30,7 @@
 static QModelIndex indexForField( QfAttributeFormModel *model, int fieldIndex )
 {
   const QModelIndexList matches = model->match( model->index( 0, 0 ), QfAttributeFormModel::FieldIndex, fieldIndex, 1, Qt::MatchExactly | Qt::MatchRecursive );
-  return matches.value( 0 );
+  return matches.isEmpty() ? QModelIndex() : matches.first();
 }
 
 TEST_CASE( "AttributeFormModel" )
@@ -113,56 +113,60 @@ TEST_CASE( "AttributeFormModel" )
 
   SECTION( "HardConstraint" )
   {
-    layer->setFieldConstraint( 1, QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintStrengthHard );
+    std::unique_ptr<QgsVectorLayer> clean = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=EPSG:3857&field=fid:integer&field=val:string" ), QStringLiteral( "Clean Layer" ), QStringLiteral( "memory" ) );
+    REQUIRE( clean->isValid() );
+    clean->setFieldConstraint( 1, QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintStrengthHard );
 
     std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
     std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
     model->setFeatureModel( fModel.get() );
-    fModel->setCurrentLayer( layer.get() );
+    fModel->setCurrentLayer( clean.get() );
 
     REQUIRE( model->hasConstraints() );
 
-    const QModelIndex strField = indexForField( model.get(), 1 );
-    REQUIRE( strField.isValid() );
+    const QModelIndex valField = indexForField( model.get(), 1 );
+    REQUIRE( valField.isValid() );
 
     fModel->resetFeature();
     fModel->resetAttributes();
 
-    model->setData( strField, QStringLiteral( "filled" ), QfAttributeFormModel::AttributeValue );
-    REQUIRE( model->data( strField, QfAttributeFormModel::ConstraintHardValid ).toBool() == true );
+    model->setData( valField, QStringLiteral( "filled" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( model->data( valField, QfAttributeFormModel::ConstraintHardValid ).toBool() == true );
     REQUIRE( model->constraintsHardValid() == true );
 
-    model->setData( strField, QVariant(), QfAttributeFormModel::AttributeValue );
-    REQUIRE( model->data( strField, QfAttributeFormModel::ConstraintHardValid ).toBool() == false );
+    model->setData( valField, QVariant(), QfAttributeFormModel::AttributeValue );
+    REQUIRE( model->data( valField, QfAttributeFormModel::ConstraintHardValid ).toBool() == false );
     REQUIRE( model->constraintsHardValid() == false );
 
-    model->setData( strField, QStringLiteral( "refilled" ), QfAttributeFormModel::AttributeValue );
-    REQUIRE( model->data( strField, QfAttributeFormModel::ConstraintHardValid ).toBool() == true );
+    model->setData( valField, QStringLiteral( "refilled" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( model->data( valField, QfAttributeFormModel::ConstraintHardValid ).toBool() == true );
     REQUIRE( model->constraintsHardValid() == true );
   }
 
   SECTION( "SoftConstraint" )
   {
-    layer->setConstraintExpression( 1, QStringLiteral( "length(\"str\") > 3" ) );
-    layer->setFieldConstraint( 1, QgsFieldConstraints::ConstraintExpression, QgsFieldConstraints::ConstraintStrengthSoft );
+    std::unique_ptr<QgsVectorLayer> clean = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=EPSG:3857&field=fid:integer&field=val:string" ), QStringLiteral( "Clean Layer" ), QStringLiteral( "memory" ) );
+    REQUIRE( clean->isValid() );
+    clean->setConstraintExpression( 1, QStringLiteral( "length(\"val\") > 3" ) );
+    clean->setFieldConstraint( 1, QgsFieldConstraints::ConstraintExpression, QgsFieldConstraints::ConstraintStrengthSoft );
 
     std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
     std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
     model->setFeatureModel( fModel.get() );
-    fModel->setCurrentLayer( layer.get() );
+    fModel->setCurrentLayer( clean.get() );
 
-    const QModelIndex strField = indexForField( model.get(), 1 );
-    REQUIRE( strField.isValid() );
+    const QModelIndex valField = indexForField( model.get(), 1 );
+    REQUIRE( valField.isValid() );
 
     fModel->resetFeature();
     fModel->resetAttributes();
 
-    model->setData( strField, QStringLiteral( "ab" ), QfAttributeFormModel::AttributeValue );
-    REQUIRE( model->data( strField, QfAttributeFormModel::ConstraintSoftValid ).toBool() == false );
+    model->setData( valField, QStringLiteral( "ab" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( model->data( valField, QfAttributeFormModel::ConstraintSoftValid ).toBool() == false );
     REQUIRE( model->constraintsSoftValid() == false );
 
-    model->setData( strField, QStringLiteral( "abcd" ), QfAttributeFormModel::AttributeValue );
-    REQUIRE( model->data( strField, QfAttributeFormModel::ConstraintSoftValid ).toBool() == true );
+    model->setData( valField, QStringLiteral( "abcd" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( model->data( valField, QfAttributeFormModel::ConstraintSoftValid ).toBool() == true );
     REQUIRE( model->constraintsSoftValid() == true );
   }
 
@@ -267,8 +271,6 @@ TEST_CASE( "AttributeFormModel" )
     const QModelIndex driverField = indexForField( model.get(), 1 );
     REQUIRE( driverField.isValid() );
 
-    // The conditional tab is filtered out of the proxy when its expression fails,
-    // so it drops from the root row count rather than staying with a false flag.
     model->setData( driverField, QStringLiteral( "hide" ), QfAttributeFormModel::AttributeValue );
     REQUIRE( model->rowCount() == 1 );
 

--- a/test/test_attributeformmodel.cpp
+++ b/test/test_attributeformmodel.cpp
@@ -117,30 +117,30 @@ TEST_CASE( "AttributeFormModel" )
     REQUIRE( clean->isValid() );
     clean->setFieldConstraint( 1, QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintStrengthHard );
 
-    std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
-    std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
-    model->setFeatureModel( fModel.get() );
-    fModel->setCurrentLayer( clean.get() );
+    std::unique_ptr<QfAttributeFormModel> formModel = std::make_unique<QfAttributeFormModel>();
+    std::unique_ptr<QfFeatureModel> featureModel = std::make_unique<QfFeatureModel>();
+    formModel->setFeatureModel( featureModel.get() );
+    featureModel->setCurrentLayer( clean.get() );
 
-    REQUIRE( model->hasConstraints() );
+    REQUIRE( formModel->hasConstraints() );
 
-    const QModelIndex valField = indexForField( model.get(), 1 );
+    const QModelIndex valField = indexForField( formModel.get(), 1 );
     REQUIRE( valField.isValid() );
 
-    fModel->resetFeature();
-    fModel->resetAttributes();
+    featureModel->resetFeature();
+    featureModel->resetAttributes();
 
-    model->setData( valField, QStringLiteral( "filled" ), QfAttributeFormModel::AttributeValue );
-    REQUIRE( model->data( valField, QfAttributeFormModel::ConstraintHardValid ).toBool() == true );
-    REQUIRE( model->constraintsHardValid() == true );
+    formModel->setData( valField, QStringLiteral( "filled" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( formModel->data( valField, QfAttributeFormModel::ConstraintHardValid ).toBool() == true );
+    REQUIRE( formModel->constraintsHardValid() == true );
 
-    model->setData( valField, QVariant(), QfAttributeFormModel::AttributeValue );
-    REQUIRE( model->data( valField, QfAttributeFormModel::ConstraintHardValid ).toBool() == false );
-    REQUIRE( model->constraintsHardValid() == false );
+    formModel->setData( valField, QVariant(), QfAttributeFormModel::AttributeValue );
+    REQUIRE( formModel->data( valField, QfAttributeFormModel::ConstraintHardValid ).toBool() == false );
+    REQUIRE( formModel->constraintsHardValid() == false );
 
-    model->setData( valField, QStringLiteral( "refilled" ), QfAttributeFormModel::AttributeValue );
-    REQUIRE( model->data( valField, QfAttributeFormModel::ConstraintHardValid ).toBool() == true );
-    REQUIRE( model->constraintsHardValid() == true );
+    formModel->setData( valField, QStringLiteral( "refilled" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( formModel->data( valField, QfAttributeFormModel::ConstraintHardValid ).toBool() == true );
+    REQUIRE( formModel->constraintsHardValid() == true );
   }
 
   SECTION( "SoftConstraint" )
@@ -150,38 +150,38 @@ TEST_CASE( "AttributeFormModel" )
     clean->setConstraintExpression( 1, QStringLiteral( "length(\"val\") > 3" ) );
     clean->setFieldConstraint( 1, QgsFieldConstraints::ConstraintExpression, QgsFieldConstraints::ConstraintStrengthSoft );
 
-    std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
-    std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
-    model->setFeatureModel( fModel.get() );
-    fModel->setCurrentLayer( clean.get() );
+    std::unique_ptr<QfAttributeFormModel> formModel = std::make_unique<QfAttributeFormModel>();
+    std::unique_ptr<QfFeatureModel> featureModel = std::make_unique<QfFeatureModel>();
+    formModel->setFeatureModel( featureModel.get() );
+    featureModel->setCurrentLayer( clean.get() );
 
-    const QModelIndex valField = indexForField( model.get(), 1 );
+    const QModelIndex valField = indexForField( formModel.get(), 1 );
     REQUIRE( valField.isValid() );
 
-    fModel->resetFeature();
-    fModel->resetAttributes();
+    featureModel->resetFeature();
+    featureModel->resetAttributes();
 
-    model->setData( valField, QStringLiteral( "ab" ), QfAttributeFormModel::AttributeValue );
-    REQUIRE( model->data( valField, QfAttributeFormModel::ConstraintSoftValid ).toBool() == false );
-    REQUIRE( model->constraintsSoftValid() == false );
+    formModel->setData( valField, QStringLiteral( "ab" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( formModel->data( valField, QfAttributeFormModel::ConstraintSoftValid ).toBool() == false );
+    REQUIRE( formModel->constraintsSoftValid() == false );
 
-    model->setData( valField, QStringLiteral( "abcd" ), QfAttributeFormModel::AttributeValue );
-    REQUIRE( model->data( valField, QfAttributeFormModel::ConstraintSoftValid ).toBool() == true );
-    REQUIRE( model->constraintsSoftValid() == true );
+    formModel->setData( valField, QStringLiteral( "abcd" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( formModel->data( valField, QfAttributeFormModel::ConstraintSoftValid ).toBool() == true );
+    REQUIRE( formModel->constraintsSoftValid() == true );
   }
 
   SECTION( "ConstraintDescription" )
   {
     layer->setFieldConstraint( 1, QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintStrengthHard );
 
-    std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
-    std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
-    model->setFeatureModel( fModel.get() );
-    fModel->setCurrentLayer( layer.get() );
+    std::unique_ptr<QfAttributeFormModel> formModel = std::make_unique<QfAttributeFormModel>();
+    std::unique_ptr<QfFeatureModel> featureModel = std::make_unique<QfFeatureModel>();
+    formModel->setFeatureModel( featureModel.get() );
+    featureModel->setCurrentLayer( layer.get() );
 
-    const QModelIndex strField = indexForField( model.get(), 1 );
+    const QModelIndex strField = indexForField( formModel.get(), 1 );
     REQUIRE( strField.isValid() );
-    REQUIRE( !model->data( strField, QfAttributeFormModel::ConstraintDescription ).toString().isEmpty() );
+    REQUIRE( formModel->data( strField, QfAttributeFormModel::ConstraintDescription ).toString() == QStringLiteral( "Not NULL" ) );
   }
 
   SECTION( "TabLayout" )
@@ -200,15 +200,15 @@ TEST_CASE( "AttributeFormModel" )
 
     layer->setEditFormConfig( config );
 
-    std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
-    std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
-    model->setFeatureModel( fModel.get() );
-    fModel->setCurrentLayer( layer.get() );
+    std::unique_ptr<QfAttributeFormModel> formModel = std::make_unique<QfAttributeFormModel>();
+    std::unique_ptr<QfFeatureModel> featureModel = std::make_unique<QfFeatureModel>();
+    formModel->setFeatureModel( featureModel.get() );
+    featureModel->setCurrentLayer( layer.get() );
 
-    REQUIRE( model->hasTabs() );
-    REQUIRE( model->rowCount() == 2 );
-    REQUIRE( model->data( model->index( 0, 0 ), QfAttributeFormModel::ElementType ) == QStringLiteral( "container" ) );
-    REQUIRE( model->data( model->index( 1, 0 ), QfAttributeFormModel::ElementType ) == QStringLiteral( "container" ) );
+    REQUIRE( formModel->hasTabs() );
+    REQUIRE( formModel->rowCount() == 2 );
+    REQUIRE( formModel->data( formModel->index( 0, 0 ), QfAttributeFormModel::ElementType ) == QStringLiteral( "container" ) );
+    REQUIRE( formModel->data( formModel->index( 1, 0 ), QfAttributeFormModel::ElementType ) == QStringLiteral( "container" ) );
   }
 
   SECTION( "FieldSynchronization" )
@@ -227,20 +227,20 @@ TEST_CASE( "AttributeFormModel" )
 
     layer->setEditFormConfig( config );
 
-    std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
-    std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
-    model->setFeatureModel( fModel.get() );
-    fModel->setCurrentLayer( layer.get() );
+    std::unique_ptr<QfAttributeFormModel> formModel = std::make_unique<QfAttributeFormModel>();
+    std::unique_ptr<QfFeatureModel> featureModel = std::make_unique<QfFeatureModel>();
+    formModel->setFeatureModel( featureModel.get() );
+    featureModel->setCurrentLayer( layer.get() );
 
-    REQUIRE( model->hasTabs() );
-    fModel->setFeature( layer->getFeature( 1 ) );
+    REQUIRE( formModel->hasTabs() );
+    featureModel->setFeature( layer->getFeature( 1 ) );
 
-    const QModelIndexList strItems = model->match( model->index( 0, 0 ), QfAttributeFormModel::FieldIndex, 1, -1, Qt::MatchExactly | Qt::MatchRecursive );
+    const QModelIndexList strItems = formModel->match( formModel->index( 0, 0 ), QfAttributeFormModel::FieldIndex, 1, -1, Qt::MatchExactly | Qt::MatchRecursive );
     REQUIRE( strItems.size() == 2 );
 
-    model->setData( strItems.at( 0 ), QStringLiteral( "synced" ), QfAttributeFormModel::AttributeValue );
-    REQUIRE( model->data( strItems.at( 0 ), QfAttributeFormModel::AttributeValue ) == QStringLiteral( "synced" ) );
-    REQUIRE( model->data( strItems.at( 1 ), QfAttributeFormModel::AttributeValue ) == QStringLiteral( "synced" ) );
+    formModel->setData( strItems.at( 0 ), QStringLiteral( "synced" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( formModel->data( strItems.at( 0 ), QfAttributeFormModel::AttributeValue ) == QStringLiteral( "synced" ) );
+    REQUIRE( formModel->data( strItems.at( 1 ), QfAttributeFormModel::AttributeValue ) == QStringLiteral( "synced" ) );
   }
 
   SECTION( "Visibility" )
@@ -260,37 +260,37 @@ TEST_CASE( "AttributeFormModel" )
 
     layer->setEditFormConfig( config );
 
-    std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
-    std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
-    model->setFeatureModel( fModel.get() );
-    fModel->setCurrentLayer( layer.get() );
+    std::unique_ptr<QfAttributeFormModel> formModel = std::make_unique<QfAttributeFormModel>();
+    std::unique_ptr<QfFeatureModel> featureModel = std::make_unique<QfFeatureModel>();
+    formModel->setFeatureModel( featureModel.get() );
+    featureModel->setCurrentLayer( layer.get() );
 
-    fModel->resetFeature();
-    fModel->resetAttributes();
+    featureModel->resetFeature();
+    featureModel->resetAttributes();
 
-    const QModelIndex driverField = indexForField( model.get(), 1 );
+    const QModelIndex driverField = indexForField( formModel.get(), 1 );
     REQUIRE( driverField.isValid() );
 
-    model->setData( driverField, QStringLiteral( "hide" ), QfAttributeFormModel::AttributeValue );
-    REQUIRE( model->rowCount() == 1 );
+    formModel->setData( driverField, QStringLiteral( "hide" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( formModel->rowCount() == 1 );
 
-    model->setData( driverField, QStringLiteral( "show" ), QfAttributeFormModel::AttributeValue );
-    REQUIRE( model->rowCount() == 2 );
+    formModel->setData( driverField, QStringLiteral( "show" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( formModel->rowCount() == 2 );
   }
 
   SECTION( "DeleteFeature" )
   {
     QgsProject::instance()->addMapLayer( layer.get(), false, false );
 
-    std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
-    std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
-    model->setFeatureModel( fModel.get() );
-    fModel->setProject( QgsProject::instance() );
-    fModel->setCurrentLayer( layer.get() );
+    std::unique_ptr<QfAttributeFormModel> formModel = std::make_unique<QfAttributeFormModel>();
+    std::unique_ptr<QfFeatureModel> featureModel = std::make_unique<QfFeatureModel>();
+    formModel->setFeatureModel( featureModel.get() );
+    featureModel->setProject( QgsProject::instance() );
+    featureModel->setCurrentLayer( layer.get() );
 
     const long countBefore = layer->featureCount();
-    fModel->setFeature( layer->getFeature( 2 ) );
-    REQUIRE( model->deleteFeature() );
+    featureModel->setFeature( layer->getFeature( 2 ) );
+    REQUIRE( formModel->deleteFeature() );
     REQUIRE( layer->featureCount() == countBefore - 1 );
 
     QgsProject::instance()->takeMapLayer( layer.get() );

--- a/test/test_attributeformmodel.cpp
+++ b/test/test_attributeformmodel.cpp
@@ -22,6 +22,12 @@
 
 #include <QAbstractItemModelTester>
 
+static QModelIndex indexForField( QfAttributeFormModel *model, int fieldIndex )
+{
+  const QModelIndexList matches = model->match( model->index( 0, 0 ), QfAttributeFormModel::FieldIndex, fieldIndex, 1, Qt::MatchExactly | Qt::MatchRecursive );
+  return matches.value( 0 );
+}
+
 TEST_CASE( "AttributeFormModel" )
 {
   std::unique_ptr<QgsVectorLayer> layer = std::make_unique<QgsVectorLayer>( QStringLiteral( "Point?crs=EPSG:3857&field=fid:integer&field=str:string&field=str2:string" ), QStringLiteral( "Input Layer" ), QStringLiteral( "memory" ) );

--- a/test/test_attributeformmodel.cpp
+++ b/test/test_attributeformmodel.cpp
@@ -276,6 +276,24 @@ TEST_CASE( "AttributeFormModel" )
     REQUIRE( model->rowCount() == 2 );
   }
 
+  SECTION( "DeleteFeature" )
+  {
+    QgsProject::instance()->addMapLayer( layer.get(), false, false );
+
+    std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
+    std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
+    model->setFeatureModel( fModel.get() );
+    fModel->setProject( QgsProject::instance() );
+    fModel->setCurrentLayer( layer.get() );
+
+    const long countBefore = layer->featureCount();
+    fModel->setFeature( layer->getFeature( 2 ) );
+    REQUIRE( model->deleteFeature() );
+    REQUIRE( layer->featureCount() == countBefore - 1 );
+
+    QgsProject::instance()->takeMapLayer( layer.get() );
+  }
+
   SECTION( "QAbstractItemModelTester" )
   {
     std::unique_ptr<QfAttributeFormModel> modelTest = std::make_unique<QfAttributeFormModel>();

--- a/test/test_attributeformmodel.cpp
+++ b/test/test_attributeformmodel.cpp
@@ -21,6 +21,7 @@
 #include "qffeaturemodel.h"
 
 #include <QAbstractItemModelTester>
+#include <qgsfieldconstraints.h>
 
 static QModelIndex indexForField( QfAttributeFormModel *model, int fieldIndex )
 {
@@ -104,6 +105,75 @@ TEST_CASE( "AttributeFormModel" )
     REQUIRE( attributeFormModel->data( attributeFormModel->index( 1, 0 ), QfAttributeFormModel::AttributeEditable ).toBool() == true );
     attributeFormModel->setData( attributeFormModel->index( 1, 0 ), QString( "data" ), QfAttributeFormModel::AttributeValue );
     REQUIRE( attributeFormModel->data( attributeFormModel->index( 1, 0 ), QfAttributeFormModel::AttributeEditable ).toBool() == false );
+  }
+
+  SECTION( "HardConstraint" )
+  {
+    layer->setFieldConstraint( 1, QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintStrengthHard );
+
+    std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
+    std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
+    model->setFeatureModel( fModel.get() );
+    fModel->setCurrentLayer( layer.get() );
+
+    REQUIRE( model->hasConstraints() );
+
+    const QModelIndex strField = indexForField( model.get(), 1 );
+    REQUIRE( strField.isValid() );
+
+    fModel->resetFeature();
+    fModel->resetAttributes();
+
+    model->setData( strField, QStringLiteral( "filled" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( model->data( strField, QfAttributeFormModel::ConstraintHardValid ).toBool() == true );
+    REQUIRE( model->constraintsHardValid() == true );
+
+    model->setData( strField, QVariant(), QfAttributeFormModel::AttributeValue );
+    REQUIRE( model->data( strField, QfAttributeFormModel::ConstraintHardValid ).toBool() == false );
+    REQUIRE( model->constraintsHardValid() == false );
+
+    model->setData( strField, QStringLiteral( "refilled" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( model->data( strField, QfAttributeFormModel::ConstraintHardValid ).toBool() == true );
+    REQUIRE( model->constraintsHardValid() == true );
+  }
+
+  SECTION( "SoftConstraint" )
+  {
+    layer->setConstraintExpression( 1, QStringLiteral( "length(\"str\") > 3" ) );
+    layer->setFieldConstraint( 1, QgsFieldConstraints::ConstraintExpression, QgsFieldConstraints::ConstraintStrengthSoft );
+
+    std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
+    std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
+    model->setFeatureModel( fModel.get() );
+    fModel->setCurrentLayer( layer.get() );
+
+    const QModelIndex strField = indexForField( model.get(), 1 );
+    REQUIRE( strField.isValid() );
+
+    fModel->resetFeature();
+    fModel->resetAttributes();
+
+    model->setData( strField, QStringLiteral( "ab" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( model->data( strField, QfAttributeFormModel::ConstraintSoftValid ).toBool() == false );
+    REQUIRE( model->constraintsSoftValid() == false );
+
+    model->setData( strField, QStringLiteral( "abcd" ), QfAttributeFormModel::AttributeValue );
+    REQUIRE( model->data( strField, QfAttributeFormModel::ConstraintSoftValid ).toBool() == true );
+    REQUIRE( model->constraintsSoftValid() == true );
+  }
+
+  SECTION( "ConstraintDescription" )
+  {
+    layer->setFieldConstraint( 1, QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintStrengthHard );
+
+    std::unique_ptr<QfAttributeFormModel> model = std::make_unique<QfAttributeFormModel>();
+    std::unique_ptr<QfFeatureModel> fModel = std::make_unique<QfFeatureModel>();
+    model->setFeatureModel( fModel.get() );
+    fModel->setCurrentLayer( layer.get() );
+
+    const QModelIndex strField = indexForField( model.get(), 1 );
+    REQUIRE( strField.isValid() );
+    REQUIRE( !model->data( strField, QfAttributeFormModel::ConstraintDescription ).toString().isEmpty() );
   }
 
   SECTION( "QAbstractItemModelTester" )


### PR DESCRIPTION
The attribute form model base was basically untested, so the old test only poked at 4 things through the derived model, none of the constraint/visibility/sync logic that actually runs the form so this adds sections for hard + soft constraints, constraint descriptions, tab layout, field sync across tabs, container visibility, and delete.

two calls I made that are worth a look:
- constraint tests build their own throwaway layer instead of reusing the fixture. the fixture sets editable = "str" is null on str, and constraints only evaluate when the field's editable, so putting a constraint there passes for the wrong reason (field goes readonly, validity forced true). own layer keeps it honest.
- visibility checks rowCount() instead of reading the CurrentlyVisible role, since the proxy just filters hidden tabs out, same way tst_featureForm already does it