### PR TITLE
[Backport release-4_3] Insure that generate QML shapes from geometries and rubber band are confined within a reasonable scene coordinates

### DIFF
--- a/src/core/qflinepolygonshape.cpp
+++ b/src/core/qflinepolygonshape.cpp
@@ -104,6 +104,11 @@ void QfLinePolygonShape::createPolylines()
             {
               polyline << QPointF( ( point.x() - visibleExtent.xMinimum() ) * scaleFactor, ( point.y() - visibleExtent.yMaximum() ) * -scaleFactor );
             }
+            const QRectF rect = polyline.boundingRect();
+            if ( std::max( { std::abs( rect.left() ), std::abs( rect.right() ), std::abs( rect.top() ), std::abs( rect.bottom() ) } ) > 500000 )
+            {
+              polyline = polyline.intersected( QPolygonF( QRectF( QPointF( -500000, -500000 ), QPointF( 500000, 500000 ) ) ) );
+            }
             mPolylines.append( polyline );
           }
         }
@@ -192,10 +197,16 @@ void QfLinePolygonShape::updateTransform()
   if ( !mMapSettings )
     return;
 
+  if ( !mDirty && !mGeometryCorner.isEmpty() )
+  {
+    const QgsPointXY pixelCorner = mMapSettings->coordinateToScreen( mGeometryCorner );
+    mDirty = std::abs( x() ) > 250000 || std::abs( y() ) > 250000;
+  }
+
   if ( mDirty )
   {
     const QgsRectangle extent = mMapSettings->visibleExtent();
-    mGeometryCorner = QgsPoint( extent.xMinimum(), extent.yMaximum() );
+    mGeometryCorner = QgsPointXY( extent.xMinimum(), extent.yMaximum() );
     mGeometryMUPP = mMapSettings->mapUnitsPerPoint();
 
     createPolylines();

--- a/src/core/qflinepolygonshape.cpp
+++ b/src/core/qflinepolygonshape.cpp
@@ -72,6 +72,8 @@ void QfLinePolygonShape::createPolylines()
   Qgis::GeometryType geomType = Qgis::GeometryType::Null;
   if ( !geometry.isEmpty() && geometry.type() != Qgis::GeometryType::Point )
   {
+    const QPolygonF boundingRect = QPolygonF( QRectF( QPointF( -MAX_SIZE, -MAX_SIZE ), QPointF( MAX_SIZE, MAX_SIZE ) ) );
+
     geometry = geometry.simplify( mMapSettings->mapUnitsPerPoint() );
     geometry = geometry.makeValid();
     geomType = geometry.type();
@@ -86,6 +88,11 @@ void QfLinePolygonShape::createPolylines()
           for ( const QgsPointXY &point : line )
           {
             polyline << QPointF( ( point.x() - visibleExtent.xMinimum() ) * scaleFactor, ( point.y() - visibleExtent.yMaximum() ) * -scaleFactor );
+          }
+          const QRectF rect = polyline.boundingRect();
+          if ( std::max( { std::abs( rect.left() ), std::abs( rect.right() ), std::abs( rect.top() ), std::abs( rect.bottom() ) } ) > MAX_SIZE )
+          {
+            polyline = polyline.intersected( boundingRect );
           }
           mPolylines.append( polyline );
         }
@@ -105,9 +112,9 @@ void QfLinePolygonShape::createPolylines()
               polyline << QPointF( ( point.x() - visibleExtent.xMinimum() ) * scaleFactor, ( point.y() - visibleExtent.yMaximum() ) * -scaleFactor );
             }
             const QRectF rect = polyline.boundingRect();
-            if ( std::max( { std::abs( rect.left() ), std::abs( rect.right() ), std::abs( rect.top() ), std::abs( rect.bottom() ) } ) > 500000 )
+            if ( std::max( { std::abs( rect.left() ), std::abs( rect.right() ), std::abs( rect.top() ), std::abs( rect.bottom() ) } ) > MAX_SIZE )
             {
-              polyline = polyline.intersected( QPolygonF( QRectF( QPointF( -500000, -500000 ), QPointF( 500000, 500000 ) ) ) );
+              polyline = polyline.intersected( boundingRect );
             }
             mPolylines.append( polyline );
           }
