### PR TITLE
Insure that we do not show both the map canvas guide and the cloud button guide at the same time

### DIFF
--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -4999,9 +4999,11 @@ ApplicationWindow {
         } else {
           projectInfo.restoreCloudUserInformation();
         }
-        if (cloudConnection.isReachable && settings.valueBool("/QField/showCloudButtonGuide", true) && cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0) {
-          cloudMenuTour.runTour();
-          settings.setValue("/QField/showCloudButtonGuide", false);
+        if (cloudConnection.isReachable) {
+          if (!settings.valueBool("/QField/showMapCanvasGuide", true) && settings.valueBool("/QField/showCloudButtonGuide", true) && cloudProjectsModel.layerObserver.deltaFileWrapper.count > 0) {
+            cloudMenuTour.runTour();
+            settings.setValue("/QField/showCloudButtonGuide", false);
+          }
         }
       } else {
         projectInfo.hasInsertRights = true;


### PR DESCRIPTION
It wouldn't happen during normal QField installation / usage, but it's a problem when upgrading from one PR build to another.