### PR TITLE
Extract the map compass into a `QfCompassDial` component

### DIFF
--- a/resources/theme/theme.json
+++ b/resources/theme/theme.json
@@ -80,6 +80,7 @@
     "vertexSelectedColorSemiOpaque": "#200000FF",
     "vertexNewColor": "#4CAF50",
     "vertexNewColorSemiOpaque": "#404CAF50",
-    "processingPreview": "#99000000"
+    "processingPreview": "#99000000",
+    "shadowColor": "#99000000"
   }
 }

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -2178,70 +2178,17 @@ ApplicationWindow {
 
     QfToolButton {
       id: compassArrow
-      rotation: mapCanvas.mapSettings.rotation
-      visible: rotation !== 0 && stateMachine.state !== '3d'
+
+      visible: mapCanvas.mapSettings.rotation !== 0 && stateMachine.state !== '3d'
       anchors.left: parent.left
       anchors.bottom: parent.bottom
       anchors.leftMargin: mainWindow.sceneLeftMargin + 4
       anchors.bottomMargin: 54
       round: true
-      bgcolor: QfTheme.toolButtonBackgroundSemiOpaqueColor
 
-      Shape {
-        width: compassArrow.width
-        height: compassArrow.height
-
-        ShapePath {
-          strokeWidth: 3
-          strokeColor: "transparent"
-          strokeStyle: ShapePath.SolidLine
-          fillColor: QfTheme.mainColor
-          joinStyle: ShapePath.MiterJoin
-          startX: compassArrow.width / 2
-          startY: 8
-          PathLine {
-            x: compassArrow.width / 2 + 6
-            y: compassArrow.height / 2
-          }
-          PathLine {
-            x: compassArrow.width / 2
-            y: compassArrow.height / 2 - 2
-          }
-          PathLine {
-            x: compassArrow.width / 2 - 6
-            y: compassArrow.height / 2
-          }
-          PathLine {
-            x: compassArrow.width / 2
-            y: 8
-          }
-        }
-
-        ShapePath {
-          strokeWidth: 3
-          strokeColor: "transparent"
-          strokeStyle: ShapePath.SolidLine
-          fillColor: QfTheme.toolButtonColor
-          joinStyle: ShapePath.MiterJoin
-          startX: compassArrow.width / 2
-          startY: compassArrow.height - 8
-          PathLine {
-            x: compassArrow.width / 2 + 6
-            y: compassArrow.height / 2
-          }
-          PathLine {
-            x: compassArrow.width / 2
-            y: compassArrow.height / 2 + 2
-          }
-          PathLine {
-            x: compassArrow.width / 2 - 6
-            y: compassArrow.height / 2
-          }
-          PathLine {
-            x: compassArrow.width / 2
-            y: compassArrow.height - 8
-          }
-        }
+      QfCompassDial {
+        anchors.fill: parent
+        mapRotation: mapCanvas.mapSettings.rotation
       }
 
       onClicked: {

--- a/src/gui/qftheme.cpp
+++ b/src/gui/qftheme.cpp
@@ -104,6 +104,7 @@ void QfTheme::loadFromJson()
   set( mVertexNewColor, "vertexNewColor" );
   set( mVertexNewColorSemiOpaque, "vertexNewColorSemiOpaque" );
   set( mProcessingPreview, "processingPreview" );
+  set( mShadowColor, "shadowColor" );
 
   emit themeDataLoaded();
 }

--- a/src/gui/qftheme.h
+++ b/src/gui/qftheme.h
@@ -104,6 +104,7 @@ class QFIELD_GUI_EXPORT QfTheme final : public QObject
     Q_PROPERTY( QColor vertexNewColor READ vertexNewColor NOTIFY themeDataLoaded )
     Q_PROPERTY( QColor vertexNewColorSemiOpaque READ vertexNewColorSemiOpaque NOTIFY themeDataLoaded )
     Q_PROPERTY( QColor processingPreview READ processingPreview NOTIFY themeDataLoaded )
+    Q_PROPERTY( QColor shadowColor READ shadowColor NOTIFY themeDataLoaded )
 
     Q_PROPERTY( qreal fontScale READ fontScale WRITE setFontScale NOTIFY fontScaleChanged )
 
@@ -289,6 +290,7 @@ class QFIELD_GUI_EXPORT QfTheme final : public QObject
     QColor vertexNewColor() const { return mVertexNewColor; }
     QColor vertexNewColorSemiOpaque() const { return mVertexNewColorSemiOpaque; }
     QColor processingPreview() const { return mProcessingPreview; }
+    QColor shadowColor() const { return mShadowColor; }
 
     QString appearance() const { return mAppearance; }
     void setAppearance( const QString &appearance );
@@ -413,6 +415,7 @@ class QFIELD_GUI_EXPORT QfTheme final : public QObject
     QColor mVertexNewColor;
     QColor mVertexNewColorSemiOpaque;
     QColor mProcessingPreview;
+    QColor mShadowColor;
 
     QString mAppearance;
     bool mDarkTheme = false;

--- a/src/gui/qml/CMakeLists.txt
+++ b/src/gui/qml/CMakeLists.txt
@@ -19,6 +19,7 @@ set(QFIELD_GUI_QML_FILES
     QfCogoOperations.qml
     QfCollapsibleMessage.qml
     QfComboBox.qml
+    QfCompassDial.qml
     QfConfirmationToolbar.qml
     QfContainerCard.qml
     QfDialog.qml

--- a/src/gui/qml/QfBookmarkRenderer.qml
+++ b/src/gui/qml/QfBookmarkRenderer.qml
@@ -120,7 +120,7 @@ Item {
           layer.effect: QfDropShadow {
             transparentBorder: true
             radius: 8
-            color: "#99000000"
+            color: QfTheme.shadowColor
             horizontalOffset: 0
             verticalOffset: 0
           }

--- a/src/gui/qml/QfCompassDial.qml
+++ b/src/gui/qml/QfCompassDial.qml
@@ -23,7 +23,7 @@ Item {
   property color tickColor: QfTheme.lightGray
 
   //! Color of the dial disc and the needle hub ring
-  property color dialColor: QfTheme.darkGray
+  property color backgroundColor: QfTheme.toolButtonBackgroundColor
 
   readonly property real centerX: width / 2
   readonly property real centerY: height / 2
@@ -35,19 +35,10 @@ Item {
   Rectangle {
     anchors.fill: parent
     radius: width / 2
-    color: Qt.hsla(compassDial.dialColor.hslHue, compassDial.dialColor.hslSaturation, compassDial.dialColor.hslLightness, 0.8)
+    color: compassDial.backgroundColor
     border.color: compassDial.southColor
     border.width: Math.max(1.5, width * 0.028)
     antialiasing: true
-
-    layer.enabled: true
-    layer.effect: QfDropShadow {
-      transparentBorder: true
-      samples: 16
-      color: QfTheme.shadowColor
-      horizontalOffset: 0
-      verticalOffset: 0
-    }
   }
 
   Repeater {
@@ -114,7 +105,7 @@ Item {
     height: compassDial.hubRadius * 2
     radius: compassDial.hubRadius
     color: QfTheme.light
-    border.color: compassDial.dialColor
+    border.color: compassDial.backgroundColor
     border.width: Math.max(1, compassDial.hubRadius * 0.45)
     antialiasing: true
   }

--- a/src/gui/qml/QfCompassDial.qml
+++ b/src/gui/qml/QfCompassDial.qml
@@ -5,7 +5,7 @@ import org.qfield.gui
 /**
  * A compass dial face made of a two-toned needle surrounded by evenly spaced
  * tick marks.
- * \ingroup qml
+ * \ingroup qml_gui
  */
 Item {
   id: compassDial
@@ -20,7 +20,7 @@ Item {
   property color southColor: QfTheme.gray
 
   //! Color of the tick marks
-  property color markingsColor: QfTheme.lightGray
+  property color tickColor: QfTheme.lightGray
 
   //! Color of the dial disc and the needle hub ring
   property color dialColor: QfTheme.darkGray
@@ -44,9 +44,9 @@ Item {
     layer.effect: QfDropShadow {
       transparentBorder: true
       samples: 16
-      color: "#66000000"
+      color: QfTheme.shadowColor
       horizontalOffset: 0
-      verticalOffset: 1
+      verticalOffset: 0
     }
   }
 
@@ -63,7 +63,7 @@ Item {
       height: compassDial.height * 0.055
       radius: width / 2
       rotation: angleDegrees
-      color: compassDial.markingsColor
+      color: compassDial.tickColor
       opacity: 0.45
       antialiasing: true
     }

--- a/src/gui/qml/QfCompassDial.qml
+++ b/src/gui/qml/QfCompassDial.qml
@@ -1,0 +1,121 @@
+import QtQuick
+import QtQuick.Shapes
+import org.qfield.gui
+
+/**
+ * A compass dial face made of a two-toned needle surrounded by evenly spaced
+ * tick marks.
+ * \ingroup qml
+ */
+Item {
+  id: compassDial
+
+  //! Map canvas rotation in degrees represented by the needle
+  property real mapRotation: 0
+
+  //! Color of the needle half pointing north
+  property color northColor: QfTheme.mainColor
+
+  //! Color of the needle half pointing south and the rim circling the dial disc
+  property color southColor: QfTheme.gray
+
+  //! Color of the tick marks
+  property color markingsColor: QfTheme.lightGray
+
+  //! Color of the dial disc and the needle hub ring
+  property color dialColor: QfTheme.darkGray
+
+  readonly property real centerX: width / 2
+  readonly property real centerY: height / 2
+  readonly property real needleHalfLength: height * 0.26
+  readonly property real needleHalfWidth: width * 0.09
+  readonly property real hubRadius: height * 0.085
+  readonly property real tickRadius: height * 0.37
+
+  Rectangle {
+    anchors.fill: parent
+    radius: width / 2
+    color: Qt.hsla(compassDial.dialColor.hslHue, compassDial.dialColor.hslSaturation, compassDial.dialColor.hslLightness, 0.8)
+    border.color: compassDial.southColor
+    border.width: Math.max(1.5, width * 0.028)
+    antialiasing: true
+
+    layer.enabled: true
+    layer.effect: QfDropShadow {
+      transparentBorder: true
+      samples: 16
+      color: "#66000000"
+      horizontalOffset: 0
+      verticalOffset: 1
+    }
+  }
+
+  Repeater {
+    model: 8
+
+    delegate: Rectangle {
+      readonly property real angleDegrees: index * 45
+      readonly property real angleRadians: angleDegrees * Math.PI / 180
+
+      x: compassDial.centerX + compassDial.tickRadius * Math.sin(angleRadians) - width / 2
+      y: compassDial.centerY - compassDial.tickRadius * Math.cos(angleRadians) - height / 2
+      width: Math.max(1.5, compassDial.width * 0.032)
+      height: compassDial.height * 0.055
+      radius: width / 2
+      rotation: angleDegrees
+      color: compassDial.markingsColor
+      opacity: 0.45
+      antialiasing: true
+    }
+  }
+
+  Shape {
+    anchors.fill: parent
+    rotation: compassDial.mapRotation
+    preferredRendererType: Shape.CurveRenderer
+
+    ShapePath {
+      strokeColor: "transparent"
+      fillColor: compassDial.northColor
+      startX: compassDial.centerX
+      startY: compassDial.centerY - compassDial.needleHalfLength
+
+      PathLine {
+        x: compassDial.centerX + compassDial.needleHalfWidth
+        y: compassDial.centerY
+      }
+      PathLine {
+        x: compassDial.centerX - compassDial.needleHalfWidth
+        y: compassDial.centerY
+      }
+    }
+
+    ShapePath {
+      strokeColor: "transparent"
+      fillColor: compassDial.southColor
+      startX: compassDial.centerX
+      startY: compassDial.centerY + compassDial.needleHalfLength
+
+      PathLine {
+        x: compassDial.centerX + compassDial.needleHalfWidth
+        y: compassDial.centerY
+      }
+      PathLine {
+        x: compassDial.centerX - compassDial.needleHalfWidth
+        y: compassDial.centerY
+      }
+    }
+  }
+
+  Rectangle {
+    x: compassDial.centerX - compassDial.hubRadius
+    y: compassDial.centerY - compassDial.hubRadius
+    width: compassDial.hubRadius * 2
+    height: compassDial.hubRadius * 2
+    radius: compassDial.hubRadius
+    color: QfTheme.light
+    border.color: compassDial.dialColor
+    border.width: Math.max(1, compassDial.hubRadius * 0.45)
+    antialiasing: true
+  }
+}

--- a/src/gui/qml/QfCompassDial.qml
+++ b/src/gui/qml/QfCompassDial.qml
@@ -17,10 +17,10 @@ Item {
   property color northColor: QfTheme.mainColor
 
   //! Color of the needle half pointing south and the rim circling the dial disc
-  property color southColor: QfTheme.gray
+  property color southColor: QfTheme.toolButtonColor
 
   //! Color of the tick marks
-  property color tickColor: QfTheme.lightGray
+  property color tickColor: QfTheme.gray
 
   //! Color of the dial disc and the needle hub ring
   property color backgroundColor: QfTheme.toolButtonBackgroundColor
@@ -36,9 +36,6 @@ Item {
     anchors.fill: parent
     radius: width / 2
     color: compassDial.backgroundColor
-    border.color: compassDial.southColor
-    border.width: Math.max(1.5, width * 0.028)
-    antialiasing: true
   }
 
   Repeater {
@@ -55,8 +52,6 @@ Item {
       radius: width / 2
       rotation: angleDegrees
       color: compassDial.tickColor
-      opacity: 0.45
-      antialiasing: true
     }
   }
 
@@ -96,17 +91,5 @@ Item {
         y: compassDial.centerY
       }
     }
-  }
-
-  Rectangle {
-    x: compassDial.centerX - compassDial.hubRadius
-    y: compassDial.centerY - compassDial.hubRadius
-    width: compassDial.hubRadius * 2
-    height: compassDial.hubRadius * 2
-    radius: compassDial.hubRadius
-    color: QfTheme.light
-    border.color: compassDial.backgroundColor
-    border.width: Math.max(1, compassDial.hubRadius * 0.45)
-    antialiasing: true
   }
 }

--- a/src/gui/qml/QfLocationMarker.qml
+++ b/src/gui/qml/QfLocationMarker.qml
@@ -254,7 +254,7 @@ Item {
     layer.effect: QfDropShadow {
       transparentBorder: true
       samples: 16
-      color: "#99000000"
+      color: QfTheme.shadowColor
       horizontalOffset: 0
       verticalOffset: 0
     }
@@ -280,7 +280,7 @@ Item {
     layer.effect: QfDropShadow {
       transparentBorder: true
       samples: 16
-      color: "#99000000"
+      color: QfTheme.shadowColor
       horizontalOffset: 0
       verticalOffset: 0
     }
@@ -328,7 +328,7 @@ Item {
     layer.effect: QfDropShadow {
       transparentBorder: true
       samples: 16
-      color: "#99000000"
+      color: QfTheme.shadowColor
       horizontalOffset: 0
       verticalOffset: 0
     }

--- a/src/gui/qml/QfNavigationRenderer.qml
+++ b/src/gui/qml/QfNavigationRenderer.qml
@@ -77,7 +77,7 @@ Item {
           layer.effect: QfDropShadow {
             transparentBorder: true
             radius: 8
-            color: "#99000000"
+            color: QfTheme.shadowColor
             horizontalOffset: 0
             verticalOffset: 0
           }
@@ -125,7 +125,7 @@ Item {
           layer.effect: QfDropShadow {
             transparentBorder: true
             radius: 8
-            color: "#99000000"
+            color: QfTheme.shadowColor
             horizontalOffset: 0
             verticalOffset: 0
           }


### PR DESCRIPTION
### 🚀 Description

The compass button at the bottom left of the map is now a proper dial instead of a bare arrow.

### ✨ Key changes

- New `QfCompassDial` component, the arrow markup is out of `QgisMobileapp.qml`.
- Only the needle rotates now, not the whole button.
- Drop shadow color moved into the theme as `shadowColor`, the location marker, navigation and bookmark renderers take it from there too.

### demo

| Before | After |
| --- | --- |
| <img width="271" alt="image" src="https://github.com/user-attachments/assets/c550c4c6-ff99-4e29-a294-f6e341019dac" /> | <img width="271" alt="image" src="https://github.com/user-attachments/assets/dddc34d3-8ded-4039-8b25-cc798c214f37" /> | 

<img width="261" height="109" alt="image" src="https://github.com/user-attachments/assets/36ea981c-877c-410e-9eb3-4211adc29501" />
