### PR TITLE
Support geographic CRS when sizing and scaling 3D terrain

### DIFF
--- a/src/3d/qf3dterrainprovider.cpp
+++ b/src/3d/qf3dterrainprovider.cpp
@@ -102,6 +102,49 @@ void Qf3DTerrainProvider::setForceSquareSize( bool forceSquareSize )
   updateFromMapSettings();
 }
 
+QSizeF Qf3DTerrainProvider::extentSizeInMeters( const QgsRectangle &extent ) const
+{
+  const QgsCoordinateReferenceSystem mapCrs = mMapSettings ? mMapSettings->mapSettings().destinationCrs() : QgsCoordinateReferenceSystem();
+  if ( extent.isEmpty() || !mapCrs.isGeographic() )
+  {
+    return QSizeF( extent.width(), extent.height() );
+  }
+
+  const QgsCoordinateReferenceSystem mercatorCrs( QStringLiteral( "EPSG:3857" ) );
+
+  QgsRectangle degreeExtent = extent;
+  const QgsRectangle mercatorBounds = mercatorCrs.bounds();
+  if ( !mercatorBounds.isEmpty() )
+  {
+    degreeExtent.setYMinimum( std::max( degreeExtent.yMinimum(), mercatorBounds.yMinimum() ) );
+    degreeExtent.setYMaximum( std::min( degreeExtent.yMaximum(), mercatorBounds.yMaximum() ) );
+    if ( degreeExtent.isEmpty() )
+    {
+      return QSizeF( extent.width(), extent.height() );
+    }
+  }
+
+  try
+  {
+    const QgsCoordinateTransform transform( mapCrs, mercatorCrs, mMapSettings->mapSettings().transformContext() );
+    const QgsRectangle mercatorExtent = transform.transformBoundingBox( degreeExtent );
+    return QSizeF( mercatorExtent.width(), mercatorExtent.height() );
+  }
+  catch ( const QgsCsException & )
+  {
+    return QSizeF( extent.width(), extent.height() );
+  }
+}
+
+void Qf3DTerrainProvider::setNormalizedDataExtent( const QgsRectangle &extent )
+{
+  mNormalizedDataExtent = extent;
+
+  const QSizeF sizeInMeters = extentSizeInMeters( extent );
+  const double longestSide = std::max( sizeInMeters.width(), sizeInMeters.height() );
+  mHeightScale = longestSide > 0 ? mBaseSize / longestSide : 1.0;
+}
+
 void Qf3DTerrainProvider::updateFromMapSettings()
 {
   if ( !mMapSettings || !mProject )
@@ -110,33 +153,38 @@ void Qf3DTerrainProvider::updateFromMapSettings()
   }
 
   QgsRectangle adjustedExtent = mMapSettings->mapSettings().visibleExtent();
