### PR TITLE
Get a slightly more decent set of legend icons using QgsScreenProperties

### DIFF
--- a/src/app/qgismobileapp.cpp
+++ b/src/app/qgismobileapp.cpp
@@ -135,6 +135,7 @@
 #include <qgsprojectviewsettings.h>
 #include <qgsrasterlayer.h>
 #include <qgsrasterresamplefilter.h>
+#include <qgsscreenproperties.h>
 #include <qgssettingsregistrycore.h>
 #include <qgssinglesymbolrenderer.h>
 #include <qgstemporalutils.h>
@@ -252,6 +253,13 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   mFeatureHistory = std::make_unique<QfFeatureHistory>( mProject, mTrackingModel );
   mClipboardManager = std::make_unique<QfClipboardManager>( this );
   mFlatLayerTree = new QfFlatLayerTreeModel( mProject->layerTreeRoot(), mProject, this );
+
+  QScreen *screen = QGuiApplication::primaryScreen();
+  if ( screen )
+  {
+    mFlatLayerTree->layerTreeModel()->addTargetScreenProperties( QgsScreenProperties( screen ) );
+  }
+
   mLegendImageProvider = new QfLegendImageProvider( mFlatLayerTree->layerTreeModel() );
   mAsyncLegendImageProvider = new QfAsyncLegendImageProvider( mFlatLayerTree->layerTreeModel() );
   mLocalFilesImageProvider = new QfLocalFilesImageProvider();

--- a/src/gui/qml/QfLegend.qml
+++ b/src/gui/qml/QfLegend.qml
@@ -271,9 +271,9 @@ ListView {
             id: trackingBadge
             property bool isVisible: InTracking ? true : false
             visible: isVisible
-            height: 24
-            width: 24
-            padding: 4
+            height: 32
+            width: 32
+            padding: 0
             enabled: isVisible
             round: true
             bgcolor: QfTheme.mainColor
@@ -311,9 +311,9 @@ ListView {
             id: invalidBadge
             property bool isVisible: Type == QfFlatLayerTreeModel.Layer && !IsValid
             visible: isVisible
-            height: 24
-            width: 24
-            padding: 4
+            height: 32
+            width: 32
+            padding: 0
             enabled: isVisible
             bgcolor: 'transparent'
             opacity: 0.5
@@ -329,9 +329,9 @@ ListView {
             id: lockedBadge
             property bool isVisible: ReadOnly || FeatureAdditionLocked
             visible: isVisible
-            height: 24
-            width: 24
-            padding: 4
+            height: 32
+            width: 32
+            padding: 0
             enabled: isVisible
             bgcolor: 'transparent'
             opacity: 0.5
@@ -352,9 +352,9 @@ ListView {
             id: notesBadge
             property bool isVisible: HasNotes
             visible: isVisible
-            height: 24
-            width: 24
-            padding: 4
+            height: 32
+            width: 32
+            padding: 0
             enabled: isVisible
             bgcolor: 'transparent'
             opacity: 0.5
@@ -376,9 +376,9 @@ ListView {
             id: snappingBadge
             property bool isVisible: stateMachine.state === "digitize" && qgisProject.snappingConfig.mode === Qgis.SnappingMode.AdvancedConfiguration && Type === QfFlatLayerTreeModel.Layer && LayerType === "vectorlayer" && VectorLayerPointer.geometryType() !== Qgis.GeometryType.Null && VectorLayerPointer.geometryType() !== Qgis.GeometryType.Unknown
             visible: isVisible
-            height: 24
-            width: 24
-            padding: 4
+            height: 32
+            width: 32
+            padding: 0
             enabled: isVisible
             round: true
             bgcolor: SnappingEnabled ? QfTheme.mainColor : QfTheme.controlBackgroundColor


### PR DESCRIPTION
There's something we can leverage since QGIS 3.32 called QgsScreenProperties. It's not perfect but it's a pretty nice improvement.

| Before | PR |
| --- | --- |
| <img width="713" height="1600" alt="image" src="https://github.com/user-attachments/assets/d01f5fce-f85d-45fe-a68b-b60063a09808" /> | <img width="713" height="1600" alt="image" src="https://github.com/user-attachments/assets/4226daa6-d88b-4a7f-b99d-59832a2755f2" /> |

