### PR TITLE
Work around OS behavior's handling of virtual keyboard when pressing the back key

### DIFF
--- a/src/gui/qml/QfFeatureListForm.qml
+++ b/src/gui/qml/QfFeatureListForm.qml
@@ -712,6 +712,10 @@ QfPaneDrawer {
       }
       if (state != "FeatureList") {
         if (featureListToolBar.state === "Edit") {
+          if (Qt.inputMethod.visible) {
+            Qt.inputMethod.hide();
+            return;
+          }
           featureForm.requestCancel();
         } else if (formOpenedFromSingleIdentify) {
           state = "Hidden";

--- a/src/gui/qml/QfOverlayFeatureFormDrawer.qml
+++ b/src/gui/qml/QfOverlayFeatureFormDrawer.qml
@@ -201,6 +201,10 @@ Drawer {
 
     Keys.onReleased: event => {
       if (event.key === Qt.Key_Back || event.key === Qt.Key_Escape) {
+        if (Qt.inputMethod.visible) {
+          Qt.inputMethod.hide();
+          return;
+        }
         if (overlayFeatureForm.model.constraintsHardValid || qfieldSettings.autoSave) {
           overlayFeatureFormDrawer.close();
         } else {


### PR DESCRIPTION
Some OSes will close the virtual keyboard when opened upon pressing the back key, some don't. The latter brings some bad UX when handling feature forms. This aims at improving the situation.