-  if ( mForceSquareSize )
+  QSizeF sizeInMeters = extentSizeInMeters( adjustedExtent );
+  if ( mForceSquareSize && sizeInMeters.width() > 0 && sizeInMeters.height() > 0 )
   {
-    if ( adjustedExtent.width() >= adjustedExtent.height() )
+    if ( sizeInMeters.width() >= sizeInMeters.height() )
     {
-      const double adjustment = ( adjustedExtent.width() - adjustedExtent.height() ) / 2;
+      const double adjustment = ( sizeInMeters.width() - sizeInMeters.height() ) * adjustedExtent.height() / sizeInMeters.height() / 2;
       adjustedExtent.setYMinimum( adjustedExtent.yMinimum() - adjustment );
       adjustedExtent.setYMaximum( adjustedExtent.yMaximum() + adjustment );
     }
     else
     {
-      const double adjustment = ( adjustedExtent.height() - adjustedExtent.width() ) / 2;
+      const double adjustment = ( sizeInMeters.height() - sizeInMeters.width() ) * adjustedExtent.width() / sizeInMeters.width() / 2;
       adjustedExtent.setXMinimum( adjustedExtent.xMinimum() - adjustment );
       adjustedExtent.setXMaximum( adjustedExtent.xMaximum() + adjustment );
     }
+    sizeInMeters = extentSizeInMeters( adjustedExtent );
   }
 
   if ( mExtent != adjustedExtent )
   {
     mExtent = adjustedExtent;
 
-    if ( mExtent.width() >= mExtent.height() )
+    if ( sizeInMeters.width() > 0 && sizeInMeters.height() > 0 )
     {
-      mSize = QSizeF( mBaseSize, mExtent.height() * mBaseSize / mExtent.width() );
-    }
-    else
-    {
-      mSize = QSizeF( mExtent.width() * mBaseSize / mExtent.height(), mBaseSize );
+      if ( sizeInMeters.width() >= sizeInMeters.height() )
+      {
+        mSize = QSizeF( mBaseSize, sizeInMeters.height() * mBaseSize / sizeInMeters.width() );
+      }
+      else
+      {
+        mSize = QSizeF( sizeInMeters.width() * mBaseSize / sizeInMeters.height(), mBaseSize );
+      }
     }
 
     emit extentChanged();
@@ -210,9 +258,7 @@ double Qf3DTerrainProvider::heightAt( double x, double y ) const
 double Qf3DTerrainProvider::normalizedHeightAt( double x, double y ) const
 {
   const double realHeight = heightAt( x, y );
-  const double extentSize = std::max( mNormalizedDataExtent.width(), mNormalizedDataExtent.height() );
-  const double scale = ( mBaseSize / extentSize );
-  return ( realHeight - mMinRealHeight ) * scale / mOffsetScale;
+  return ( realHeight - mMinRealHeight ) * mHeightScale / mOffsetScale;
 }
 
 QVector3D Qf3DTerrainProvider::geoTo3D( double geoX, double geoY, float heightOffset ) const
@@ -247,9 +293,7 @@ QVector3D Qf3DTerrainProvider::geoTo3D( const QgsPoint &geoPoint, float heightOf
   }
   else
   {
-    const double extentSize = std::max( mNormalizedDataExtent.width(), mNormalizedDataExtent.height() );
-    const double scale = ( mBaseSize / extentSize );
-    y3d = ( geoPoint.z() - mMinRealHeight ) * scale / mOffsetScale;
+    y3d = ( geoPoint.z() - mMinRealHeight ) * mHeightScale / mOffsetScale;
   }
   y3d += heightOffset;
 
@@ -275,7 +319,7 @@ void Qf3DTerrainProvider::calcNormalizedData()
   if ( mExtent.isEmpty() || !mTerrainProvider )
   {
     mNormalizedData.fill( 0.0, static_cast<qsizetype>( mGridSize.width() ) * mGridSize.height() );
-    mNormalizedDataExtent = mExtent;
+    setNormalizedDataExtent( mExtent );
 
     emit normalizedDataChanged();
     emit terrainDataReady();
@@ -331,7 +375,7 @@ void Qf3DTerrainProvider::calcNormalizedData()
   if ( ( !rasterProvider && !terrainProvider ) || extent.isEmpty() )
   {
     mNormalizedData.fill( 0.0, static_cast<qsizetype>( mGridSize.width() ) * mGridSize.height() );
-    mNormalizedDataExtent = mExtent;
+    setNormalizedDataExtent( mExtent );
 
     emit normalizedDataChanged();
     emit terrainDataReady();
@@ -526,16 +570,14 @@ void Qf3DTerrainProvider::onTerrainDataCalculated()
   mMinRealHeight = *minmax.first;
   mMaxRealHeight = *minmax.second;
 
-  const double extentSize = std::max( mExtent.width(), mExtent.height() );
-  const double scale = ( mBaseSize / extentSize );
+  setNormalizedDataExtent( mFutureExtent );
 
   mNormalizedData.clear();
   mNormalizedData.reserve( heights.size() );
   for ( const double h : heights )
   {
-    mNormalizedData.append( ( h - mMinRealHeight ) * scale );
+    mNormalizedData.append( ( h - mMinRealHeight ) * mHeightScale );
   }
-  mNormalizedDataExtent = mFutureExtent;
 
   mIsLoading = false;
   emit isLoadingChanged();
@@ -553,8 +595,9 @@ void Qf3DTerrainProvider::updateExtentFromOffsets()
   }
   if ( mOffsetVector.x() != 0 || mOffsetVector.y() != 0 )
   {
-    const double mupp = mExtent.width() / mSize.width();
-    QgsVector panVector( -mOffsetVector.x() * mupp, mOffsetVector.z() * mupp );
+    const double mapUnitsPerSceneUnitX = mExtent.width() / mSize.width();
+    const double mapUnitsPerSceneUnitZ = mExtent.height() / mSize.height();
+    QgsVector panVector( -mOffsetVector.x() * mapUnitsPerSceneUnitX, mOffsetVector.z() * mapUnitsPerSceneUnitZ );
     modifiedExtent += panVector;
   }
 

--- a/src/3d/qf3dterrainprovider.cpp
+++ b/src/3d/qf3dterrainprovider.cpp
@@ -104,36 +104,31 @@ void Qf3DTerrainProvider::setForceSquareSize( bool forceSquareSize )
 
 QSizeF Qf3DTerrainProvider::extentSizeInMeters( const QgsRectangle &extent ) const
 {
+  if ( extent.isEmpty() )
+  {
+    return QSizeF();
+  }
+
   const QgsCoordinateReferenceSystem mapCrs = mMapSettings ? mMapSettings->mapSettings().destinationCrs() : QgsCoordinateReferenceSystem();
-  if ( extent.isEmpty() || !mapCrs.isGeographic() )
+  if ( !mapCrs.isGeographic() )
   {
     return QSizeF( extent.width(), extent.height() );
   }
 
   const QgsCoordinateReferenceSystem mercatorCrs( QStringLiteral( "EPSG:3857" ) );
 
-  QgsRectangle degreeExtent = extent;
-  const QgsRectangle mercatorBounds = mercatorCrs.bounds();
-  if ( !mercatorBounds.isEmpty() )
-  {
-    degreeExtent.setYMinimum( std::max( degreeExtent.yMinimum(), mercatorBounds.yMinimum() ) );
-    degreeExtent.setYMaximum( std::min( degreeExtent.yMaximum(), mercatorBounds.yMaximum() ) );
-    if ( degreeExtent.isEmpty() )
-    {
-      return QSizeF( extent.width(), extent.height() );
-    }
-  }
-
+  QSizeF extentSize;
   try
   {
     const QgsCoordinateTransform transform( mapCrs, mercatorCrs, mMapSettings->mapSettings().transformContext() );
-    const QgsRectangle mercatorExtent = transform.transformBoundingBox( degreeExtent );
-    return QSizeF( mercatorExtent.width(), mercatorExtent.height() );
+    const QgsRectangle mercatorExtent = transform.transformBoundingBox( extent );
+    extentSize = QSizeF( mercatorExtent.width(), mercatorExtent.height() );
   }
   catch ( const QgsCsException & )
   {
-    return QSizeF( extent.width(), extent.height() );
+    extentSize = QSizeF( extent.width(), extent.height() );
   }
+  return extentSize;
 }
 
 void Qf3DTerrainProvider::setNormalizedDataExtent( const QgsRectangle &extent )

--- a/src/3d/qf3dterrainprovider.h
+++ b/src/3d/qf3dterrainprovider.h
@@ -203,6 +203,10 @@ class Qf3DTerrainProvider : public QObject
   private:
     void updateTerrainProvider();
     void updateFromMapSettings();
+
+    QSizeF extentSizeInMeters( const QgsRectangle &extent ) const;
+    void setNormalizedDataExtent( const QgsRectangle &extent );
+
     void updateExtentFromOffsets();
     void calculateResolution();
     void generateData();
@@ -239,6 +243,9 @@ class Qf3DTerrainProvider : public QObject
 
     double mMinRealHeight = 0.0;
     double mMaxRealHeight = 0.0;
+
+    //! Scene units per meter of elevation, derived from the terrain data extent
+    double mHeightScale = 1.0;
 
     QFutureWatcher<QVector<double>> *mFutureWatcher = nullptr;
     QgsRectangle mFutureExtent;

--- a/src/app/qml/QfDashBoard.qml
+++ b/src/app/qml/QfDashBoard.qml
@@ -348,7 +348,7 @@ Drawer {
           return "";
         }
 
-        property string projectCoordinateReferenceSystem: qgisProject ? qgisProject.crs.authid + ": " + qgisProject.crs.description : ""
+        property string projectCoordinateReferenceSystem: qgisProject ? qgisProject.crs.authid + " — " + qgisProject.crs.description : ""
 
         Layout.alignment: Qt.AlignVCenter
         visible: true

--- a/src/app/qml/QfDashBoard.qml
+++ b/src/app/qml/QfDashBoard.qml
@@ -348,8 +348,10 @@ Drawer {
           return "";
         }
 
+        property string projectCoordinateReferenceSystem: qgisProject ? QfCoordinateReferenceSystemUtils.userFriendlyIdentifier(qgisProject.crs) : ""
+
         Layout.alignment: Qt.AlignVCenter
-        visible: projectDescription != "" || projectAuthor != ""
+        visible: true
         width: 36
         height: 36
         padding: 0
@@ -363,6 +365,7 @@ Drawer {
           informationPopup.descriptionFormat = Text.MarkdownText;
           informationPopup.description = projectDescription;
           informationPopup.author = projectAuthor;
+          informationPopup.coordinateReferenceSystem = projectCoordinateReferenceSystem;
 
           informationPopup.open();
         }

--- a/src/app/qml/QfDashBoard.qml
+++ b/src/app/qml/QfDashBoard.qml
@@ -348,7 +348,7 @@ Drawer {
           return "";
         }
 
-        property string projectCoordinateReferenceSystem: qgisProject ? QfCoordinateReferenceSystemUtils.userFriendlyIdentifier(qgisProject.crs) : ""
+        property string projectCoordinateReferenceSystem: qgisProject ? qgisProject.crs.authid + ": " + qgisProject.crs.description : ""
 
         Layout.alignment: Qt.AlignVCenter
         visible: true

--- a/src/core/utils/qfcoordinatereferencesystemutils.h
+++ b/src/core/utils/qfcoordinatereferencesystemutils.h
@@ -52,9 +52,6 @@ class QFIELD_CORE_EXPORT QfCoordinateReferenceSystemUtils : public QObject
 
     //! Returns whether the default coordinate order of a given \a crs is XY
     static Q_INVOKABLE bool defaultCoordinateOrderForCrsIsXY( const QgsCoordinateReferenceSystem &crs );
-
-    //! Returns a user friendly identifier for a given \a crs, such as "EPSG:4326 - WGS 84"
-    static Q_INVOKABLE QString userFriendlyIdentifier( const QgsCoordinateReferenceSystem &crs ) { return crs.userFriendlyIdentifier(); }
 };
 
 #endif // QFCOORDINATEREFERENCESYSTEMUTILS_H

--- a/src/core/utils/qfcoordinatereferencesystemutils.h
+++ b/src/core/utils/qfcoordinatereferencesystemutils.h
@@ -52,6 +52,9 @@ class QFIELD_CORE_EXPORT QfCoordinateReferenceSystemUtils : public QObject
 
     //! Returns whether the default coordinate order of a given \a crs is XY
     static Q_INVOKABLE bool defaultCoordinateOrderForCrsIsXY( const QgsCoordinateReferenceSystem &crs );
+
+    //! Returns a user friendly identifier for a given \a crs, such as "EPSG:4326 - WGS 84"
+    static Q_INVOKABLE QString userFriendlyIdentifier( const QgsCoordinateReferenceSystem &crs ) { return crs.userFriendlyIdentifier(); }
 };
 
 #endif // QFCOORDINATEREFERENCESYSTEMUTILS_H

