### PR TITLE
Help users by avoiding invalid geometry when digitizing new lines and polygons

### DIFF
--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -965,7 +965,7 @@ ApplicationWindow {
               return;
             }
             // the sourceLocation test checks if a (stylus) hover is active
-            if ((Number(currentRubberband.model.geometryType) === Qgis.GeometryType.Line && currentRubberband.model.vertexCount >= 2) || (Number(currentRubberband.model.geometryType) === Qgis.GeometryType.Polygon && currentRubberband.model.vertexCount >= 2)) {
+            if ((currentRubberband.model.geometryType === Qgis.GeometryType.Line && currentRubberband.model.vertexCount >= 2) || (currentRubberband.model.geometryType === Qgis.GeometryType.Polygon && currentRubberband.model.vertexCount >= 3)) {
               digitizingToolbar.addVertex();
 
               // When it's released, it will normally cause a release event to close the attribute form.

--- a/src/gui/qml/QfDigitizingToolbar.qml
+++ b/src/gui/qml/QfDigitizingToolbar.qml
@@ -49,13 +49,35 @@ QfVisibilityFadingRow {
   Connections {
     target: rubberbandModel
 
-    function onVertexCountChanged() {
-      // check whether geometry is valid and can be confirmed
-      checkGeometryValidity();
+    property bool deferredVertexCountChanged: false
 
-      // emit the signal of digitizingToolbar
-      vertexCountChanged();
+    function onCurrentCoordinateChanged() {
+      if (deferredVertexCountChanged) {
+        const vertices = rubberbandModel.vertices;
+        if (vertices[rubberbandModel.vertexCount - 1] !== vertices[rubberbandModel.vertexCount - 2]) {
+          processVertexCountChanged();
+          deferredVertexCountChanged = false;
+        }
+      }
     }
+
+    function onVertexCountChanged() {
+      if (rubberbandModel.geometryType === Qgis.GeometryType.Line && rubberbandModel.vertexCount === 2) {
+        deferredVertexCountChanged = true;
+      } else if (rubberbandModel.geometryType === Qgis.GeometryType.Polygon && rubberbandModel.vertexCount === 3) {
+        deferredVertexCountChanged = true;
+      } else {
+        processVertexCountChanged();
+      }
+    }
+  }
+
+  function processVertexCountChanged() {
+    // check whether geometry is valid and can be confirmed
+    checkGeometryValidity();
+
+    // emit the signal of digitizingToolbar
+    vertexCountChanged();
   }
 
   QfDigitizingLogger {
@@ -190,7 +212,7 @@ QfVisibilityFadingRow {
         QfTheme.toolButtonBackgroundSemiOpaqueColor;
       } else if (!showConfirmButton) {
         QfTheme.toolButtonBackgroundColor;
-      } else if (Number(rubberbandModel ? rubberbandModel.geometryType : 0) === Qgis.GeometryType.Point || Number(rubberbandModel.geometryType) === Qgis.GeometryType.Null) {
+      } else if (!rubberbandModel || rubberbandModel.geometryType === Qgis.GeometryType.Point || rubberbandModel.geometryType === Qgis.GeometryType.Null) {
         QfTheme.mainColor;
       } else {
         QfTheme.toolButtonBackgroundColor;
@@ -242,7 +264,7 @@ QfVisibilityFadingRow {
         }
         lastAdditionAveraged = true;
         addVertex();
-        if (Number(rubberbandModel.geometryType) === Qgis.GeometryType.Point || Number(rubberbandModel.geometryType) === Qgis.GeometryType.Null) {
+        if (rubberbandModel.geometryType === Qgis.GeometryType.Point || rubberbandModel.geometryType === Qgis.GeometryType.Null) {
           confirm();
         }
         positionSource.averagedPosition = false;
@@ -284,7 +306,7 @@ QfVisibilityFadingRow {
         return;
       }
       lastAdditionAveraged = false;
-      if (Number(rubberbandModel.geometryType) === Qgis.GeometryType.Point || Number(rubberbandModel.geometryType) === Qgis.GeometryType.Null) {
+      if (rubberbandModel.geometryType === Qgis.GeometryType.Point || rubberbandModel.geometryType === Qgis.GeometryType.Null) {
         confirm();
       } else {
         addVertex();
@@ -323,15 +345,15 @@ QfVisibilityFadingRow {
   }
 
   function checkGeometryValidity() {
-    var extraVertexNeed = cogoEnabled || (coordinateLocator && coordinateLocator.positionLocked && positioningSettings.averagedPositioning && positioningSettings.averagedPositioningMinimumCount > 1) ? 1 : 0;
+    const extraVertexNeed = cogoEnabled || (coordinateLocator && coordinateLocator.positionLocked && positioningSettings.averagedPositioning && positioningSettings.averagedPositioningMinimumCount > 1) ? 1 : 0;
 
     // set geometry valid
-    if (Number(rubberbandModel ? rubberbandModel.geometryType : 0) === 0) {
+    if (!rubberbandModel || rubberbandModel.geometryType === Qgis.GeometryType.Point) {
       geometryValid = false;
-    } else if (Number(rubberbandModel.geometryType) === 1) {
+    } else if (rubberbandModel.geometryType === Qgis.GeometryType.Line) {
       // Line: at least 2 points
       geometryValid = rubberbandModel.vertexCount > 1 + extraVertexNeed;
-    } else if (Number(rubberbandModel.geometryType) === 2) {
+    } else if (rubberbandModel.geometryType === Qgis.GeometryType.Polygon) {
       // Polygon: at least 3 points
       geometryValid = rubberbandModel.vertexCount > 2 + extraVertexNeed;
     } else {


### PR DESCRIPTION
The long story short here is that when adding a vertex to the digitizing rubber band, we do increase the nb of vertices, however the immediate aftermath of a vertex addition will result in a duplicate vertex. That duplicate will get cleaned out when finalizing a line or polygon geometry, which means that a rubberband vertex count of 3 becomes _2_.

This PR defers the validity check _after_ the newly added vertex has had a position change. 

Fixes https://github.com/opengisch/QField/issues/7891