### PR TITLE
Fix QfAudioRecorder name collision

### DIFF
--- a/src/app/qml/QfCloudProjectDetails.qml
+++ b/src/app/qml/QfCloudProjectDetails.qml
@@ -279,7 +279,7 @@ ColumnLayout {
             sourceSize.height: desiredWidth * Screen.devicePixelRatio
             source: cloudProject != undefined ? "image://barcode/?text=" + encodeURIComponent(QfUrlUtils.createActionUrl("qfield", "cloud", {
               "project": cloudProject.owner + '/' + cloudProject.name
-            })) + "&color=" + encodeURIComponent(QfTheme.mainColor) : ""
+            })) + "&color=" + encodeURIComponent(QfTheme.mainTextColor) : ""
             property int desiredWidth: Math.min(mainWindow.width - 40, 250)
           }
 

--- a/src/app/qml_compat/QFieldAudioRecorder.qml
+++ b/src/app/qml_compat/QFieldAudioRecorder.qml
@@ -1,3 +1,3 @@
 import org.qfield.gui
 
-QfAudioRecorder {}
+QfAudioClipRecorder {}

--- a/src/gui/qml/CMakeLists.txt
+++ b/src/gui/qml/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(QFIELD_GUI_QML_FILES
     QfActionButton.qml
-    QfAudioRecorder.qml
+    QfAudioClipRecorder.qml
     QfBadge.qml
     QfBluetoothDeviceChooser.qml
     QfBookmarkHighlight.qml

--- a/src/gui/qml/QfAudioClipRecorder.qml
+++ b/src/gui/qml/QfAudioClipRecorder.qml
@@ -11,7 +11,7 @@ import org.qfield.gui
  * \ingroup qml
  */
 QfPopup {
-  id: audioRecorder
+  id: audioClipRecorder
 
   signal finished(string path)
   signal canceled
@@ -63,7 +63,7 @@ QfPopup {
   }
 
   /**
-   * Until QAudioRecorder reliably changes its status across all platforms after calling stop(),
+   * Until the recorder reliably changes its status across all platforms after calling stop(),
    * use a timer as workaround and check for duration > 0 as condition for successful
    * saved audio recording.
    */
@@ -147,7 +147,7 @@ QfPopup {
           bgcolor: "transparent"
 
           onClicked: {
-            audioRecorder.canceled();
+            audioClipRecorder.canceled();
           }
         }
       }
@@ -247,7 +247,7 @@ QfPopup {
 
         QfToolButton {
           id: playButton
-          enabled: audioRecorder.hasRecordedClip
+          enabled: audioClipRecorder.hasRecordedClip
           opacity: enabled ? 1 : 0.25
 
           iconSource: player.playbackState == MediaPlayer.PlayingState ? QfTheme.getThemeVectorIcon('ic_pause_black_24dp') : QfTheme.getThemeVectorIcon('ic_play_black_24dp')
@@ -270,7 +270,7 @@ QfPopup {
           from: 0
           to: 0
 
-          enabled: audioRecorder.hasRecordedClip
+          enabled: audioClipRecorder.hasRecordedClip
           opacity: enabled ? 1 : 0.25
 
           onMoved: {
@@ -309,7 +309,7 @@ QfPopup {
 
         QfToolButton {
           id: acceptButton
-          enabled: audioRecorder.hasRecordedClip
+          enabled: audioClipRecorder.hasRecordedClip
           opacity: enabled ? 1 : 0.2
           Layout.alignment: Qt.AlignVCenter
           iconSource: QfTheme.getThemeVectorIcon('ic_check_white_24dp')
@@ -319,8 +319,8 @@ QfPopup {
 
           onClicked: {
             const path = recorder.actualLocation.toString();
-            audioRecorder.finished(QfUrlUtils.toLocalFile(path));
-            audioRecorder.close();
+            audioClipRecorder.finished(QfUrlUtils.toLocalFile(path));
+            audioClipRecorder.close();
           }
         }
       }

--- a/src/gui/qml/QfFeatureForm.qml
+++ b/src/gui/qml/QfFeatureForm.qml
@@ -1238,7 +1238,6 @@ Page {
   QfDialog {
     id: cancelDialog
     parent: mainWindow.contentItem
-    width: mainWindow.width - QfTheme.popupScreenEdgeHorizontalMargin * 2
     z: 10000 // 1000s are embedded feature forms, user a higher value to insure the dialog will always show above embedded feature forms
     title: qsTr("Cancel")
     Label {

--- a/src/gui/qml/editorwidgets/QfEditorWidgetExternalResource.qml
+++ b/src/gui/qml/editorwidgets/QfEditorWidgetExternalResource.qml
@@ -675,7 +675,7 @@ QfEditorWidgetBase {
   Component {
     id: audioRecorderComponent
 
-    QfAudioRecorder {
+    QfAudioClipRecorder {
       z: 10000
       visible: false
 

--- a/src/gui/qml/editorwidgets/QfRelationEditorBase.qml
+++ b/src/gui/qml/editorwidgets/QfRelationEditorBase.qml
@@ -207,7 +207,6 @@ QfEditorWidgetBase {
     property string nmReferencedLayerName: relationEditorModel.nmRelation.referencedLayer ? relationEditorModel.nmRelation.referencedLayer.name : ''
     property string nmReferencingLayerName
 
-    width: mainWindow.width - QfTheme.popupScreenEdgeHorizontalMargin * 2
     z: 10000 // 1000s are embedded feature forms, use a higher value to insure feature form popups always show above embedded feature forms
     title: nmRelationId ? qsTr('Unlink Feature') : qsTr('Delete Feature')
 

--- a/src/gui/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
+++ b/src/gui/qml/editorwidgets/relationeditors/gallery_relation_editor.qml
@@ -577,7 +577,7 @@ QfRelationEditorBase {
     id: relationAudioRecorderLoader
     active: false
     sourceComponent: Component {
-      QfAudioRecorder {
+      QfAudioClipRecorder {
         z: 10000
         visible: false
         Component.onCompleted: open()


### PR DESCRIPTION
Audio clip recording was broken on master due to item/class name collision following our re-structure of the source tree.

Big thanks to @SeqLaz for testing our upcoming release and documenting this regression.