@@ -200,7 +207,7 @@ void QfLinePolygonShape::updateTransform()
   if ( !mDirty && !mGeometryCorner.isEmpty() )
   {
     const QgsPointXY pixelCorner = mMapSettings->coordinateToScreen( mGeometryCorner );
-    mDirty = std::abs( x() ) > 250000 || std::abs( y() ) > 250000;
+    mDirty = std::abs( x() ) > MAX_OFFSET || std::abs( y() ) > MAX_OFFSET;
   }
 
   if ( mDirty )

--- a/src/core/qflinepolygonshape.h
+++ b/src/core/qflinepolygonshape.h
@@ -94,6 +94,9 @@ class QfLinePolygonShape : public QQuickItem
     double mGeometryMUPP = 0.0;
     QList<QPolygonF> mPolylines;
     Qgis::GeometryType mPolylinesType = Qgis::GeometryType::Null;
+
+    static constexpr double MAX_SIZE = 250000;
+    static constexpr double MAX_OFFSET = 200000;
 };
 
 #endif // QFLINEPOLYGONSHAPE_H

--- a/src/core/qflinepolygonshape.h
+++ b/src/core/qflinepolygonshape.h
@@ -90,7 +90,7 @@ class QfLinePolygonShape : public QQuickItem
     bool mDirty = false;
     QgsQuickMapSettings *mMapSettings = nullptr;
     QfGeometryWrapper *mGeometry = nullptr;
-    QgsPoint mGeometryCorner;
+    QgsPointXY mGeometryCorner;
     double mGeometryMUPP = 0.0;
     QList<QPolygonF> mPolylines;
     Qgis::GeometryType mPolylinesType = Qgis::GeometryType::Null;

--- a/src/core/qfrubberbandshape.cpp
+++ b/src/core/qfrubberbandshape.cpp
@@ -191,7 +191,7 @@ void QfRubberbandShape::updateTransform()
   if ( !mDirty && !mGeometryCorner.isEmpty() )
   {
     const QgsPointXY pixelCorner = mMapSettings->coordinateToScreen( mGeometryCorner );
-    mDirty = std::abs( x() ) > 250000 || std::abs( y() ) > 250000;
+    mDirty = std::abs( x() ) > MAX_OFFSET || std::abs( y() ) > MAX_OFFSET;
   }
 
   if ( mDirty )
@@ -261,9 +261,10 @@ void QfRubberbandShape::createPolylines()
   }
 
   const QRectF rect = polyline.boundingRect();
-  if ( std::max( { std::abs( rect.left() ), std::abs( rect.right() ), std::abs( rect.top() ), std::abs( rect.bottom() ) } ) > 500000 )
+  if ( std::max( { std::abs( rect.left() ), std::abs( rect.right() ), std::abs( rect.top() ), std::abs( rect.bottom() ) } ) > MAX_SIZE )
   {
-    polyline = polyline.intersected( QPolygonF( QRectF( QPointF( -500000, -500000 ), QPointF( 500000, 500000 ) ) ) );
+    const QPolygonF boundingRect( QRectF( QPointF( -MAX_SIZE, -MAX_SIZE ), QPointF( MAX_SIZE, MAX_SIZE ) ) );
+    polyline = polyline.intersected( boundingRect );
   }
 
   mPolylines.append( polyline );

--- a/src/core/qfrubberbandshape.cpp
+++ b/src/core/qfrubberbandshape.cpp
@@ -188,10 +188,16 @@ void QfRubberbandShape::updateTransform()
   if ( !mMapSettings )
     return;
 