--- a/src/gui/qml/QfInformationPopup.qml
+++ b/src/gui/qml/QfInformationPopup.qml
@@ -16,6 +16,7 @@ QfPopup {
   property alias description: descriptionText.text
   property alias descriptionFormat: descriptionText.textFormat
   property alias author: authorText.text
+  property string coordinateReferenceSystem
 
   parent: mainWindow.contentItem
   width: Math.min(450, mainWindow.width - QfTheme.popupScreenEdgeHorizontalMargin)
@@ -81,6 +82,30 @@ QfPopup {
           text: ""
           font: QfTheme.defaultFont
           color: QfTheme.mainTextColor
+        }
+
+        Label {
+          id: coordinateReferenceSystemChip
+          Layout.alignment: Qt.AlignLeft
+          Layout.maximumWidth: popupLayout.width
+          visible: popup.coordinateReferenceSystem !== ""
+
+          leftPadding: 10
+          rightPadding: 10
+          topPadding: 6
+          bottomPadding: 6
+
+          wrapMode: Text.Wrap
+          text: popup.coordinateReferenceSystem
+          font: QfTheme.tipFont
+          color: QfTheme.secondaryTextColor
+
+          background: Rectangle {
+            radius: 6
+            color: "transparent"
+            border.width: 1
+            border.color: QfTheme.controlBorderColor
+          }
         }
 
         ColumnLayout {

--- a/src/gui/qml/QfInformationPopup.qml
+++ b/src/gui/qml/QfInformationPopup.qml
@@ -85,27 +85,14 @@ QfPopup {
         }
 
         Label {
-          id: coordinateReferenceSystemChip
-          Layout.alignment: Qt.AlignLeft
-          Layout.maximumWidth: popupLayout.width
+          id: coordinateReferenceSystemText
+          Layout.fillWidth: true
           visible: popup.coordinateReferenceSystem !== ""
-
-          leftPadding: 10
-          rightPadding: 10
-          topPadding: 6
-          bottomPadding: 6
 
           wrapMode: Text.Wrap
           text: popup.coordinateReferenceSystem
           font: QfTheme.tipFont
           color: QfTheme.secondaryTextColor
-
-          background: Rectangle {
-            radius: 6
-            color: "transparent"
-            border.width: 1
-            border.color: QfTheme.controlBorderColor
-          }
         }
 
         ColumnLayout {

--- a/src/gui/qml/QfLegend.qml
+++ b/src/gui/qml/QfLegend.qml
@@ -368,6 +368,7 @@ ListView {
               informationPopup.descriptionFormat = Text.RichText;
               informationPopup.description = Notes;
               informationPopup.author = "";
+              informationPopup.coordinateReferenceSystem = "";
               informationPopup.open();
             }
           }


### PR DESCRIPTION
### 🚀 Description

Adds support for projects with a degree based CRS in the 3D terrain.

### ✨ Key changes

- extent size is measured in meters now (via 3857), so terrain is not stretched
- height scale is calculated in one place instead of 3
- project CRS is shown in the project info popup

### demo

|  |  |
| --- | --- |
| <img width="271" alt="image" src="https://github.com/user-attachments/assets/a88c74d9-5a16-4e80-b487-10111716c3f2" /> | <img width="271" alt="image" src="https://github.com/user-attachments/assets/5802f98c-5f8f-47e2-8894-f28211fc5951" /> |
