### PR TITLE
Never add a layer tree image node for WMS provider serving mbtiles datasets

### DIFF
--- a/src/core/qflayertreemodel.cpp
+++ b/src/core/qflayertreemodel.cpp
@@ -480,9 +480,9 @@ int QfFlatLayerTreeModelBase::buildMap( QgsLayerTreeModel *model, const QModelIn
           QgsRasterLayer *rasterLayer = qobject_cast<QgsRasterLayer *>( nodeLayer->layer() );
           if ( rasterLayer && rasterLayer->dataProvider() && rasterLayer->dataProvider()->name() == QStringLiteral( "wms" ) )
           {
-            if ( rasterLayer->source().contains( QStringLiteral( "type=xyz" ), Qt::CaseInsensitive ) )
+            if ( rasterLayer->source().contains( QStringLiteral( "type=xyz" ), Qt::CaseInsensitive ) || rasterLayer->source().contains( QStringLiteral( "type=mbtiles" ), Qt::CaseInsensitive ) )
             {
-              // XYZ layers have no legend items, skip those.
+              // XYZ and mbtiles layers have no legend items, skip those.
               continue;
             }
           }


### PR DESCRIPTION
A WMS provided layer of type mbtiles - like xyz - will never have a remote legend attached to it, we shouldn't add a legend placeholder in our legend tree.

Fixes the rounded rectangle that feels misplaced below the Vantor layer:

<img width="713" height="1600" alt="image" src="https://github.com/user-attachments/assets/b0e6d991-d2b7-46f3-8159-496490c8f010" />