+  if ( !mDirty && !mGeometryCorner.isEmpty() )
+  {
+    const QgsPointXY pixelCorner = mMapSettings->coordinateToScreen( mGeometryCorner );
+    mDirty = std::abs( x() ) > 250000 || std::abs( y() ) > 250000;
+  }
+
   if ( mDirty )
   {
     const QgsRectangle extent = mMapSettings->visibleExtent();
-    mGeometryCorner = QgsPoint( extent.xMinimum(), extent.yMaximum() );
+    mGeometryCorner = QgsPointXY( extent.xMinimum(), extent.yMaximum() );
     mGeometryMUPP = mMapSettings->mapUnitsPerPoint();
 
     createPolylines();
@@ -253,6 +259,13 @@ void QfRubberbandShape::createPolylines()
   {
     polyline << QPointF( ( point.x() - visibleExtent.xMinimum() ) * scaleFactor, ( point.y() - visibleExtent.yMaximum() ) * -scaleFactor );
   }
+
+  const QRectF rect = polyline.boundingRect();
+  if ( std::max( { std::abs( rect.left() ), std::abs( rect.right() ), std::abs( rect.top() ), std::abs( rect.bottom() ) } ) > 500000 )
+  {
+    polyline = polyline.intersected( QPolygonF( QRectF( QPointF( -500000, -500000 ), QPointF( 500000, 500000 ) ) ) );
+  }
+
   mPolylines.append( polyline );
 
   if ( geomType != mPolylinesType )

--- a/src/core/qfrubberbandshape.h
+++ b/src/core/qfrubberbandshape.h
@@ -141,6 +141,9 @@ class QfRubberbandShape : public QQuickItem
     double mGeometryMUPP = 0.0;
     QList<QPolygonF> mPolylines;
     Qgis::GeometryType mPolylinesType = Qgis::GeometryType::Null;
+
+    static constexpr double MAX_SIZE = 250000;
+    static constexpr double MAX_OFFSET = 200000;
 };
 
 

--- a/src/core/qfrubberbandshape.h
+++ b/src/core/qfrubberbandshape.h
@@ -137,7 +137,7 @@ class QfRubberbandShape : public QQuickItem
     QColor mOutlineColor = QColor( 255, 255, 255, 100 );
     float mWidth = 4;
     Qgis::GeometryType mGeometryType = Qgis::GeometryType::Null;
-    QgsPoint mGeometryCorner;
+    QgsPointXY mGeometryCorner;
     double mGeometryMUPP = 0.0;
     QList<QPolygonF> mPolylines;
     Qgis::GeometryType mPolylinesType = Qgis::GeometryType::Null;

--- a/src/core/qgsquick/qgsquickmapsettings.cpp
+++ b/src/core/qgsquick/qgsquickmapsettings.cpp
@@ -332,6 +332,14 @@ QPointF QgsQuickMapSettings::coordinateToScreen( const QgsPoint &point ) const
   return pp.toQPointF();
 }
 
+QPointF QgsQuickMapSettings::coordinateToScreen( const QgsPointXY &point ) const
+{
+  QgsPointXY pp = mMapSettings.mapToPixel().transform( point );
+  pp.setX( pp.x() / devicePixelRatio() );
+  pp.setY( pp.y() / devicePixelRatio() );
+  return pp.toQPointF();
+}
+
 QgsPoint QgsQuickMapSettings::screenToCoordinate( const QPointF &point ) const
 {
   const QgsPointXY pp = mMapSettings.mapToPixel().toMapCoordinates( point.x() * devicePixelRatio(), point.y() * devicePixelRatio() );

--- a/src/core/qgsquick/qgsquickmapsettings.h
+++ b/src/core/qgsquick/qgsquickmapsettings.h
@@ -211,11 +211,20 @@ class QFIELD_CORE_EXPORT QgsQuickMapSettings : public QObject
     /**
      * Convert a map coordinate to screen pixel coordinates
      *
-     * \param point A coordinate in map coordinates
+     * \param point A QgsPoint coordinate in map coordinates
      *
      * \return A coordinate in pixel / screen space
      */
     Q_INVOKABLE QPointF coordinateToScreen( const QgsPoint &point ) const;
+
+    /**
+     * Convert a map coordinate to screen pixel coordinates
+     *
+     * \param point A QgsPointXY coordinate in map coordinates
+     *
+     * \return A coordinate in pixel / screen space
+     */
+    Q_INVOKABLE QPointF coordinateToScreen( const QgsPointXY &point ) const;
 
     /**
      * Convert a screen coordinate to a map coordinate


### PR DESCRIPTION
Backport #7913
 **Authored by:** @nirvn