### PR TITLE
API documentation upgrade

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,13 +74,13 @@ This [QField template plugin](https://github.com/opengisch/qfield-template-plugi
 
 ## 🧠 Core Interfaces
 
-QField exposes an [`iface`](QField/classAppInterface.md) object and a set of utility modules.
+QField exposes an [`iface`](QField/classQfAppInterface.md) object and a set of utility modules.
 
 ### **Key `iface` functions**
 
 - `iface.mainWindow()` – access to the main application window
-- `iface.mapCanvas()` – retrieve the main [map canvas](QField/classMapCanvas.md) and [map settings](QField/classQgsQuickMapSettings.md)
-- `iface.positioning()` – retrieve the [positioning](QField/classPositioning.md) object
+- `iface.mapCanvas()` – retrieve the main [map canvas](QField/classQfMapCanvas.md) and [map settings](QField/classQgsQuickMapSettings.md)
+- `iface.positioning()` – retrieve the [positioning](QField/classQfPositioning.md) object
 - `iface.addItemToPluginsToolbar(item)` – add custom toolbar buttons overlays in the main window
 - `iface.addItemToDashboardActionsToolbar(item)` – add actions to the side dashboard
 - `iface.addItemToCanvasActionsToolbar(item)` – add actions to the map canvas long-press menu
@@ -90,8 +90,8 @@ QField exposes an [`iface`](QField/classAppInterface.md) object and a set of uti
 
 Examples:
 
-- `GeometryUtils.createGeometryFromWkt()`
-- `FeatureUtils.createFeature()`
+- `QfGeometryUtils.createGeometryFromWkt()`
+- `QfFeatureUtils.createFeature()`
 
 These allow plugins to create features, manipulate geometry, work with the camera, and more.
 
@@ -103,7 +103,7 @@ Minimal plugin example:
 
 ```qml
 import QtQuick
-import org.qfield
+import org.qfield.org
 
 Item {
   Component.onCompleted: {

--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -8,8 +8,8 @@ Mobile devices can handle several useful hyperlinks protocols such as `tel:` and
 
 ```qml
 import QtQuick
-import org.qfield
-import Theme
+import org.qfield.org
+import org.qfield.gui
 
 Item {
   QfToolButton {
@@ -33,12 +33,12 @@ Item {
 
 ## Change the map canvas center or extent
 
-This code below will re-center the map canvas around a WGS84 point reprojected to match the current project CRS by using [`GeometryUtils`](QField/classGeometryUtils.md) functions.
+This code below will re-center the map canvas around a WGS84 point reprojected to match the current project CRS by using [`QfGeometryUtils`](QField/classQfGeometryUtils.md) functions.
 
 ```qml
 import QtQuick
-import org.qfield
-import Theme
+import org.qfield.org
+import org.qfield.gui
 
 Item {
   QfToolButton {
@@ -50,8 +50,8 @@ Item {
     round: true
 
     onClicked: {
-      const point = GeometryUtils.point(174.7656025, -36.8533493);
-      const projectedPoint = GeometryUtils.reprojectPoint(point, CoordinateReferenceSystemUtils.wgs84Crs(), qgisProject.crs);
+      const point = QfGeometryUtils.point(174.7656025, -36.8533493);
+      const projectedPoint = QfGeometryUtils.reprojectPoint(point, CoordinateReferenceSystemUtils.wgs84Crs(), qgisProject.crs);
       iface.mapCanvas().mapSettings.center = projectedPoint;
     }
   }
@@ -66,10 +66,10 @@ It's also possible to use an extent instead of a point to be in control of the s
 
 ```qml
     onClicked: {
-      const point1 = GeometryUtils.point(174.7646543, -36.8519053);
-      const point2 = GeometryUtils.point(174.7682343, -36.8542590);
-      const extent = GeometryUtils.createRectangleFromPoints(point1, point2);
-      const projectedExtent = GeometryUtils.reprojectRectangle(extent, CoordinateReferenceSystemUtils.wgs84Crs(), qgisProject.crs);
+      const point1 = QfGeometryUtils.point(174.7646543, -36.8519053);
+      const point2 = QfGeometryUtils.point(174.7682343, -36.8542590);
+      const extent = QfGeometryUtils.createRectangleFromPoints(point1, point2);
+      const projectedExtent = QfGeometryUtils.reprojectRectangle(extent, CoordinateReferenceSystemUtils.wgs84Crs(), qgisProject.crs);
       iface.mapCanvas().mapSettings.extent = projectedExtent;
     }
 ```
@@ -80,8 +80,8 @@ One of the basic functionality you will likely seek is the ability to retrieve t
 
 ```qml
 import QtQuick
-import org.qfield
-import Theme
+import org.qfield.org
+import org.qfield.gui
 
 Item {
   QfToolButton {
@@ -93,7 +93,7 @@ Item {
     round: true
 
     onClicked: {
-      let positioning = iface.findItemByObjectName('positionSource');
+      let positioning = iface.positioning();
       if (positioning.active) {
         const info = positioning.positionInformation;
         if (info.longitudeValid && info.latitudeValid) {
@@ -113,10 +113,10 @@ Item {
 
 ## Integrate with the search bar
 
-The plugin framework empowers you to integrate custom searches into the QField search bar through the [`QFieldLocatorFilter`](QField/classQFieldLocatorFilter.md) item which can be added into a plugin's root item:
+The plugin framework empowers you to integrate custom searches into the QField search bar through the [`QfLocatorFilter`](QField/classQfLocatorFilter.md) item which can be added into a plugin's root item:
 
 ```qml
-QFieldLocatorFilter {
+QfLocatorFilter {
   id: locatorFilter
 
   delay: 1000
@@ -146,7 +146,6 @@ Here's a simple search QML source code:
 
 ```qml
 import QtQuick
-import org.qfield
 
 Item {
   signal prepareResult(var details)
@@ -156,7 +155,7 @@ Item {
     // string is the search term(s) typed into the search bar
     // context is a QgsLocatorContext object with the following properties:
     // - targetExtent, targetExtentCrs, and transformContext
-    // parameters is a map of keys and values attached to the QFieldLocatorFilter parameters properties
+    // parameters is a map of keys and values attached to the QfLocatorFilter parameters properties
 
     // sample details object
     let result_details = {
@@ -186,7 +185,7 @@ To do so, you can simply add a `function configure()` invocable function attache
 
 ```qml
 import QtQuick
-import org.qfield
+import org.qfield.org
 
 Item {
   // ...
@@ -210,11 +209,11 @@ Item {
 
 ## Flash geometries on top of the map canvas
 
-Plugins can make use of QField's [`GeometryHighlighter`](QField/classGeometryHighlighter.md) item to flash created or fetched geometries through the following code:
+Plugins can make use of QField's [`QfGeometryHighlighter`](QField/classQfGeometryHighlighter.md) item to flash created or fetched geometries through the following code:
 
 ```qml
 import QtQuick
-import org.qfield
+import org.qfield.org
 
 Item {
   // ...
@@ -223,8 +222,8 @@ Item {
 
   function demo() {
     // Flash Null Island geometry
-    let geom = GeometryUtils.createGeometryFromWkt("POINT(0 0)")
-    let crs = CoordinateReferenceSystemUtils.fromDescription("EPSG:4326")
+    let geom = QfGeometryUtils.createGeometryFromWkt("POINT(0 0)")
+    let crs = QfCoordinateReferenceSystemUtils.fromDescription("EPSG:4326")
 
     geometryHighlighter.geometryWrapper.qgsGeometry = geometry
     geometryHighlighter.geometryWrapper.crs = crs;
@@ -234,20 +233,20 @@ Item {
 
 ## Add a project variable through dialog input
 
-This example demonstrates how to check for a given project variable on project load and asks the user for a value if not present or empty through [`ExpressionContextUtils`](QField/classExpressionContextUtils.md) functions. The plugin also uses the projectInfo object to save the variable across sessions.
+This example demonstrates how to check for a given project variable on project load and asks the user for a value if not present or empty through [`QfExpressionContextUtils`](QField/classQfExpressionContextUtils.md) functions. The plugin also uses the projectInfo object to save the variable across sessions.
 
 ```qml
 import QtQuick
 import QtQuick.Controls
-import org.qfield
-import Theme
+import org.qfield.org
+import org.qfield.gui
 
 Item {
   Connections {
     target: iface
 
     function onLoadProjectEnded() {
-      const variables = ExpressionContextUtils.projectVariables(qgisProject);
+      const variables = QfExpressionContextUtils.projectVariables(qgisProject);
       if (variables["favorite_icecream"] === undefined || variables["favorite_icecream"] === "") {
         favoriteIceCreamDialog.open();
       }
@@ -276,7 +275,7 @@ Item {
     }
 
     onAccepted: {
-      ExpressionContextUtils.setProjectVariable(qgisProject, "favorite_icecream", favoriteIceCreamField.text);
+      QfExpressionContextUtils.setProjectVariable(qgisProject, "favorite_icecream", favoriteIceCreamField.text);
       let projectInfo = iface.findItemByObjectName("projectInfo");
       projectInfo.saveVariable("favorite_icecream", favoriteIceCreamField.text);
     }
@@ -286,9 +285,10 @@ Item {
 
 ## Register a map canvas point handler to take over taps
 
-Plugins can take over map canvas taps behavior by registering an handler with the [`MapCanvasPointHandler`](QField/classMapCanvasPointHandler.md) object. The code snippet below will look for features within a given layer and return an attribute instead of showing the features list. Feature iteration is done using functions provided by the [`LayerUtils`](QField/classLayerUtils.md) class.
+Plugins can take over map canvas taps behavior by registering an handler with the [`QfMapCanvasPointHandler`](QField/classQfMapCanvasPointHandler.md) object. The code snippet below will look for features within a given layer and return an attribute instead of showing the features list. Feature iteration is done using functions provided by the [`QfLayerUtils`](QField/classQfLayerUtils.md) class.
 
 ```qml
+let pointHandler = iface.findItemByObjectName("pointHandler");
 pointHandler.registerHandler("feature_iteration_example", (point, type, interactionType) => {
   if (interactionType === "clicked") {
     let mapCanvas = iface.mapCanvas();
@@ -311,7 +311,7 @@ By returning true, we are telling QField that we have taken over the handling an
 
 ## Split the `qml` code into multiple files
 
-Sometimes, the plugin's `main.qml` file can become long. In such cases, it is possible and recommended to split the code into multiple `qml` files.
+Sometimes, the plugin's `main.qml` file's content can become too long. In such cases, it is possible and recommended to split the code into multiple `qml` files.
 
 _This snippet does not intend to be a tutorial on QML itself, rather on how to organize QML code within a QField plugin. Also consider it as a hint that splitting QML code into multiple files can be considered as a good practice._
 
@@ -321,8 +321,8 @@ Here is an example of the content of the `main.qml` plugin file:
 import QtQuick
 import QtCore
 
-import org.qfield
-import "qrc:/qml" as QFieldItems
+import org.qfield.core
+import org.qfield.gui
 
 Item {
   id: myPlugin
@@ -352,7 +352,8 @@ And an example of the content of the `MyOtherDialog.qml` file:
 ```qml
 import QtQuick
 
-import org.qfield
+import org.qfield.org
+import org.qfield.gui
 
 Dialog {
   id: myOtherDialog

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,10 +42,10 @@ nav:
   - C++ core classes: QField/group__core.md
   - C++ gui classes: QField/group__gui.md
   - C++ 3D classes: QField/group____3d.md
-  - QML app items: QField/group__org.qfield.app.md
-  - QML core items: QField/group__org.qfield.core.md
-  - QML gui items: QField/group__org.qfield.gui.md
-  - QML 3D items: QField/group__org.qfield._3d.md
+  - QML app items: QField/group__qml__app.md
+  - QML core items: QField/group__qml__core.md
+  - QML gui items: QField/group__qml__gui.md
+  - QML 3D items: QField/group__qml__3d.md
 
 markdown_extensions:
   - admonition

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,8 +38,14 @@ nav:
   - Home: index.md
   - Code Snippets: snippets.md
   - Translate a plugin: translate.md
-  - C++ Classes: QField/group__core.md
-  - QML Items: QField/group__qml.md
+  - C++ app classes: QField/group__app.md
+  - C++ core classes: QField/group__core.md
+  - C++ gui classes: QField/group__gui.md
+  - C++ 3D classes: QField/group____3d.md
+  - QML app items: QField/group__org.qfield.app.md
+  - QML core items: QField/group__org.qfield.core.md
+  - QML gui items: QField/group__org.qfield.gui.md
+  - QML 3D items: QField/group__org.qfield._3d.md
 
 markdown_extensions:
   - admonition

--- a/src/3d/qf3dgeometry.h
+++ b/src/3d/qf3dgeometry.h
@@ -28,7 +28,7 @@
 class QgsLineString;
 
 /**
- * \defgroup _3d
+ * \defgroup _3d 3D
  * \brief QField application C++ classes
  */
 

--- a/src/3d/qf3dgeometry.h
+++ b/src/3d/qf3dgeometry.h
@@ -28,6 +28,11 @@
 class QgsLineString;
 
 /**
+ * \defgroup _3d
+ * \brief QField application C++ classes
+ */
+
+/**
  * Generates 3D geometry for an identified or selected feature on
  * top of the terrain mesh.
  *
@@ -37,7 +42,7 @@ class QgsLineString;
  * draped on the terrain surface.
  *
  * \note QML Type: Qf3DGeometry
- * \ingroup core
+ * \ingroup _3d
  */
 class Qf3DGeometry : public QQuick3DGeometry
 {

--- a/src/3d/qf3dgeometryconfiguration.h
+++ b/src/3d/qf3dgeometryconfiguration.h
@@ -27,7 +27,7 @@
  * \brief Lightweight data item used by plugins to inject geometry into the 3D map scene.
  *
  * \note QML Type: Qf3DGeometryConfiguration
- * \ingroup core
+ * \ingroup _3d
  */
 class Qf3DGeometryConfiguration : public QQuickItem
 {

--- a/src/3d/qf3dgeometryutils.h
+++ b/src/3d/qf3dgeometryutils.h
@@ -27,7 +27,7 @@
  * geometries. Each helper appends to a raw vertex/index buffer using a fixed
  * 10-float vertex layout: position(3) + normal(3) + rgba(4).
  *
- * \ingroup core
+ * \ingroup _3d
  */
 class QFIELD_3D_EXPORT Qf3DGeometryUtils
 {

--- a/src/3d/qf3dmaptexturedata.h
+++ b/src/3d/qf3dmaptexturedata.h
@@ -34,7 +34,7 @@ class QgsMapRendererParallelJob;
  * and the result is exposed as texture data for Qt Quick 3D.
  *
  * \note QML Type: Qf3DMapTextureData
- * \ingroup core
+ * \ingroup _3d
  */
 class Qf3DMapTextureData : public QQuick3DTextureData
 {

--- a/src/3d/qf3drubberbandgeometry.h
+++ b/src/3d/qf3drubberbandgeometry.h
@@ -31,7 +31,7 @@
  * Everything is packed into a single indexed triangle mesh with per-vertex colors.
  *
  * \note QML Type: Qf3DRubberbandGeometry
- * \ingroup core
+ * \ingroup _3d
  */
 class Qf3DRubberbandGeometry : public QQuick3DGeometry
 {

--- a/src/3d/qf3dterraingeometry.h
+++ b/src/3d/qf3dterraingeometry.h
@@ -32,7 +32,7 @@ class Qf3DTerrainProvider;
  * use with Qt Quick 3D Model items and supports dynamic updates when height data changes.
  *
  * \note QML Type: Qf3DTerrainGeometry
- * \ingroup core
+ * \ingroup _3d
  *
  */
 class Qf3DTerrainGeometry : public QQuick3DGeometry

--- a/src/3d/qf3dterrainprovider.h
+++ b/src/3d/qf3dterrainprovider.h
@@ -43,7 +43,7 @@ class QgsAbstractTerrainProvider;
  * generation in Qt Quick 3D.
  *
  * \note QML Type: Qf3DTerrainProvider
- * \ingroup core
+ * \ingroup _3d
  *
  */
 class Qf3DTerrainProvider : public QObject

--- a/src/3d/qfmaptoview3d.h
+++ b/src/3d/qfmaptoview3d.h
@@ -31,7 +31,7 @@
  * provider extent changes, enabling dynamic positioning of 3D elements.
  *
  * \note QML Type: QfMapToView3D
- * \ingroup core
+ * \ingroup _3d
  */
 class QfMapToView3D : public QObject
 {

--- a/src/3d/qml/QfFeatureListSelectionHighlight3D.qml
+++ b/src/3d/qml/QfFeatureListSelectionHighlight3D.qml
@@ -4,7 +4,7 @@ import org.qfield._3d
 import org.qfield.core
 
 /**
- * \ingroup org.qfield._3d
+ * \ingroup qml_3d
  */
 Node {
   id: featureListSelectionHighlight3D

--- a/src/3d/qml/QfFeatureListSelectionHighlight3D.qml
+++ b/src/3d/qml/QfFeatureListSelectionHighlight3D.qml
@@ -4,7 +4,7 @@ import org.qfield._3d
 import org.qfield.core
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield._3d
  */
 Node {
   id: featureListSelectionHighlight3D

--- a/src/3d/qml/QfMapCanvas3D.qml
+++ b/src/3d/qml/QfMapCanvas3D.qml
@@ -6,7 +6,7 @@ import org.qfield._3d
 import org.qfield.core
 
 /**
- * \defgroup qml_3d
+ * \defgroup qml_3d QML 3D
  * \brief QField 3D QML items available through import org.qfield._3d
  */
 

--- a/src/3d/qml/QfMapCanvas3D.qml
+++ b/src/3d/qml/QfMapCanvas3D.qml
@@ -6,12 +6,12 @@ import org.qfield._3d
 import org.qfield.core
 
 /**
- * \defgroup org.qfield._3d
- * \brief QField 3D QML items
+ * \defgroup qml_3d
+ * \brief QField 3D QML items available through import org.qfield._3d
  */
 
 /**
- * \ingroup org.qfield._3d
+ * \ingroup qml_3d
  */
 Item {
   id: mapArea

--- a/src/3d/qml/QfMapCanvas3D.qml
+++ b/src/3d/qml/QfMapCanvas3D.qml
@@ -5,6 +5,14 @@ import QtQuick3D.Helpers
 import org.qfield._3d
 import org.qfield.core
 
+/**
+ * \defgroup org.qfield._3d
+ * \brief QField 3D QML items
+ */
+
+/**
+ * \ingroup org.qfield._3d
+ */
 Item {
   id: mapArea
   focus: true

--- a/src/3d/qml/QfRubberband3D.qml
+++ b/src/3d/qml/QfRubberband3D.qml
@@ -4,7 +4,7 @@ import org.qfield._3d
 
 /**
  * Wraps Qf3DRubberbandGeometry in a ready-to-use Node with a matte PBR material.
- * \ingroup qml
+ * \ingroup org.qfield._3d
  */
 Node {
   id: root

--- a/src/3d/qml/QfRubberband3D.qml
+++ b/src/3d/qml/QfRubberband3D.qml
@@ -4,7 +4,7 @@ import org.qfield._3d
 
 /**
  * Wraps Qf3DRubberbandGeometry in a ready-to-use Node with a matte PBR material.
- * \ingroup org.qfield._3d
+ * \ingroup qml_3d
  */
 Node {
   id: root

--- a/src/3d/qml/QfTerrainMesh.qml
+++ b/src/3d/qml/QfTerrainMesh.qml
@@ -3,7 +3,7 @@ import QtQuick3D
 import org.qfield._3d
 
 /**
- * \ingroup org.qfield._3d
+ * \ingroup qml_3d
  */
 Node {
   id: root

--- a/src/3d/qml/QfTerrainMesh.qml
+++ b/src/3d/qml/QfTerrainMesh.qml
@@ -2,6 +2,9 @@ import QtQuick
 import QtQuick3D
 import org.qfield._3d
 
+/**
+ * \ingroup org.qfield._3d
+ */
 Node {
   id: root
 

--- a/src/3d/qml/QfTouchCameraController.qml
+++ b/src/3d/qml/QfTouchCameraController.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick3D
 
 /**
- * \ingroup org.qfield._3d
+ * \ingroup qml_3d
  */
 Item {
   id: root

--- a/src/3d/qml/QfTouchCameraController.qml
+++ b/src/3d/qml/QfTouchCameraController.qml
@@ -1,6 +1,9 @@
 import QtQuick
 import QtQuick3D
 
+/**
+ * \ingroup org.qfield._3d
+ */
 Item {
   id: root
 

--- a/src/app/qfappauthrequesthandler.h
+++ b/src/app/qfappauthrequesthandler.h
@@ -24,7 +24,6 @@
 #include <qgsnetworkaccessmanager.h>
 
 /**
- *
  * When a layer requests and authentication, this handler is triggered. When the credentials are found in
  * QgsCredentials (because it's stored before), they are used for the login. If not, QGIS would popup a
  * Login Dialog, but QField does not. The realms (where it should log in to) are just added to the list
@@ -32,7 +31,7 @@
  * successful login, the credentials are stored in QgsCredentials and removed from the list. When the list
  * is empty (or contains only canceled realms), the project is reloaded. This time the logins are contained
  * in QgsCredentials and no dialog needs to pop up.
- * \ingroup core
+ * \ingroup app
  */
 class QfAppAuthRequestHandler : public QObject, public QgsCredentials, public QgsNetworkAuthenticationHandler
 {

--- a/src/app/qfappcoordinateoperationhandlers.h
+++ b/src/app/qfappcoordinateoperationhandlers.h
@@ -24,7 +24,7 @@
  * Alerts users when a transform grids are required (or desired) for an operation between two
  * CRSes, yet they are not available on the current system. Derived from the
  * QgsAppCoordinateOperationHandlers class created by QGIS developer Nyall Dawson.
- * \ingroup core
+ * \ingroup app
  */
 class QfAppMissingGridHandler : public QObject
 {

--- a/src/app/qfbadlayerhandler.h
+++ b/src/app/qfbadlayerhandler.h
@@ -21,7 +21,7 @@
 #include <qgsprojectbadlayerhandler.h>
 
 /**
- * \ingroup core
+ * \ingroup app
  */
 class QfBadLayerHandler : public QStandardItemModel, public QgsProjectBadLayerHandler
 {

--- a/src/app/qfchangelogcontents.h
+++ b/src/app/qfchangelogcontents.h
@@ -20,7 +20,7 @@
 
 /**
  * Obtain the QField changelog contents from the GitHub releases API.
- * \ingroup core
+ * \ingroup app
  */
 class QfChangelogContents : public QObject
 {

--- a/src/app/qfclipboardmanager.h
+++ b/src/app/qfclipboardmanager.h
@@ -27,7 +27,7 @@ class QgsVectorLayer;
 
 /**
  * This class handles clipboard operations.
- * \ingroup core
+ * \ingroup app
  */
 class QfClipboardManager : public QObject
 {

--- a/src/app/qfpluginmanager.h
+++ b/src/app/qfpluginmanager.h
@@ -24,7 +24,7 @@
 #include <QTranslator>
 
 /**
- * \ingroup core
+ * \ingroup app
  */
 class QfPluginInformation
 {
@@ -75,7 +75,7 @@ class QfPluginInformation
 Q_DECLARE_METATYPE( QfPluginInformation )
 
 /**
- * \ingroup core
+ * \ingroup app
  */
 class QfPluginManager : public QObject
 {

--- a/src/app/qfpluginmodel.h
+++ b/src/app/qfpluginmodel.h
@@ -132,7 +132,7 @@ class QfPluginModel : public QAbstractListModel
 };
 
 /**
- * \ingroup core
+ * \ingroup app
  */
 class QfPluginProxyModel : public QSortFilterProxyModel
 {

--- a/src/app/qfscreendimmer.h
+++ b/src/app/qfscreendimmer.h
@@ -20,8 +20,8 @@
 #include <qgsapplication.h>
 
 /**
- * @brief The QfScreenDimmer class handles dimming of screen brightness.
- * \ingroup core
+ * \brief The QfScreenDimmer class handles dimming of screen brightness.
+ * \ingroup app
  */
 class QfScreenDimmer : public QObject
 {

--- a/src/app/qfurlhandler.h
+++ b/src/app/qfurlhandler.h
@@ -22,6 +22,9 @@
 
 class QfAppInterface;
 
+/**
+ * \ingroup app
+ */
 class QfUrlHandler : public QObject
 {
     Q_OBJECT

--- a/src/app/qml/QfAbout.qml
+++ b/src/app/qml/QfAbout.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Item {
   id: aboutPanel

--- a/src/app/qml/QfAbout.qml
+++ b/src/app/qml/QfAbout.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Item {
   id: aboutPanel

--- a/src/app/qml/QfBadLayerItem.qml
+++ b/src/app/qml/QfBadLayerItem.qml
@@ -6,7 +6,7 @@ import org.qfield.app
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Page {
   id: badLayerPage

--- a/src/app/qml/QfBadLayerItem.qml
+++ b/src/app/qml/QfBadLayerItem.qml
@@ -6,7 +6,7 @@ import org.qfield.app
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Page {
   id: badLayerPage

--- a/src/app/qml/QfChangelog.qml
+++ b/src/app/qml/QfChangelog.qml
@@ -6,7 +6,7 @@ import org.qfield.app
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 QfPopup {
   id: changelogPopup

--- a/src/app/qml/QfChangelog.qml
+++ b/src/app/qml/QfChangelog.qml
@@ -6,7 +6,7 @@ import org.qfield.app
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 QfPopup {
   id: changelogPopup

--- a/src/app/qml/QfCloudDangerZone.qml
+++ b/src/app/qml/QfCloudDangerZone.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Item {
   id: dangerZone

--- a/src/app/qml/QfCloudDangerZone.qml
+++ b/src/app/qml/QfCloudDangerZone.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Item {
   id: dangerZone

--- a/src/app/qml/QfCloudDeltaHistory.qml
+++ b/src/app/qml/QfCloudDeltaHistory.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 QfPopup {
   id: popup

--- a/src/app/qml/QfCloudDeltaHistory.qml
+++ b/src/app/qml/QfCloudDeltaHistory.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 QfPopup {
   id: popup

--- a/src/app/qml/QfCloudLogin.qml
+++ b/src/app/qml/QfCloudLogin.qml
@@ -6,7 +6,7 @@ import org.qfield.app
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Item {
   id: qfieldCloudLogin

--- a/src/app/qml/QfCloudLogin.qml
+++ b/src/app/qml/QfCloudLogin.qml
@@ -6,7 +6,7 @@ import org.qfield.app
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Item {
   id: qfieldCloudLogin

--- a/src/app/qml/QfCloudPackageLayersFeedback.qml
+++ b/src/app/qml/QfCloudPackageLayersFeedback.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 QfDialog {
   property int selectedCount: 0

--- a/src/app/qml/QfCloudPackageLayersFeedback.qml
+++ b/src/app/qml/QfCloudPackageLayersFeedback.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 QfDialog {
   property int selectedCount: 0

--- a/src/app/qml/QfCloudPendingChanges.qml
+++ b/src/app/qml/QfCloudPendingChanges.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Rectangle {
   id: pendingChanges

--- a/src/app/qml/QfCloudPendingChanges.qml
+++ b/src/app/qml/QfCloudPendingChanges.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Rectangle {
   id: pendingChanges

--- a/src/app/qml/QfCloudPopup.qml
+++ b/src/app/qml/QfCloudPopup.qml
@@ -6,7 +6,7 @@ import org.qfield.app
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Popup {
   id: popup

--- a/src/app/qml/QfCloudPopup.qml
+++ b/src/app/qml/QfCloudPopup.qml
@@ -6,7 +6,7 @@ import org.qfield.app
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Popup {
   id: popup

--- a/src/app/qml/QfCloudProjectDetails.qml
+++ b/src/app/qml/QfCloudProjectDetails.qml
@@ -4,6 +4,9 @@ import QtQuick.Layouts
 import org.qfield.core
 import org.qfield.gui
 
+/**
+ * \ingroup org.qfield.app
+ */
 ColumnLayout {
   id: projectDetails
   spacing: 5

--- a/src/app/qml/QfCloudProjectDetails.qml
+++ b/src/app/qml/QfCloudProjectDetails.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 ColumnLayout {
   id: projectDetails

--- a/src/app/qml/QfCloudProjectFilter.qml
+++ b/src/app/qml/QfCloudProjectFilter.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Pane {
   id: filterPanel

--- a/src/app/qml/QfCloudProjectFilter.qml
+++ b/src/app/qml/QfCloudProjectFilter.qml
@@ -5,6 +5,9 @@ import QtQuick.Layouts
 import org.qfield.core
 import org.qfield.gui
 
+/**
+ * \ingroup org.qfield.app
+ */
 Pane {
   id: filterPanel
 

--- a/src/app/qml/QfCloudScreen.qml
+++ b/src/app/qml/QfCloudScreen.qml
@@ -7,7 +7,7 @@ import org.qfield.gui
 import org.qfield.app
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Page {
   id: qfieldCloudScreen

--- a/src/app/qml/QfCloudScreen.qml
+++ b/src/app/qml/QfCloudScreen.qml
@@ -7,7 +7,7 @@ import org.qfield.gui
 import org.qfield.app
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Page {
   id: qfieldCloudScreen

--- a/src/app/qml/QfCloudStatusBanner.qml
+++ b/src/app/qml/QfCloudStatusBanner.qml
@@ -4,9 +4,8 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
- *
  * A reusable banner that displays the current QFieldCloud service status.
+ * \ingroup org.qfield.app
  */
 QfCollapsibleMessage {
   id: statusBanner

--- a/src/app/qml/QfCloudStatusBanner.qml
+++ b/src/app/qml/QfCloudStatusBanner.qml
@@ -5,7 +5,7 @@ import org.qfield.gui
 
 /**
  * A reusable banner that displays the current QFieldCloud service status.
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 QfCollapsibleMessage {
   id: statusBanner

--- a/src/app/qml/QfCoordinateLocator.qml
+++ b/src/app/qml/QfCoordinateLocator.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Item {
   id: locator

--- a/src/app/qml/QfCoordinateLocator.qml
+++ b/src/app/qml/QfCoordinateLocator.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Item {
   id: locator

--- a/src/app/qml/QfDashBoard.qml
+++ b/src/app/qml/QfDashBoard.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Drawer {
   id: dashBoard

--- a/src/app/qml/QfDashBoard.qml
+++ b/src/app/qml/QfDashBoard.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Drawer {
   id: dashBoard

--- a/src/app/qml/QfFeatureListSelectionHighlight.qml
+++ b/src/app/qml/QfFeatureListSelectionHighlight.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Repeater {
   id: featureListSelectionHighlight

--- a/src/app/qml/QfFeatureListSelectionHighlight.qml
+++ b/src/app/qml/QfFeatureListSelectionHighlight.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Repeater {
   id: featureListSelectionHighlight

--- a/src/app/qml/QfGuide.qml
+++ b/src/app/qml/QfGuide.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Popup {
   id: guide

--- a/src/app/qml/QfGuide.qml
+++ b/src/app/qml/QfGuide.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Popup {
   id: guide

--- a/src/app/qml/QfLocalDataPickerScreen.qml
+++ b/src/app/qml/QfLocalDataPickerScreen.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Page {
   id: qfieldLocalDataPickerScreen

--- a/src/app/qml/QfLocalDataPickerScreen.qml
+++ b/src/app/qml/QfLocalDataPickerScreen.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Page {
   id: qfieldLocalDataPickerScreen

--- a/src/app/qml/QfMeasuringTool.qml
+++ b/src/app/qml/QfMeasuringTool.qml
@@ -4,7 +4,7 @@ import org.qgis
 import org.qfield.core
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Item {
   id: measuringTool

--- a/src/app/qml/QfMeasuringTool.qml
+++ b/src/app/qml/QfMeasuringTool.qml
@@ -4,7 +4,7 @@ import org.qgis
 import org.qfield.core
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Item {
   id: measuringTool

--- a/src/app/qml/QfNyuki.qml
+++ b/src/app/qml/QfNyuki.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Item {
   id: nyukiContainer

--- a/src/app/qml/QfNyuki.qml
+++ b/src/app/qml/QfNyuki.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Item {
   id: nyukiContainer

--- a/src/app/qml/QfPluginItem.qml
+++ b/src/app/qml/QfPluginItem.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Rectangle {
   height: pluginItemContent.height + 10

--- a/src/app/qml/QfPluginItem.qml
+++ b/src/app/qml/QfPluginItem.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Rectangle {
   height: pluginItemContent.height + 10

--- a/src/app/qml/QfPluginManagerSettings.qml
+++ b/src/app/qml/QfPluginManagerSettings.qml
@@ -7,7 +7,7 @@ import org.qfield.app
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 QfPopup {
   id: popup

--- a/src/app/qml/QfPluginManagerSettings.qml
+++ b/src/app/qml/QfPluginManagerSettings.qml
@@ -7,7 +7,7 @@ import org.qfield.app
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 QfPopup {
   id: popup

--- a/src/app/qml/QfPositioningSettings.qml
+++ b/src/app/qml/QfPositioningSettings.qml
@@ -3,7 +3,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Settings {
   enum FollowMode {

--- a/src/app/qml/QfPositioningSettings.qml
+++ b/src/app/qml/QfPositioningSettings.qml
@@ -3,7 +3,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Settings {
   enum FollowMode {

--- a/src/app/qml/QfScreenLocker.qml
+++ b/src/app/qml/QfScreenLocker.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Item {
   id: screenLocker

--- a/src/app/qml/QfScreenLocker.qml
+++ b/src/app/qml/QfScreenLocker.qml
@@ -3,6 +3,9 @@ import QtQuick.Controls
 import org.qfield.core
 import org.qfield.gui
 
+/**
+ * \ingroup org.qfield.app
+ */
 Item {
   id: screenLocker
 

--- a/src/app/qml/QfSettings.qml
+++ b/src/app/qml/QfSettings.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Page {
   id: page

--- a/src/app/qml/QfSettings.qml
+++ b/src/app/qml/QfSettings.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Page {
   id: page

--- a/src/app/qml/QfSketcher.qml
+++ b/src/app/qml/QfSketcher.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Popup {
   id: sketcher

--- a/src/app/qml/QfSketcher.qml
+++ b/src/app/qml/QfSketcher.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Popup {
   id: sketcher

--- a/src/app/qml/QfTrackerSettings.qml
+++ b/src/app/qml/QfTrackerSettings.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 QfPopup {
   id: trackerSettings

--- a/src/app/qml/QfTrackerSettings.qml
+++ b/src/app/qml/QfTrackerSettings.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 QfPopup {
   id: trackerSettings

--- a/src/app/qml/QfWelcomeScreen.qml
+++ b/src/app/qml/QfWelcomeScreen.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 Page {
   id: welcomeScreen

--- a/src/app/qml/QfWelcomeScreen.qml
+++ b/src/app/qml/QfWelcomeScreen.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 Page {
   id: welcomeScreen

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -31,7 +31,7 @@ import org.qfield.gui
 import org.qfield.app
 
 /**
- * \defgroup qml_app
+ * \defgroup qml_app QML app
  * \brief QField application QML items available through import org.qfield.app
  */
 

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -32,7 +32,7 @@ import org.qfield.app
 
 /**
  * \defgroup qml
- * \brief QField QML items
+ * \brief QField QML core items
  */
 
 /**

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -32,7 +32,7 @@ import org.qfield.app
 
 /**
  * \defgroup org.qfield.app
- * \brief QField application QML core items
+ * \brief QField application QML items
  */
 
 /**

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -31,12 +31,12 @@ import org.qfield.gui
 import org.qfield.app
 
 /**
- * \defgroup qml
- * \brief QField QML core items
+ * \defgroup org.qfield.app
+ * \brief QField application QML core items
  */
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.app
  */
 ApplicationWindow {
   id: mainWindow

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -31,12 +31,12 @@ import org.qfield.gui
 import org.qfield.app
 
 /**
- * \defgroup org.qfield.app
- * \brief QField application QML items
+ * \defgroup qml_app
+ * \brief QField application QML items available through import org.qfield.app
  */
 
 /**
- * \ingroup org.qfield.app
+ * \ingroup qml_app
  */
 ApplicationWindow {
   id: mainWindow

--- a/src/core/platforms/qfplatformutilities.h
+++ b/src/core/platforms/qfplatformutilities.h
@@ -74,6 +74,13 @@ class QFIELD_CORE_EXPORT QfPlatformUtilities : public QObject
     void initSystem();
 
     /**
+     * This method can be used to implement platform specific initialization tasks to be performed after an app update.
+     * This is implemented for Android to extract app assets to location where it can
+     * be accessed via filesystem.
+     */
+    virtual void afterUpdate();
+
+    /**
      * The path to share data location.
      * Under this path, there should be the app specific directories qgis/ proj/ qfield/ ...
      * Refers to /share or /usr/share on Linux.
@@ -337,13 +344,6 @@ class QFIELD_CORE_EXPORT QfPlatformUtilities : public QObject
     void resourceCanceled( const QString &message );
 
   private:
-    /**
-     * This method can be used to implement platform specific initialization tasks to be performed after an app update.
-     * This is implemented for Android to extract app assets to location where it can
-     * be accessed via filesystem.
-     */
-    virtual void afterUpdate();
-
     void copySampleProjects();
 
     QfResourceSource *createResource( const QString &prefix, const QString &filePath, const QString &fileName, QObject *parent );

--- a/src/core/qfpeliasgeocoder.h
+++ b/src/core/qfpeliasgeocoder.h
@@ -17,19 +17,17 @@
 #define QFPELIASGEOCODER_H
 
 #include "qfield_core_export.h"
-#include "qgis_core.h"
-#include "qgsgeocoder.h"
 
 #include <QMutex>
+#include <qgsgeocoder.h>
 
 /**
- * \ingroup core
  * \brief A geocoder which uses the Pelias geocoding API to retrieve results.
  *
  * This geocoder utilizes the Pelias geocoding API in order to geocode
  * strings from an endpoint server.
  *
- * \since QField 1.9
+ * \ingroup core
 */
 class QFIELD_CORE_EXPORT QfPeliasGeocoder : public QgsGeocoderInterface
 {

--- a/src/core/qfrubberbandmodel.h
+++ b/src/core/qfrubberbandmodel.h
@@ -36,7 +36,6 @@ class QgsVectorLayer;
  * as a ring in a polygon.
  * \ingroup core
  */
-
 class QFIELD_CORE_EXPORT QfRubberbandModel : public QObject
 {
     Q_OBJECT

--- a/src/core/qfrubberbandshape.h
+++ b/src/core/qfrubberbandshape.h
@@ -26,7 +26,7 @@ class QfVertexModel;
 class QgsQuickMapSettings;
 
 /**
- * @brief The QfRubberbandShape class is used to provide the shape data to draw rubber bands
+ * \brief The QfRubberbandShape class is used to provide the shape data to draw rubber bands
  * on the map canvas using the QML Shape item.
  * It is aimed to be used with either a QfVertexModel or a QfRubberbandModel.
  * \ingroup core

--- a/src/core/qml/QfGridRenderer.qml
+++ b/src/core/qml/QfGridRenderer.qml
@@ -3,7 +3,7 @@ import QtQuick.Shapes
 import org.qfield.core
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.core
  */
 Item {
   id: gridRenderer

--- a/src/core/qml/QfGridRenderer.qml
+++ b/src/core/qml/QfGridRenderer.qml
@@ -3,7 +3,7 @@ import QtQuick.Shapes
 import org.qfield.core
 
 /**
- * \defgroup qml_core
+ * \defgroup qml_core QML core
  * \brief QField core QML items available through import org.qfield.core
  */
 

--- a/src/core/qml/QfGridRenderer.qml
+++ b/src/core/qml/QfGridRenderer.qml
@@ -3,6 +3,11 @@ import QtQuick.Shapes
 import org.qfield.core
 
 /**
+ * \defgroup org.qfield.core
+ * \brief QField core QML items
+ */
+
+/**
  * \ingroup org.qfield.core
  */
 Item {

--- a/src/core/qml/QfGridRenderer.qml
+++ b/src/core/qml/QfGridRenderer.qml
@@ -3,12 +3,12 @@ import QtQuick.Shapes
 import org.qfield.core
 
 /**
- * \defgroup org.qfield.core
- * \brief QField core QML items
+ * \defgroup qml_core
+ * \brief QField core QML items available through import org.qfield.core
  */
 
 /**
- * \ingroup org.qfield.core
+ * \ingroup qml_core
  */
 Item {
   id: gridRenderer

--- a/src/core/qml/QfKineticHandler.qml
+++ b/src/core/qml/QfKineticHandler.qml
@@ -7,7 +7,7 @@ import QtQuick
  * We sample finger positions over a short time window to compute release velocity.
  * After the gesture ends motion continues with exponential friction decay (~60fps timer).
  *
- * \ingroup qml
+ * \ingroup org.qfield.core
  */
 Item {
   id: kineticHandler

--- a/src/core/qml/QfKineticHandler.qml
+++ b/src/core/qml/QfKineticHandler.qml
@@ -7,7 +7,7 @@ import QtQuick
  * We sample finger positions over a short time window to compute release velocity.
  * After the gesture ends motion continues with exponential friction decay (~60fps timer).
  *
- * \ingroup org.qfield.core
+ * \ingroup qml_core
  */
 Item {
   id: kineticHandler

--- a/src/core/qml/QfLinePolygon.qml
+++ b/src/core/qml/QfLinePolygon.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qgis
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.core
  */
 QfLinePolygonShape {
   id: linePolygonShape

--- a/src/core/qml/QfLinePolygon.qml
+++ b/src/core/qml/QfLinePolygon.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qgis
 
 /**
- * \ingroup org.qfield.core
+ * \ingroup qml_core
  */
 QfLinePolygonShape {
   id: linePolygonShape

--- a/src/core/qml/QfMapCanvas.qml
+++ b/src/core/qml/QfMapCanvas.qml
@@ -21,7 +21,7 @@ import org.qgis
 import org.qfield.core
 
 /**
- * \ingroup org.qfield.core
+ * \ingroup qml_core
  */
 Item {
   id: mapArea

--- a/src/core/qml/QfMapCanvas.qml
+++ b/src/core/qml/QfMapCanvas.qml
@@ -21,7 +21,7 @@ import org.qgis
 import org.qfield.core
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.core
  */
 Item {
   id: mapArea

--- a/src/core/qml/QfMapCanvasPointHandler.qml
+++ b/src/core/qml/QfMapCanvasPointHandler.qml
@@ -2,7 +2,7 @@ import QtQuick
 import org.qfield.core
 
 /**
- * \ingroup org.qfield.core
+ * \ingroup qml_core
  */
 Item {
   id: root

--- a/src/core/qml/QfMapCanvasPointHandler.qml
+++ b/src/core/qml/QfMapCanvasPointHandler.qml
@@ -2,7 +2,7 @@ import QtQuick
 import org.qfield.core
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.core
  */
 Item {
   id: root

--- a/src/core/qml/QfRubberband.qml
+++ b/src/core/qml/QfRubberband.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qgis
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.core
  */
 QfRubberbandShape {
   id: rubberbandShape

--- a/src/core/qml/QfRubberband.qml
+++ b/src/core/qml/QfRubberband.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qgis
 
 /**
- * \ingroup org.qfield.core
+ * \ingroup qml_core
  */
 QfRubberbandShape {
   id: rubberbandShape

--- a/src/core/qml/QfVertexRubberband.qml
+++ b/src/core/qml/QfVertexRubberband.qml
@@ -4,7 +4,7 @@ import org.qgis
 import org.qfield.core
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.core
  */
 Repeater {
   id: vertexRubberband

--- a/src/core/qml/QfVertexRubberband.qml
+++ b/src/core/qml/QfVertexRubberband.qml
@@ -4,7 +4,7 @@ import org.qgis
 import org.qfield.core
 
 /**
- * \ingroup org.qfield.core
+ * \ingroup qml_core
  */
 Repeater {
   id: vertexRubberband

--- a/src/gui/qfattributeformmodel.h
+++ b/src/gui/qfattributeformmodel.h
@@ -23,7 +23,7 @@
 class QfFeatureModel;
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfAttributeFormModel : public QSortFilterProxyModel
 {

--- a/src/gui/qfattributeformmodelbase.h
+++ b/src/gui/qfattributeformmodelbase.h
@@ -25,7 +25,7 @@
 #include <qgsexpressioncontext.h>
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfAttributeFormModelBase : public QStandardItemModel
 {

--- a/src/gui/qfbarcodeimageprovider.h
+++ b/src/gui/qfbarcodeimageprovider.h
@@ -21,7 +21,7 @@
 #define DEFAULT_BARCODE_SIZE 255
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfBarcodeImageProvider : public QQuickImageProvider
 {

--- a/src/gui/qfdrawingtemplatemodel.h
+++ b/src/gui/qfdrawingtemplatemodel.h
@@ -19,7 +19,7 @@
 #include <QAbstractListModel>
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfDrawingTemplateModel : public QAbstractListModel
 {

--- a/src/gui/qfexpressionevaluator.h
+++ b/src/gui/qfexpressionevaluator.h
@@ -30,9 +30,9 @@
 
 
 /**
- * @brief The QfExpressionEvaluator class enables evaluation of expression
+ * \brief The QfExpressionEvaluator class enables evaluation of expression
  * strings and expression templates.
- * \ingroup core
+ * \ingroup gui
  */
 class QfExpressionEvaluator : public QObject
 {

--- a/src/gui/qfexpressionvariablemodel.h
+++ b/src/gui/qfexpressionvariablemodel.h
@@ -20,7 +20,7 @@
 #include <qgsproject.h>
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfExpressionVariableModel : public QStandardItemModel
 {

--- a/src/gui/qffeaturechecklistmodel.h
+++ b/src/gui/qffeaturechecklistmodel.h
@@ -23,7 +23,7 @@
 #include <qgsvectorlayer.h>
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfFeatureCheckListModelBase : public QfFeatureListModel
 {

--- a/src/gui/qffocusstack.h
+++ b/src/gui/qffocusstack.h
@@ -20,7 +20,7 @@
 #include <QQuickItem>
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfFocusStack : public QObject
 {

--- a/src/gui/qfgeometryeditorsmodel.h
+++ b/src/gui/qfgeometryeditorsmodel.h
@@ -24,7 +24,7 @@
 #include <QStandardItemModel>
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfGeometryEditorsModel : public QStandardItemModel
 {

--- a/src/gui/qflegendimageprovider.h
+++ b/src/gui/qflegendimageprovider.h
@@ -29,7 +29,7 @@ class QgsLayerTree;
 
 /**
  * \brief This class provides legend images for the layer tree model.
- * \ingroup core
+ * \ingroup gui
  */
 class QfLegendImageProvider : public QQuickImageProvider
 {

--- a/src/gui/qflocalfilesimageprovider.h
+++ b/src/gui/qflocalfilesimageprovider.h
@@ -19,7 +19,7 @@
 #include <QQuickImageProvider>
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfLocalFilesImageProvider : public QQuickImageProvider
 {

--- a/src/gui/qflocalfilesmodel.h
+++ b/src/gui/qflocalfilesmodel.h
@@ -21,7 +21,7 @@
 class QfLocalFileItem;
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfLocalFilesModel : public QAbstractListModel
 {

--- a/src/gui/qfmessagelogmodel.h
+++ b/src/gui/qfmessagelogmodel.h
@@ -23,7 +23,7 @@
 /**
  * This model will connect to the message log and publish any
  * messages received from there.
- * \ingroup core
+ * \ingroup gui
  */
 class QfMessageLogModel : public QAbstractListModel
 {

--- a/src/gui/qforderedrelationmodel.h
+++ b/src/gui/qforderedrelationmodel.h
@@ -27,7 +27,7 @@
 class QfFeatureExpressionValuesGatherer;
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfOrderedRelationModel : public QfReferencingFeatureListModelBase
 {

--- a/src/gui/qfparameterizedimage.h
+++ b/src/gui/qfparameterizedimage.h
@@ -23,7 +23,7 @@
 #define DEFAULT_STROKE_WIDTH 5
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfParameterizedImage : public QQuickPaintedItem
 {

--- a/src/gui/qfpermissions.h
+++ b/src/gui/qfpermissions.h
@@ -21,7 +21,7 @@
 #include <QPermission>
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfCameraPermission : public QObject
 {

--- a/src/gui/qfprintlayoutlistmodel.h
+++ b/src/gui/qfprintlayoutlistmodel.h
@@ -25,7 +25,7 @@ class QgsProject;
 class QgsVectorLayer;
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfPrintLayoutListModel : public QAbstractListModel
 {

--- a/src/gui/qfprojectsimageprovider.h
+++ b/src/gui/qfprojectsimageprovider.h
@@ -19,7 +19,7 @@
 #include <QQuickImageProvider>
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfProjectsImageProvider : public QQuickImageProvider
 {

--- a/src/gui/qfrecentprojectlistmodel.h
+++ b/src/gui/qfrecentprojectlistmodel.h
@@ -19,7 +19,7 @@
 #include <QAbstractListModel>
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfRecentProjectListModel : public QAbstractListModel
 {

--- a/src/gui/qfreferencingfeaturelistmodel.h
+++ b/src/gui/qfreferencingfeaturelistmodel.h
@@ -32,7 +32,7 @@ class QfFeatureGatherer;
 class QfOrderedRelationModel;
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QFIELD_GUI_EXPORT QfReferencingFeatureListModelBase : public QAbstractItemModel
 {
@@ -496,7 +496,7 @@ class QfFeatureGatherer : public QThread
         mNmDisplayExpression = nmRelation.referencedLayer()->displayExpression();
       }
 
-      //mRequest.setExpressionContext( mContext );
+      mRequest.setExpressionContext( mContext );
     }
 
     void run() override

--- a/src/gui/qfsensorlistmodel.h
+++ b/src/gui/qfsensorlistmodel.h
@@ -24,7 +24,7 @@ class QgsProject;
 class QgsVectorLayer;
 
 /**
- * \ingroup core
+ * \ingroup gui
  */
 class QfSensorListModel : public QSortFilterProxyModel
 {

--- a/src/gui/qftheme.h
+++ b/src/gui/qftheme.h
@@ -25,12 +25,16 @@ email                : kaustuv@opengis.ch
 #include <QVariantMap>
 
 /**
- * \ingroup gui
- *
+ * \defgroup gui
+ * \brief QField GUI C++ classes
+ */
+
+/**
  * \brief Provides all color, font scale, and layout constants used throughout
  * the QField UI. Registered as a QML singleton in org.qfield.gui.
  *
  * \note Default colors are loaded from :/theme/theme.json
+ * \ingroup gui
  */
 class QFIELD_GUI_EXPORT QfTheme final : public QObject
 {

--- a/src/gui/qfvaluemapmodel.h
+++ b/src/gui/qfvaluemapmodel.h
@@ -26,7 +26,7 @@
 
 /**
  * A model that manages the key/value pairs for a ValueMap widget.
- * \ingroup core
+ * \ingroup gui
  */
 class QfValueMapModel : public QSortFilterProxyModel
 {

--- a/src/gui/qfvaluemapmodelbase.h
+++ b/src/gui/qfvaluemapmodelbase.h
@@ -24,7 +24,7 @@
 
 /**
  * A base model that manages the key/value pairs for a ValueMap widget.
- * \ingroup core
+ * \ingroup gui
  */
 class QfValueMapModelBase : public QAbstractListModel
 {

--- a/src/gui/qml/QfActionButton.qml
+++ b/src/gui/qml/QfActionButton.qml
@@ -5,7 +5,7 @@ import QtQuick.Controls.Material.impl
 import org.qfield.core
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 ToolButton {
   id: button

--- a/src/gui/qml/QfActionButton.qml
+++ b/src/gui/qml/QfActionButton.qml
@@ -5,7 +5,7 @@ import QtQuick.Controls.Material.impl
 import org.qfield.core
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 ToolButton {
   id: button

--- a/src/gui/qml/QfAudioClipRecorder.qml
+++ b/src/gui/qml/QfAudioClipRecorder.qml
@@ -8,7 +8,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfPopup {
   id: audioClipRecorder

--- a/src/gui/qml/QfAudioClipRecorder.qml
+++ b/src/gui/qml/QfAudioClipRecorder.qml
@@ -8,7 +8,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfPopup {
   id: audioClipRecorder

--- a/src/gui/qml/QfBadge.qml
+++ b/src/gui/qml/QfBadge.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Rectangle {
   id: badge

--- a/src/gui/qml/QfBadge.qml
+++ b/src/gui/qml/QfBadge.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Rectangle {
   id: badge

--- a/src/gui/qml/QfBluetoothDeviceChooser.qml
+++ b/src/gui/qml/QfBluetoothDeviceChooser.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: bluetoothDeviceChooser

--- a/src/gui/qml/QfBluetoothDeviceChooser.qml
+++ b/src/gui/qml/QfBluetoothDeviceChooser.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: bluetoothDeviceChooser

--- a/src/gui/qml/QfBookmarkHighlight.qml
+++ b/src/gui/qml/QfBookmarkHighlight.qml
@@ -3,7 +3,7 @@ import org.qgis
 import org.qfield.core
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Repeater {
   id: bookmarkHighlight

--- a/src/gui/qml/QfBookmarkHighlight.qml
+++ b/src/gui/qml/QfBookmarkHighlight.qml
@@ -3,7 +3,7 @@ import org.qgis
 import org.qfield.core
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Repeater {
   id: bookmarkHighlight

--- a/src/gui/qml/QfBookmarkList.qml
+++ b/src/gui/qml/QfBookmarkList.qml
@@ -8,7 +8,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfPaneDrawer {
   id: bookmarkList

--- a/src/gui/qml/QfBookmarkList.qml
+++ b/src/gui/qml/QfBookmarkList.qml
@@ -8,7 +8,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfPaneDrawer {
   id: bookmarkList

--- a/src/gui/qml/QfBookmarkProperties.qml
+++ b/src/gui/qml/QfBookmarkProperties.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfPopup {
   id: bookmarkProperties

--- a/src/gui/qml/QfBookmarkProperties.qml
+++ b/src/gui/qml/QfBookmarkProperties.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfPopup {
   id: bookmarkProperties

--- a/src/gui/qml/QfBookmarkRenderer.qml
+++ b/src/gui/qml/QfBookmarkRenderer.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: bookmarkRenderer

--- a/src/gui/qml/QfBookmarkRenderer.qml
+++ b/src/gui/qml/QfBookmarkRenderer.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: bookmarkRenderer

--- a/src/gui/qml/QfBrowserPanel.qml
+++ b/src/gui/qml/QfBrowserPanel.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfPopup {
   id: browserPanel

--- a/src/gui/qml/QfBrowserPanel.qml
+++ b/src/gui/qml/QfBrowserPanel.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfPopup {
   id: browserPanel

--- a/src/gui/qml/QfBusyOverlay.qml
+++ b/src/gui/qml/QfBusyOverlay.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Rectangle {
   id: busyOverlay

--- a/src/gui/qml/QfBusyOverlay.qml
+++ b/src/gui/qml/QfBusyOverlay.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Rectangle {
   id: busyOverlay

--- a/src/gui/qml/QfButton.qml
+++ b/src/gui/qml/QfButton.qml
@@ -9,7 +9,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Button {
   id: button

--- a/src/gui/qml/QfButton.qml
+++ b/src/gui/qml/QfButton.qml
@@ -9,7 +9,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Button {
   id: button

--- a/src/gui/qml/QfCalendarItem.qml
+++ b/src/gui/qml/QfCalendarItem.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: calendarItem

--- a/src/gui/qml/QfCalendarItem.qml
+++ b/src/gui/qml/QfCalendarItem.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: calendarItem

--- a/src/gui/qml/QfCalendarPanel.qml
+++ b/src/gui/qml/QfCalendarPanel.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfDialog {
   id: calendarPopup

--- a/src/gui/qml/QfCalendarPanel.qml
+++ b/src/gui/qml/QfCalendarPanel.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfDialog {
   id: calendarPopup

--- a/src/gui/qml/QfCamera.qml
+++ b/src/gui/qml/QfCamera.qml
@@ -8,7 +8,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Popup {
   id: cameraItem

--- a/src/gui/qml/QfCamera.qml
+++ b/src/gui/qml/QfCamera.qml
@@ -8,7 +8,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Popup {
   id: cameraItem

--- a/src/gui/qml/QfCodeReader.qml
+++ b/src/gui/qml/QfCodeReader.qml
@@ -8,7 +8,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfPopup {
   id: codeReader

--- a/src/gui/qml/QfCodeReader.qml
+++ b/src/gui/qml/QfCodeReader.qml
@@ -8,7 +8,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfPopup {
   id: codeReader

--- a/src/gui/qml/QfCogoOperationPreview.qml
+++ b/src/gui/qml/QfCogoOperationPreview.qml
@@ -4,7 +4,7 @@ import org.qgis
 import org.qfield.core
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: cogoOperationPreview

--- a/src/gui/qml/QfCogoOperationPreview.qml
+++ b/src/gui/qml/QfCogoOperationPreview.qml
@@ -4,7 +4,7 @@ import org.qgis
 import org.qfield.core
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: cogoOperationPreview

--- a/src/gui/qml/QfCogoOperationSettings.qml
+++ b/src/gui/qml/QfCogoOperationSettings.qml
@@ -4,6 +4,9 @@ import org.qgis
 import org.qfield.core
 import org.qfield.gui
 
+/**
+ * \ingroup org.qfield.gui
+ */
 QfOverlayContainer {
   id: cogoOperationSettings
 

--- a/src/gui/qml/QfCogoOperationSettings.qml
+++ b/src/gui/qml/QfCogoOperationSettings.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfOverlayContainer {
   id: cogoOperationSettings

--- a/src/gui/qml/QfCogoOperations.qml
+++ b/src/gui/qml/QfCogoOperations.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: cogoOperations

--- a/src/gui/qml/QfCogoOperations.qml
+++ b/src/gui/qml/QfCogoOperations.qml
@@ -5,6 +5,9 @@ import org.qgis
 import org.qfield.core
 import org.qfield.gui
 
+/**
+ * \ingroup org.qfield.gui
+ */
 Item {
   id: cogoOperations
 

--- a/src/gui/qml/QfCollapsibleMessage.qml
+++ b/src/gui/qml/QfCollapsibleMessage.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: collapsibleMessage

--- a/src/gui/qml/QfCollapsibleMessage.qml
+++ b/src/gui/qml/QfCollapsibleMessage.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: collapsibleMessage

--- a/src/gui/qml/QfComboBox.qml
+++ b/src/gui/qml/QfComboBox.qml
@@ -7,7 +7,7 @@ import QtQuick.Controls.Material.impl
 import org.qfield.core
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 ComboBox {
   id: comboBox

--- a/src/gui/qml/QfComboBox.qml
+++ b/src/gui/qml/QfComboBox.qml
@@ -7,7 +7,7 @@ import QtQuick.Controls.Material.impl
 import org.qfield.core
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 ComboBox {
   id: comboBox

--- a/src/gui/qml/QfConfirmationToolbar.qml
+++ b/src/gui/qml/QfConfirmationToolbar.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfVisibilityFadingRow {
   id: confirmationToolbar

--- a/src/gui/qml/QfConfirmationToolbar.qml
+++ b/src/gui/qml/QfConfirmationToolbar.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfVisibilityFadingRow {
   id: confirmationToolbar

--- a/src/gui/qml/QfContainerCard.qml
+++ b/src/gui/qml/QfContainerCard.qml
@@ -8,7 +8,7 @@ import org.qfield.gui
  * action button or a toggle) can be added as children and is placed below
  * the texts.
  *
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Rectangle {
   id: containerCard

--- a/src/gui/qml/QfContainerCard.qml
+++ b/src/gui/qml/QfContainerCard.qml
@@ -8,7 +8,7 @@ import org.qfield.gui
  * action button or a toggle) can be added as children and is placed below
  * the texts.
  *
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Rectangle {
   id: containerCard

--- a/src/gui/qml/QfDialog.qml
+++ b/src/gui/qml/QfDialog.qml
@@ -4,7 +4,12 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \defgroup org.qfield.gui
+ * \brief QField GUI QML core items
+ */
+
+/**
+ * \ingroup org.qfield.gui
  */
 Dialog {
   visible: false

--- a/src/gui/qml/QfDialog.qml
+++ b/src/gui/qml/QfDialog.qml
@@ -5,7 +5,7 @@ import org.qfield.gui
 
 /**
  * \defgroup org.qfield.gui
- * \brief QField GUI QML core items
+ * \brief QField GUI QML items
  */
 
 /**

--- a/src/gui/qml/QfDialog.qml
+++ b/src/gui/qml/QfDialog.qml
@@ -4,12 +4,12 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \defgroup org.qfield.gui
- * \brief QField GUI QML items
+ * \defgroup qml_gui
+ * \brief QField GUI QML items available through import org.qfield.gui
  */
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Dialog {
   visible: false

--- a/src/gui/qml/QfDialog.qml
+++ b/src/gui/qml/QfDialog.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \defgroup qml_gui
+ * \defgroup qml_gui QML gui
  * \brief QField GUI QML items available through import org.qfield.gui
  */
 

--- a/src/gui/qml/QfDigitizingToolbar.qml
+++ b/src/gui/qml/QfDigitizingToolbar.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfVisibilityFadingRow {
   id: digitizingToolbar

--- a/src/gui/qml/QfDigitizingToolbar.qml
+++ b/src/gui/qml/QfDigitizingToolbar.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfVisibilityFadingRow {
   id: digitizingToolbar

--- a/src/gui/qml/QfDropShadow.qml
+++ b/src/gui/qml/QfDropShadow.qml
@@ -1,6 +1,9 @@
 import QtQuick
 import QtQuick.Effects
 
+/**
+ * \ingroup org.qfield.gui
+ */
 MultiEffect {
   id: effect
 

--- a/src/gui/qml/QfDropShadow.qml
+++ b/src/gui/qml/QfDropShadow.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Effects
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 MultiEffect {
   id: effect

--- a/src/gui/qml/QfEgenioussDeviceChooser.qml
+++ b/src/gui/qml/QfEgenioussDeviceChooser.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   width: parent.width

--- a/src/gui/qml/QfEgenioussDeviceChooser.qml
+++ b/src/gui/qml/QfEgenioussDeviceChooser.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   width: parent.width

--- a/src/gui/qml/QfElevationProfile.qml
+++ b/src/gui/qml/QfElevationProfile.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Rectangle {
   id: elevationProfile

--- a/src/gui/qml/QfElevationProfile.qml
+++ b/src/gui/qml/QfElevationProfile.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Rectangle {
   id: elevationProfile

--- a/src/gui/qml/QfEmbeddedFeatureForm.qml
+++ b/src/gui/qml/QfEmbeddedFeatureForm.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfPopup {
   id: formPopup

--- a/src/gui/qml/QfEmbeddedFeatureForm.qml
+++ b/src/gui/qml/QfEmbeddedFeatureForm.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfPopup {
   id: formPopup

--- a/src/gui/qml/QfExpandableGroupBox.qml
+++ b/src/gui/qml/QfExpandableGroupBox.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Rectangle {
   id: expandableGroupBox

--- a/src/gui/qml/QfExpandableGroupBox.qml
+++ b/src/gui/qml/QfExpandableGroupBox.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Rectangle {
   id: expandableGroupBox

--- a/src/gui/qml/QfFeatureForm.qml
+++ b/src/gui/qml/QfFeatureForm.qml
@@ -11,7 +11,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Page {
   id: form

--- a/src/gui/qml/QfFeatureForm.qml
+++ b/src/gui/qml/QfFeatureForm.qml
@@ -11,7 +11,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Page {
   id: form

--- a/src/gui/qml/QfFeatureListForm.qml
+++ b/src/gui/qml/QfFeatureListForm.qml
@@ -24,7 +24,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfPaneDrawer {
   id: featureFormList

--- a/src/gui/qml/QfFeatureListForm.qml
+++ b/src/gui/qml/QfFeatureListForm.qml
@@ -24,7 +24,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfPaneDrawer {
   id: featureFormList

--- a/src/gui/qml/QfFileDeviceChooser.qml
+++ b/src/gui/qml/QfFileDeviceChooser.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   width: parent.width

--- a/src/gui/qml/QfFileDeviceChooser.qml
+++ b/src/gui/qml/QfFileDeviceChooser.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   width: parent.width

--- a/src/gui/qml/QfGeometryEditorsToolbar.qml
+++ b/src/gui/qml/QfGeometryEditorsToolbar.qml
@@ -21,7 +21,7 @@ import org.qfield.gui
  *  - canvasLongPressed(point)
  * These functions must return true if they catch the event.
  *
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfVisibilityFadingRow {
   id: geometryEditorsToolbar

--- a/src/gui/qml/QfGeometryEditorsToolbar.qml
+++ b/src/gui/qml/QfGeometryEditorsToolbar.qml
@@ -21,7 +21,7 @@ import org.qfield.gui
  *  - canvasLongPressed(point)
  * These functions must return true if they catch the event.
  *
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfVisibilityFadingRow {
   id: geometryEditorsToolbar

--- a/src/gui/qml/QfGeometryHighlighter.qml
+++ b/src/gui/qml/QfGeometryHighlighter.qml
@@ -2,7 +2,7 @@ import QtQuick
 import org.qfield.core
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: geometryHighlighter

--- a/src/gui/qml/QfGeometryHighlighter.qml
+++ b/src/gui/qml/QfGeometryHighlighter.qml
@@ -2,7 +2,7 @@ import QtQuick
 import org.qfield.core
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: geometryHighlighter

--- a/src/gui/qml/QfGeometryRenderer.qml
+++ b/src/gui/qml/QfGeometryRenderer.qml
@@ -3,7 +3,7 @@ import org.qgis
 import org.qfield.core
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: geometryRenderer

--- a/src/gui/qml/QfGeometryRenderer.qml
+++ b/src/gui/qml/QfGeometryRenderer.qml
@@ -3,7 +3,7 @@ import org.qgis
 import org.qfield.core
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: geometryRenderer

--- a/src/gui/qml/QfImageDial.qml
+++ b/src/gui/qml/QfImageDial.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Dial {
   id: control

--- a/src/gui/qml/QfImageDial.qml
+++ b/src/gui/qml/QfImageDial.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Dial {
   id: control

--- a/src/gui/qml/QfInformationDrawer.qml
+++ b/src/gui/qml/QfInformationDrawer.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: controller

--- a/src/gui/qml/QfInformationDrawer.qml
+++ b/src/gui/qml/QfInformationDrawer.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: controller

--- a/src/gui/qml/QfInformationPopup.qml
+++ b/src/gui/qml/QfInformationPopup.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfPopup {
   id: popup

--- a/src/gui/qml/QfInformationPopup.qml
+++ b/src/gui/qml/QfInformationPopup.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfPopup {
   id: popup

--- a/src/gui/qml/QfLayerLoginDialog.qml
+++ b/src/gui/qml/QfLayerLoginDialog.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Page {
   signal enter(string usr, string pw)

--- a/src/gui/qml/QfLayerLoginDialog.qml
+++ b/src/gui/qml/QfLayerLoginDialog.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Page {
   signal enter(string usr, string pw)

--- a/src/gui/qml/QfLayerTreeItemProperties.qml
+++ b/src/gui/qml/QfLayerTreeItemProperties.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfPopup {
   id: popup

--- a/src/gui/qml/QfLayerTreeItemProperties.qml
+++ b/src/gui/qml/QfLayerTreeItemProperties.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfPopup {
   id: popup

--- a/src/gui/qml/QfLegend.qml
+++ b/src/gui/qml/QfLegend.qml
@@ -8,7 +8,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 ListView {
   id: legend

--- a/src/gui/qml/QfLegend.qml
+++ b/src/gui/qml/QfLegend.qml
@@ -8,7 +8,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 ListView {
   id: legend

--- a/src/gui/qml/QfLocationMarker.qml
+++ b/src/gui/qml/QfLocationMarker.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: locationMarker

--- a/src/gui/qml/QfLocationMarker.qml
+++ b/src/gui/qml/QfLocationMarker.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: locationMarker

--- a/src/gui/qml/QfLocatorItem.qml
+++ b/src/gui/qml/QfLocatorItem.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: locatorItem

--- a/src/gui/qml/QfLocatorItem.qml
+++ b/src/gui/qml/QfLocatorItem.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: locatorItem

--- a/src/gui/qml/QfLocatorSettings.qml
+++ b/src/gui/qml/QfLocatorSettings.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfPopup {
   id: popup

--- a/src/gui/qml/QfLocatorSettings.qml
+++ b/src/gui/qml/QfLocatorSettings.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfPopup {
   id: popup

--- a/src/gui/qml/QfMenu.qml
+++ b/src/gui/qml/QfMenu.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Menu {
   id: control

--- a/src/gui/qml/QfMenu.qml
+++ b/src/gui/qml/QfMenu.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Menu {
   id: control

--- a/src/gui/qml/QfMessageLog.qml
+++ b/src/gui/qml/QfMessageLog.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Page {
   id: messageLog

--- a/src/gui/qml/QfMessageLog.qml
+++ b/src/gui/qml/QfMessageLog.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Page {
   id: messageLog

--- a/src/gui/qml/QfMeterBar.qml
+++ b/src/gui/qml/QfMeterBar.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: meterBar

--- a/src/gui/qml/QfMeterBar.qml
+++ b/src/gui/qml/QfMeterBar.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: meterBar

--- a/src/gui/qml/QfNavigationBar.qml
+++ b/src/gui/qml/QfNavigationBar.qml
@@ -21,7 +21,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Rectangle {
   id: toolBar

--- a/src/gui/qml/QfNavigationBar.qml
+++ b/src/gui/qml/QfNavigationBar.qml
@@ -21,7 +21,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Rectangle {
   id: toolBar

--- a/src/gui/qml/QfNavigationHighlight.qml
+++ b/src/gui/qml/QfNavigationHighlight.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: navigationHighlight

--- a/src/gui/qml/QfNavigationHighlight.qml
+++ b/src/gui/qml/QfNavigationHighlight.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: navigationHighlight

--- a/src/gui/qml/QfNavigationInformationView.qml
+++ b/src/gui/qml/QfNavigationInformationView.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Rectangle {
   id: navigationInformationView

--- a/src/gui/qml/QfNavigationInformationView.qml
+++ b/src/gui/qml/QfNavigationInformationView.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Rectangle {
   id: navigationInformationView

--- a/src/gui/qml/QfNavigationRenderer.qml
+++ b/src/gui/qml/QfNavigationRenderer.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: navigationRenderer

--- a/src/gui/qml/QfNavigationRenderer.qml
+++ b/src/gui/qml/QfNavigationRenderer.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: navigationRenderer

--- a/src/gui/qml/QfOpacityMask.qml
+++ b/src/gui/qml/QfOpacityMask.qml
@@ -1,6 +1,9 @@
 import QtQuick
 import QtQuick.Effects
 
+/**
+ * \ingroup org.qfield.gui
+ */
 MultiEffect {
   maskEnabled: true
 }

--- a/src/gui/qml/QfOpacityMask.qml
+++ b/src/gui/qml/QfOpacityMask.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Effects
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 MultiEffect {
   maskEnabled: true

--- a/src/gui/qml/QfOverlayContainer.qml
+++ b/src/gui/qml/QfOverlayContainer.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Rectangle {
   id: container

--- a/src/gui/qml/QfOverlayContainer.qml
+++ b/src/gui/qml/QfOverlayContainer.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Rectangle {
   id: container

--- a/src/gui/qml/QfOverlayFeatureFormDrawer.qml
+++ b/src/gui/qml/QfOverlayFeatureFormDrawer.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Drawer {
   id: overlayFeatureFormDrawer

--- a/src/gui/qml/QfOverlayFeatureFormDrawer.qml
+++ b/src/gui/qml/QfOverlayFeatureFormDrawer.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Drawer {
   id: overlayFeatureFormDrawer

--- a/src/gui/qml/QfPageHeader.qml
+++ b/src/gui/qml/QfPageHeader.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 ToolBar {
   property alias title: titleLabel.text

--- a/src/gui/qml/QfPageHeader.qml
+++ b/src/gui/qml/QfPageHeader.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 ToolBar {
   property alias title: titleLabel.text

--- a/src/gui/qml/QfPaneDrawer.qml
+++ b/src/gui/qml/QfPaneDrawer.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Pane {
   id: paneDrawer

--- a/src/gui/qml/QfPaneDrawer.qml
+++ b/src/gui/qml/QfPaneDrawer.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Pane {
   id: paneDrawer

--- a/src/gui/qml/QfPopup.qml
+++ b/src/gui/qml/QfPopup.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Popup {
   id: control

--- a/src/gui/qml/QfPopup.qml
+++ b/src/gui/qml/QfPopup.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Popup {
   id: control

--- a/src/gui/qml/QfPositioningDeviceSettings.qml
+++ b/src/gui/qml/QfPositioningDeviceSettings.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfPopup {
   id: popup

--- a/src/gui/qml/QfPositioningDeviceSettings.qml
+++ b/src/gui/qml/QfPositioningDeviceSettings.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfPopup {
   id: popup

--- a/src/gui/qml/QfPositioningInformationView.qml
+++ b/src/gui/qml/QfPositioningInformationView.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Rectangle {
   id: positioningInformationView

--- a/src/gui/qml/QfPositioningInformationView.qml
+++ b/src/gui/qml/QfPositioningInformationView.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Rectangle {
   id: positioningInformationView

--- a/src/gui/qml/QfPositioningNtripSettings.qml
+++ b/src/gui/qml/QfPositioningNtripSettings.qml
@@ -9,7 +9,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfPopup {
   id: popup

--- a/src/gui/qml/QfPositioningNtripSettings.qml
+++ b/src/gui/qml/QfPositioningNtripSettings.qml
@@ -9,7 +9,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfPopup {
   id: popup

--- a/src/gui/qml/QfPositioningPreciseView.qml
+++ b/src/gui/qml/QfPositioningPreciseView.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: positioningPreciseView

--- a/src/gui/qml/QfPositioningPreciseView.qml
+++ b/src/gui/qml/QfPositioningPreciseView.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: positioningPreciseView

--- a/src/gui/qml/QfProcessingAlgorithmForm.qml
+++ b/src/gui/qml/QfProcessingAlgorithmForm.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: processingAlgorithmForm

--- a/src/gui/qml/QfProcessingAlgorithmForm.qml
+++ b/src/gui/qml/QfProcessingAlgorithmForm.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: processingAlgorithmForm

--- a/src/gui/qml/QfProcessingAlgorithmPreview.qml
+++ b/src/gui/qml/QfProcessingAlgorithmPreview.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Repeater {
   id: processingAlgorithmPreview

--- a/src/gui/qml/QfProcessingAlgorithmPreview.qml
+++ b/src/gui/qml/QfProcessingAlgorithmPreview.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Repeater {
   id: processingAlgorithmPreview

--- a/src/gui/qml/QfProcessingAlgorithmsList.qml
+++ b/src/gui/qml/QfProcessingAlgorithmsList.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: processingAlgorithmsList

--- a/src/gui/qml/QfProcessingAlgorithmsList.qml
+++ b/src/gui/qml/QfProcessingAlgorithmsList.qml
@@ -7,7 +7,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: processingAlgorithmsList

--- a/src/gui/qml/QfProgressRing.qml
+++ b/src/gui/qml/QfProgressRing.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 ProgressBar {
   id: control

--- a/src/gui/qml/QfProgressRing.qml
+++ b/src/gui/qml/QfProgressRing.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 ProgressBar {
   id: control

--- a/src/gui/qml/QfProjectCreationScreen.qml
+++ b/src/gui/qml/QfProjectCreationScreen.qml
@@ -5,6 +5,9 @@ import QtQuick.Controls.Material.impl
 import org.qfield.core
 import org.qfield.gui
 
+/**
+ * \ingroup org.qfield.gui
+ */
 Page {
   id: projectCreation
 

--- a/src/gui/qml/QfProjectCreationScreen.qml
+++ b/src/gui/qml/QfProjectCreationScreen.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Page {
   id: projectCreation

--- a/src/gui/qml/QfProjectThumbnail.qml
+++ b/src/gui/qml/QfProjectThumbnail.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Rectangle {
   id: thumbnail

--- a/src/gui/qml/QfProjectThumbnail.qml
+++ b/src/gui/qml/QfProjectThumbnail.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Rectangle {
   id: thumbnail

--- a/src/gui/qml/QfRelationCombobox.qml
+++ b/src/gui/qml/QfRelationCombobox.qml
@@ -6,7 +6,7 @@ import org.qfield.gui
 import org.qgis
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: relationCombobox

--- a/src/gui/qml/QfRelationCombobox.qml
+++ b/src/gui/qml/QfRelationCombobox.qml
@@ -6,7 +6,7 @@ import org.qfield.gui
 import org.qgis
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: relationCombobox

--- a/src/gui/qml/QfScaleBar.qml
+++ b/src/gui/qml/QfScaleBar.qml
@@ -5,7 +5,7 @@ import org.qfield.gui
 import org.qgis
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: scaleBar

--- a/src/gui/qml/QfScaleBar.qml
+++ b/src/gui/qml/QfScaleBar.qml
@@ -5,7 +5,7 @@ import org.qfield.gui
 import org.qgis
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: scaleBar

--- a/src/gui/qml/QfScrollBar.qml
+++ b/src/gui/qml/QfScrollBar.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 T.ScrollBar {
   id: control

--- a/src/gui/qml/QfScrollBar.qml
+++ b/src/gui/qml/QfScrollBar.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 T.ScrollBar {
   id: control

--- a/src/gui/qml/QfSearchBar.qml
+++ b/src/gui/qml/QfSearchBar.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: searchBar

--- a/src/gui/qml/QfSearchBar.qml
+++ b/src/gui/qml/QfSearchBar.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: searchBar

--- a/src/gui/qml/QfSensorInformationView.qml
+++ b/src/gui/qml/QfSensorInformationView.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Rectangle {
   id: sensorInformationView

--- a/src/gui/qml/QfSensorInformationView.qml
+++ b/src/gui/qml/QfSensorInformationView.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Rectangle {
   id: sensorInformationView

--- a/src/gui/qml/QfSerialPortDeviceChooser.qml
+++ b/src/gui/qml/QfSerialPortDeviceChooser.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   width: parent.width

--- a/src/gui/qml/QfSerialPortDeviceChooser.qml
+++ b/src/gui/qml/QfSerialPortDeviceChooser.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   width: parent.width

--- a/src/gui/qml/QfSlider.qml
+++ b/src/gui/qml/QfSlider.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: wrapper

--- a/src/gui/qml/QfSlider.qml
+++ b/src/gui/qml/QfSlider.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: wrapper

--- a/src/gui/qml/QfSwipeAnimator.qml
+++ b/src/gui/qml/QfSwipeAnimator.qml
@@ -2,7 +2,7 @@ import QtQuick
 import org.qfield.core
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Flickable {
   id: flick

--- a/src/gui/qml/QfSwipeAnimator.qml
+++ b/src/gui/qml/QfSwipeAnimator.qml
@@ -1,6 +1,9 @@
 import QtQuick
 import org.qfield.core
 
+/**
+ * \ingroup org.qfield.gui
+ */
 Flickable {
   id: flick
   boundsBehavior: Flickable.StopAtBounds

--- a/src/gui/qml/QfSwitch.qml
+++ b/src/gui/qml/QfSwitch.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 SwitchDelegate {
   id: control

--- a/src/gui/qml/QfSwitch.qml
+++ b/src/gui/qml/QfSwitch.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 SwitchDelegate {
   id: control

--- a/src/gui/qml/QfTabBar.qml
+++ b/src/gui/qml/QfTabBar.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 ListView {
   id: tabRow

--- a/src/gui/qml/QfTabBar.qml
+++ b/src/gui/qml/QfTabBar.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 ListView {
   id: tabRow

--- a/src/gui/qml/QfTcpDeviceChooser.qml
+++ b/src/gui/qml/QfTcpDeviceChooser.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   width: parent.width

--- a/src/gui/qml/QfTcpDeviceChooser.qml
+++ b/src/gui/qml/QfTcpDeviceChooser.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   width: parent.width

--- a/src/gui/qml/QfTemporalProperties.qml
+++ b/src/gui/qml/QfTemporalProperties.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfPopup {
   id: temporalProperties

--- a/src/gui/qml/QfTemporalProperties.qml
+++ b/src/gui/qml/QfTemporalProperties.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfPopup {
   id: temporalProperties

--- a/src/gui/qml/QfTextField.qml
+++ b/src/gui/qml/QfTextField.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 TextField {
   id: textField

--- a/src/gui/qml/QfTextField.qml
+++ b/src/gui/qml/QfTextField.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 TextField {
   id: textField

--- a/src/gui/qml/QfTimeItem.qml
+++ b/src/gui/qml/QfTimeItem.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   property alias hours: hoursSpinBox.value

--- a/src/gui/qml/QfTimeItem.qml
+++ b/src/gui/qml/QfTimeItem.qml
@@ -4,6 +4,9 @@ import QtQuick.Controls
 import org.qfield.core
 import org.qfield.gui
 
+/**
+ * \ingroup org.qfield.gui
+ */
 Item {
   property alias hours: hoursSpinBox.value
   property alias minutes: minutesSpinBox.value

--- a/src/gui/qml/QfToast.qml
+++ b/src/gui/qml/QfToast.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Popup {
   id: toast

--- a/src/gui/qml/QfToast.qml
+++ b/src/gui/qml/QfToast.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Popup {
   id: toast

--- a/src/gui/qml/QfToggleButtonGroup.qml
+++ b/src/gui/qml/QfToggleButtonGroup.qml
@@ -7,7 +7,7 @@ import org.qgis
 
 /**
  * Provides a consistent UI for selecting single values from a list of options.
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: toggleButtonGroup

--- a/src/gui/qml/QfToggleButtonGroup.qml
+++ b/src/gui/qml/QfToggleButtonGroup.qml
@@ -7,7 +7,7 @@ import org.qgis
 
 /**
  * Provides a consistent UI for selecting single values from a list of options.
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: toggleButtonGroup

--- a/src/gui/qml/QfToolButton.qml
+++ b/src/gui/qml/QfToolButton.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 RoundButton {
   id: button

--- a/src/gui/qml/QfToolButton.qml
+++ b/src/gui/qml/QfToolButton.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 RoundButton {
   id: button

--- a/src/gui/qml/QfToolButtonDrawer.qml
+++ b/src/gui/qml/QfToolButtonDrawer.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Container {
   id: container

--- a/src/gui/qml/QfToolButtonDrawer.qml
+++ b/src/gui/qml/QfToolButtonDrawer.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Container {
   id: container

--- a/src/gui/qml/QfToolButtonPie.qml
+++ b/src/gui/qml/QfToolButtonPie.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Menu {
   id: pieMenu

--- a/src/gui/qml/QfToolButtonPie.qml
+++ b/src/gui/qml/QfToolButtonPie.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Menu {
   id: pieMenu

--- a/src/gui/qml/QfTrackerFeatureForm.qml
+++ b/src/gui/qml/QfTrackerFeatureForm.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 QfPopup {
   id: trackingFeatureForm

--- a/src/gui/qml/QfTrackerFeatureForm.qml
+++ b/src/gui/qml/QfTrackerFeatureForm.qml
@@ -6,7 +6,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 QfPopup {
   id: trackingFeatureForm

--- a/src/gui/qml/QfTrackingSession.qml
+++ b/src/gui/qml/QfTrackingSession.qml
@@ -5,7 +5,7 @@ import org.qgis
 import org.qfield.core
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   id: trackingSession

--- a/src/gui/qml/QfTrackingSession.qml
+++ b/src/gui/qml/QfTrackingSession.qml
@@ -5,7 +5,7 @@ import org.qgis
 import org.qfield.core
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   id: trackingSession

--- a/src/gui/qml/QfUdpDeviceChooser.qml
+++ b/src/gui/qml/QfUdpDeviceChooser.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Item {
   width: parent.width

--- a/src/gui/qml/QfUdpDeviceChooser.qml
+++ b/src/gui/qml/QfUdpDeviceChooser.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Item {
   width: parent.width

--- a/src/gui/qml/QfVariableEditor.qml
+++ b/src/gui/qml/QfVariableEditor.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 ColumnLayout {
   function reset() {

--- a/src/gui/qml/QfVariableEditor.qml
+++ b/src/gui/qml/QfVariableEditor.qml
@@ -5,7 +5,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 ColumnLayout {
   function reset() {

--- a/src/gui/qml/QfVisibilityFadingRow.qml
+++ b/src/gui/qml/QfVisibilityFadingRow.qml
@@ -2,7 +2,7 @@ import QtQuick
 import org.qfield.core
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 Row {
   id: visibilityFadingRow

--- a/src/gui/qml/QfVisibilityFadingRow.qml
+++ b/src/gui/qml/QfVisibilityFadingRow.qml
@@ -2,7 +2,7 @@ import QtQuick
 import org.qfield.core
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 Row {
   id: visibilityFadingRow

--- a/src/gui/qml/QfWelcomeAction.qml
+++ b/src/gui/qml/QfWelcomeAction.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup qml
+ * \ingroup org.qfield.gui
  */
 ColumnLayout {
   id: root

--- a/src/gui/qml/QfWelcomeAction.qml
+++ b/src/gui/qml/QfWelcomeAction.qml
@@ -4,7 +4,7 @@ import org.qfield.core
 import org.qfield.gui
 
 /**
- * \ingroup org.qfield.gui
+ * \ingroup qml_gui
  */
 ColumnLayout {
   id: root


### PR DESCRIPTION
This aligns with our restructured code, and fixes a bunch of wrong group assignment in .[h]eader and .qml files.

Improved TOC:

<img width="726" height="569" alt="image" src="https://github.com/user-attachments/assets/c34471ca-cf26-4b8b-9abb-7f9776fc2d3e" />
