### PR TITLE
Fix opaque texture and color when identifying features in 3D map view

### DIFF
--- a/src/3d/qml/QfFeatureListSelectionHighlight3D.qml
+++ b/src/3d/qml/QfFeatureListSelectionHighlight3D.qml
@@ -43,12 +43,9 @@ Node {
 
         materials: [
           PrincipledMaterial {
-            baseColor: "white"
-            metalness: 0.0
-            roughness: 1.0
             vertexColorsEnabled: true
             alphaMode: model.extrusion > 0 ? PrincipledMaterial.Opaque : PrincipledMaterial.Blend
-            depthDrawMode: Material.AlwaysDepthDraw
+            depthDrawMode: Material.OpaqueOnlyDepthDraw
             cullMode: PrincipledMaterial.NoCulling
           }
         ]

--- a/src/3d/qml/QfFeatureListSelectionHighlight3D.qml
+++ b/src/3d/qml/QfFeatureListSelectionHighlight3D.qml
@@ -47,6 +47,7 @@ Node {
             alphaMode: model.extrusion > 0 ? PrincipledMaterial.Opaque : PrincipledMaterial.Blend
             depthDrawMode: Material.OpaqueOnlyDepthDraw
             cullMode: PrincipledMaterial.NoCulling
+            lighting: PrincipledMaterial.NoLighting
           }
         ]
       }

--- a/src/3d/qml/QfMapCanvas3D.qml
+++ b/src/3d/qml/QfMapCanvas3D.qml
@@ -98,6 +98,9 @@ Item {
               stage: Shader.Fragment
               shader: "qrc:/3d/eye_dome_lighting.frag"
             }
+            output: Buffer {
+              format: Buffer.RGBA8
+            }
           }
         }
       ]
@@ -278,6 +281,7 @@ Item {
           }
           materials: PrincipledMaterial {
             vertexColorsEnabled: true
+            alphaMode: PrincipledMaterial.Blend
           }
         }
       }

--- a/src/3d/qml/QfMapCanvas3D.qml
+++ b/src/3d/qml/QfMapCanvas3D.qml
@@ -282,6 +282,9 @@ Item {
           materials: PrincipledMaterial {
             vertexColorsEnabled: true
             alphaMode: PrincipledMaterial.Blend
+            depthDrawMode: Material.OpaqueOnlyDepthDraw
+            cullMode: PrincipledMaterial.NoCulling
+            lighting: PrincipledMaterial.NoLighting
           }
         }
       }


### PR DESCRIPTION
While the 3D map view correctly renders polygons with a semi transparent fill, it shows as opaque when eye dome lightning is turned on.

| before | PR |
| --- | --- |
| <img width="713" height="1600" alt="image" src="https://github.com/user-attachments/assets/d2857213-7ff1-410a-a54c-d859109d6e90" /> | <img width="713" height="1600" alt="image" src="https://github.com/user-attachments/assets/0ba6a970-5cb8-4097-957b-519e0a7be159" /> |

