### PR TITLE
fix(positioning): improve BLE correction throughput for NTRIP RTK

### DIFF
--- a/src/core/positioning/qfbluetoothlowenergyreceiver.cpp
+++ b/src/core/positioning/qfbluetoothlowenergyreceiver.cpp
@@ -16,10 +16,12 @@
 
 #include "qfbluetoothlowenergyreceiver.h"
 
+#include <QDateTime>
 #include <QDebug>
 #include <QGuiApplication>
 #include <QMetaEnum>
 #include <QTimer>
+#include <QtBluetooth/QLowEnergyConnectionParameters>
 
 // Map of BLE service UUID (key) and a pair of RX (first, incoming) and TX (second, outgoing) characteristics
 QMap<QBluetoothUuid, std::pair<QBluetoothUuid, QBluetoothUuid>> QfBluetoothLowEnergyReceiver::serviceChars = {
@@ -111,10 +113,33 @@ void QfBluetoothLowEnergyReceiver::doConnectDevice()
     connect( mController, qOverload<QLowEnergyController::Error>( &QLowEnergyController::errorOccurred ), this, &QfBluetoothLowEnergyReceiver::controllerErrorOccurred );
     connect( mController, &QLowEnergyController::serviceDiscovered, this, &QfBluetoothLowEnergyReceiver::serviceDiscovered );
     connect( mController, &QLowEnergyController::discoveryFinished, this, &QfBluetoothLowEnergyReceiver::serviceDiscoveryFinished );
+    connect( mController, &QLowEnergyController::mtuChanged, this, [this]( int mtu ) {
+      mBleTxPayloadSize = std::max<qsizetype>( 20, mtu - 3 );
+      qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: MTU changed to %1, BLE TX payload size set to %2" )
+                   .arg( mtu )
+                   .arg( mBleTxPayloadSize );
+    } );
+    connect( mController, &QLowEnergyController::connectionUpdated, this, []( const QLowEnergyConnectionParameters &parameters ) {
+      qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: Connection parameters updated, interval=%1-%2 ms, latency=%3, supervisionTimeout=%4 ms" )
+                   .arg( parameters.minimumInterval() )
+                   .arg( parameters.maximumInterval() )
+                   .arg( parameters.latency() )
+                   .arg( parameters.supervisionTimeout() );
+    } );
   }
 
   setSocketState( QAbstractSocket::ConnectingState );
 
+  const int mtu = mController->mtu();
+  if ( mtu > 3 )
+  {
+    mBleTxPayloadSize = std::max<qsizetype>( 20, mtu - 3 );
+  }
+
+  qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: connectToDevice requested, controller state %1, mtu=%2, txPayload=%3" )
+               .arg( QMetaEnum::fromType<QLowEnergyController::ControllerState>().valueToKey( mController->state() ) )
+               .arg( mtu )
+               .arg( mBleTxPayloadSize );
   mController->connectToDevice();
 }
 
@@ -134,13 +159,41 @@ void QfBluetoothLowEnergyReceiver::doDisconnectDevice()
 
 void QfBluetoothLowEnergyReceiver::deviceConnected()
 {
-  qInfo() << "BluetoothLowEnergyReceiver: Connected, discovering services";
+  const int mtu = mController->mtu();
+  if ( mtu > 3 )
+  {
+    mBleTxPayloadSize = std::max<qsizetype>( 20, mtu - 3 );
+  }
+
+  qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: Connected, discovering services, controller state %1, mtu=%2, txPayload=%3" )
+               .arg( QMetaEnum::fromType<QLowEnergyController::ControllerState>().valueToKey( mController->state() ) )
+               .arg( mtu )
+               .arg( mBleTxPayloadSize );
+
+  QLowEnergyConnectionParameters parameters;
+  parameters.setIntervalRange( 15.0, 30.0 );
+  parameters.setLatency( 0 );
+  parameters.setSupervisionTimeout( 2000 );
+  qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: Requesting faster BLE connection parameters, interval=%1-%2 ms, latency=%3, supervisionTimeout=%4 ms" )
+               .arg( parameters.minimumInterval() )
+               .arg( parameters.maximumInterval() )
+               .arg( parameters.latency() )
+               .arg( parameters.supervisionTimeout() );
+  mController->requestConnectionUpdate( parameters );
+
   mController->discoverServices();
 }
 
 void QfBluetoothLowEnergyReceiver::deviceDisconnected()
 {
-  qInfo() << "BluetoothLowEnergyReceiver: Received disconnected signal.";
+  qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: Received disconnected signal. rxNotifications=%1 rxBytes=%2 rxSentences=%3 correctionReceived=%4 correctionWritten=%5 correctionPending=%6 chunksWritten=%7" )
+               .arg( mBleRxNotifications )
+               .arg( mBleRxBytes )
+               .arg( mBleRxSentences )
+               .arg( mCorrectionBytesReceived )
+               .arg( mCorrectionBytesWritten )
+               .arg( mCorrectionData.size() )
+               .arg( mCorrectionChunksWritten );
 
   if ( mDisconnecting )
   {
@@ -241,6 +294,11 @@ void QfBluetoothLowEnergyReceiver::serviceDiscoveryFinished()
 
 void QfBluetoothLowEnergyReceiver::serviceStateChanged( QLowEnergyService::ServiceState state )
 {
+  qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: Service %1 state changed to %2" )
+               .arg( sender() == mService && mService ? mService->serviceUuid().toString() : sender() == mBatteryService && mBatteryService ? mBatteryService->serviceUuid().toString()
+                                                                                                                                            : QStringLiteral( "unknown" ) )
+               .arg( QMetaEnum::fromType<QLowEnergyService::ServiceState>().valueToKey( state ) );
+
   if ( sender() == mService )
   {
     if ( state == QLowEnergyService::RemoteServiceDiscovered )
@@ -311,7 +369,10 @@ void QfBluetoothLowEnergyReceiver::serviceStateChanged( QLowEnergyService::Servi
 void QfBluetoothLowEnergyReceiver::serviceErrorOccurred( QLowEnergyService::ServiceError error )
 {
   mLastError = QStringLiteral( "Service Error: %1" ).arg( QMetaEnum::fromType<QLowEnergyService::ServiceError>().valueToKey( static_cast<int>( error ) ) );
-  qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: %1" ).arg( mLastError );
+  qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: %1, correctionPending=%2 correctionWritten=%3" )
+               .arg( mLastError )
+               .arg( mCorrectionData.size() )
+               .arg( mCorrectionBytesWritten );
   emit lastErrorChanged( mLastError );
 }
 
@@ -319,16 +380,34 @@ void QfBluetoothLowEnergyReceiver::characteristicChanged( const QLowEnergyCharac
 {
   if ( characteristic.uuid() == mRxCharacteristic.uuid() )
   {
+    mBleRxNotifications++;
+    mBleRxBytes += value.size();
+
     mBufferData.append( value );
     int endSentenceIndex = mBufferData.lastIndexOf( QLatin1String( "\r\n" ) );
     if ( endSentenceIndex > -1 )
     {
+      const QByteArray completedSentences = mBufferData.mid( 0, endSentenceIndex + 2 );
+      mBleRxSentences += completedSentences.count( "\r\n" );
+
       mBuffer->buffer().clear();
       mBuffer->seek( 0 );
-      mBuffer->write( mBufferData.mid( 0, endSentenceIndex + 2 ) );
+      mBuffer->write( completedSentences );
       mBuffer->seek( 0 );
 
       mBufferData = mBufferData.mid( endSentenceIndex + 2 );
+    }
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    if ( mLastBleRxLogMs == 0 || now - mLastBleRxLogMs >= 5000 )
+    {
+      qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: BLE RX stats notifications=%1 bytes=%2 nmeaSentences=%3 partialBuffer=%4 socketState=%5" )
+                   .arg( mBleRxNotifications )
+                   .arg( mBleRxBytes )
+                   .arg( mBleRxSentences )
+                   .arg( mBufferData.size() )
+                   .arg( socketStateString() );
+      mLastBleRxLogMs = now;
     }
   }
   else if ( characteristic.uuid() == mBatteryCharacteristic.uuid() )
@@ -344,6 +423,11 @@ void QfBluetoothLowEnergyReceiver::characteristicChanged( const QLowEnergyCharac
 
 void QfBluetoothLowEnergyReceiver::clearService()
 {
+  if ( !mCorrectionData.isEmpty() )
+  {
+    qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: Clearing BLE service with %1 correction bytes still pending" ).arg( mCorrectionData.size() );
+  }
+
   if ( mBuffer->isOpen() )
   {
     mBuffer->close();
@@ -386,10 +470,27 @@ void QfBluetoothLowEnergyReceiver::onCorrectionDataReceived( const QByteArray &d
 {
   if ( !mService || !mTxCharacteristic.isValid() )
   {
+    qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: Dropping %1 correction bytes because BLE TX is not ready. service=%2 txValid=%3" )
+                 .arg( data.size() )
+                 .arg( mService ? mService->serviceUuid().toString() : QStringLiteral( "none" ) )
+                 .arg( mTxCharacteristic.isValid() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
     return;
   }
 
+  mCorrectionBytesReceived += data.size();
   mCorrectionData.append( data );
+
+  const qint64 now = QDateTime::currentMSecsSinceEpoch();
+  if ( mLastCorrectionLogMs == 0 || now - mLastCorrectionLogMs >= 5000 )
+  {
+    qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: RTCM queued from NTRIP received=%1 written=%2 pending=%3 chunksWritten=%4 timerActive=%5" )
+                 .arg( mCorrectionBytesReceived )
+                 .arg( mCorrectionBytesWritten )
+                 .arg( mCorrectionData.size() )
+                 .arg( mCorrectionChunksWritten )
+                 .arg( mCorrectionTimer.isActive() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+    mLastCorrectionLogMs = now;
+  }
 
   if ( !mCorrectionTimer.isActive() )
   {
@@ -401,14 +502,52 @@ void QfBluetoothLowEnergyReceiver::forwardCorrectionDataChunk()
 {
   if ( mCorrectionData.isEmpty() || !mService || !mTxCharacteristic.isValid() )
   {
+    if ( !mCorrectionData.isEmpty() )
+    {
+      qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: Stopping correction forwarding with %1 bytes pending. service=%2 txValid=%3" )
+                   .arg( mCorrectionData.size() )
+                   .arg( mService ? mService->serviceUuid().toString() : QStringLiteral( "none" ) )
+                   .arg( mTxCharacteristic.isValid() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+    }
     mCorrectionTimer.stop();
     return;
   }
 
-  // Payloag must not be longer than 20 bytes
-  // https://doc.qt.io/qt-6/qlowenergyservice.html#WriteMode-enum
-  const qsizetype chunkSize = std::min( static_cast<qsizetype>( 20 ), mCorrectionData.size() );
-  QByteArray chunk = mCorrectionData.left( chunkSize );
-  mCorrectionData.remove( 0, chunkSize );
-  mService->writeCharacteristic( mTxCharacteristic, chunk, QLowEnergyService::WriteWithoutResponse );
+  qsizetype bytesWrittenThisTick = 0;
+  qsizetype lastChunkSize = 0;
+  int chunksWrittenThisTick = 0;
+  const int maxChunksPerTick = mCorrectionData.size() > 4096 ? 6 : 3;
+
+  while ( !mCorrectionData.isEmpty() && chunksWrittenThisTick < maxChunksPerTick )
+  {
+    // BLE payload must not be longer than ATT MTU minus the 3-byte ATT header.
+    const qsizetype chunkSize = std::min( mBleTxPayloadSize, mCorrectionData.size() );
+    QByteArray chunk = mCorrectionData.left( chunkSize );
+    mCorrectionData.remove( 0, chunkSize );
+    mService->writeCharacteristic( mTxCharacteristic, chunk, QLowEnergyService::WriteWithoutResponse );
+    mCorrectionBytesWritten += chunk.size();
+    mCorrectionChunksWritten++;
+    bytesWrittenThisTick += chunk.size();
+    lastChunkSize = chunk.size();
+    chunksWrittenThisTick++;
+  }
+
+  if ( mCorrectionData.isEmpty() )
+  {
+    mCorrectionTimer.stop();
+  }
+
+  const qint64 now = QDateTime::currentMSecsSinceEpoch();
+  if ( mLastCorrectionLogMs == 0 || now - mLastCorrectionLogMs >= 5000 )
+  {
+    qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: RTCM forwarded over BLE written=%1 pending=%2 chunksWritten=%3 chunksThisTick=%4 bytesThisTick=%5 lastChunk=%6 serviceState=%7" )
+                 .arg( mCorrectionBytesWritten )
+                 .arg( mCorrectionData.size() )
+                 .arg( mCorrectionChunksWritten )
+                 .arg( chunksWrittenThisTick )
+                 .arg( bytesWrittenThisTick )
+                 .arg( lastChunkSize )
+                 .arg( mService ? QMetaEnum::fromType<QLowEnergyService::ServiceState>().valueToKey( mService->state() ) : "none" );
+    mLastCorrectionLogMs = now;
+  }
 }

--- a/src/core/positioning/qfbluetoothlowenergyreceiver.cpp
+++ b/src/core/positioning/qfbluetoothlowenergyreceiver.cpp
@@ -23,6 +23,14 @@
 #include <QTimer>
 #include <QtBluetooth/QLowEnergyConnectionParameters>
 
+namespace
+{
+  constexpr int CorrectionTimerIntervalMs = 20;
+  constexpr qsizetype CorrectionCatchUpThresholdBytes = 4096;
+  constexpr int NormalCorrectionChunksPerTick = 3;
+  constexpr int CatchUpCorrectionChunksPerTick = 6;
+} // namespace
+
 // Map of BLE service UUID (key) and a pair of RX (first, incoming) and TX (second, outgoing) characteristics
 QMap<QBluetoothUuid, std::pair<QBluetoothUuid, QBluetoothUuid>> QfBluetoothLowEnergyReceiver::serviceChars = {
   { // Standard Nordic UART Service (NUS)
@@ -43,7 +51,7 @@ QfBluetoothLowEnergyReceiver::QfBluetoothLowEnergyReceiver( const QString &addre
 {
   qInfo() << "BluetoothLowEnergyReceiver: Creating the receiver";
 
-  mCorrectionTimer.setInterval( 20 );
+  mCorrectionTimer.setInterval( CorrectionTimerIntervalMs );
   connect( &mCorrectionTimer, &QTimer::timeout, this, &QfBluetoothLowEnergyReceiver::forwardCorrectionDataChunk );
 
   initNmeaConnection( mBuffer );
@@ -130,15 +138,9 @@ void QfBluetoothLowEnergyReceiver::doConnectDevice()
 
   setSocketState( QAbstractSocket::ConnectingState );
 
-  const int mtu = mController->mtu();
-  if ( mtu > 3 )
-  {
-    mBleTxPayloadSize = std::max<qsizetype>( 20, mtu - 3 );
-  }
-
   qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: connectToDevice requested, controller state %1, mtu=%2, txPayload=%3" )
                .arg( QMetaEnum::fromType<QLowEnergyController::ControllerState>().valueToKey( mController->state() ) )
-               .arg( mtu )
+               .arg( mController->mtu() )
                .arg( mBleTxPayloadSize );
   mController->connectToDevice();
 }
@@ -516,7 +518,10 @@ void QfBluetoothLowEnergyReceiver::forwardCorrectionDataChunk()
   qsizetype bytesWrittenThisTick = 0;
   qsizetype lastChunkSize = 0;
   int chunksWrittenThisTick = 0;
-  const int maxChunksPerTick = mCorrectionData.size() > 4096 ? 6 : 3;
+  // With the default BLE MTU, each write carries 20 payload bytes. At a
+  // 20 ms timer interval, 3 chunks/tick keeps up with typical 2-3 KB/s RTCM
+  // streams while 6 chunks/tick allows catching up after short bursts.
+  const int maxChunksPerTick = mCorrectionData.size() > CorrectionCatchUpThresholdBytes ? CatchUpCorrectionChunksPerTick : NormalCorrectionChunksPerTick;
 
   while ( !mCorrectionData.isEmpty() && chunksWrittenThisTick < maxChunksPerTick )
   {

--- a/src/core/positioning/qfbluetoothlowenergyreceiver.cpp
+++ b/src/core/positioning/qfbluetoothlowenergyreceiver.cpp
@@ -115,7 +115,7 @@ void QfBluetoothLowEnergyReceiver::doConnectDevice()
     connect( mController, &QLowEnergyController::serviceDiscovered, this, &QfBluetoothLowEnergyReceiver::serviceDiscovered );
     connect( mController, &QLowEnergyController::discoveryFinished, this, &QfBluetoothLowEnergyReceiver::serviceDiscoveryFinished );
     connect( mController, &QLowEnergyController::mtuChanged, this, [this]( int mtu ) {
-      mBleTxPayloadSize = std::max<qsizetype>( DEFAULT_BLE_TX_PAYLOAD_SIZE, mtu - 3 );
+      updateBleTxPayloadSize( mtu );
       qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: MTU changed to %1, BLE TX payload size set to %2" )
                    .arg( mtu )
                    .arg( mBleTxPayloadSize );
@@ -152,13 +152,20 @@ void QfBluetoothLowEnergyReceiver::doDisconnectDevice()
   }
 }
 
+void QfBluetoothLowEnergyReceiver::updateBleTxPayloadSize( int mtu )
+{
+  // Called both when connected and when the MTU changes, as some platforms
+  // expose the negotiated MTU only after the connection has been established.
+  if ( mtu > 3 )
+  {
+    mBleTxPayloadSize = std::max<qsizetype>( DEFAULT_BLE_TX_PAYLOAD_SIZE, mtu - 3 );
+  }
+}
+
 void QfBluetoothLowEnergyReceiver::deviceConnected()
 {
   const int mtu = mController->mtu();
-  if ( mtu > 3 )
-  {
-    mBleTxPayloadSize = std::max<qsizetype>( 20, mtu - 3 );
-  }
+  updateBleTxPayloadSize( mtu );
 
   qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: Connected, discovering services, controller state %1, mtu=%2, txPayload=%3" )
                .arg( QMetaEnum::fromType<QLowEnergyController::ControllerState>().valueToKey( mController->state() ) )

--- a/src/core/positioning/qfbluetoothlowenergyreceiver.cpp
+++ b/src/core/positioning/qfbluetoothlowenergyreceiver.cpp
@@ -23,13 +23,6 @@
 #include <QTimer>
 #include <QtBluetooth/QLowEnergyConnectionParameters>
 
-namespace
-{
-  constexpr int CorrectionTimerIntervalMs = 20;
-  constexpr qsizetype CorrectionCatchUpThresholdBytes = 4096;
-  constexpr int NormalCorrectionChunksPerTick = 3;
-  constexpr int CatchUpCorrectionChunksPerTick = 6;
-} // namespace
 
 // Map of BLE service UUID (key) and a pair of RX (first, incoming) and TX (second, outgoing) characteristics
 QMap<QBluetoothUuid, std::pair<QBluetoothUuid, QBluetoothUuid>> QfBluetoothLowEnergyReceiver::serviceChars = {
@@ -51,7 +44,7 @@ QfBluetoothLowEnergyReceiver::QfBluetoothLowEnergyReceiver( const QString &addre
 {
   qInfo() << "BluetoothLowEnergyReceiver: Creating the receiver";
 
-  mCorrectionTimer.setInterval( CorrectionTimerIntervalMs );
+  mCorrectionTimer.setInterval( CORRECTION_TIMER_INTERVAL_MS );
   connect( &mCorrectionTimer, &QTimer::timeout, this, &QfBluetoothLowEnergyReceiver::forwardCorrectionDataChunk );
 
   initNmeaConnection( mBuffer );
@@ -122,7 +115,7 @@ void QfBluetoothLowEnergyReceiver::doConnectDevice()
     connect( mController, &QLowEnergyController::serviceDiscovered, this, &QfBluetoothLowEnergyReceiver::serviceDiscovered );
     connect( mController, &QLowEnergyController::discoveryFinished, this, &QfBluetoothLowEnergyReceiver::serviceDiscoveryFinished );
     connect( mController, &QLowEnergyController::mtuChanged, this, [this]( int mtu ) {
-      mBleTxPayloadSize = std::max<qsizetype>( 20, mtu - 3 );
+      mBleTxPayloadSize = std::max<qsizetype>( DEFAULT_BLE_TX_PAYLOAD_SIZE, mtu - 3 );
       qInfo() << QStringLiteral( "BluetoothLowEnergyReceiver: MTU changed to %1, BLE TX payload size set to %2" )
                    .arg( mtu )
                    .arg( mBleTxPayloadSize );
@@ -521,7 +514,7 @@ void QfBluetoothLowEnergyReceiver::forwardCorrectionDataChunk()
   // With the default BLE MTU, each write carries 20 payload bytes. At a
   // 20 ms timer interval, 3 chunks/tick keeps up with typical 2-3 KB/s RTCM
   // streams while 6 chunks/tick allows catching up after short bursts.
-  const int maxChunksPerTick = mCorrectionData.size() > CorrectionCatchUpThresholdBytes ? CatchUpCorrectionChunksPerTick : NormalCorrectionChunksPerTick;
+  const int maxChunksPerTick = mCorrectionData.size() > CORRECTION_CATCH_UP_THRESHOLD_BYTES ? CATCH_UP_CORRECTION_CHUNKS_PER_TICK : NORMAL_CORRECTION_CHUNKS_PER_TICK;
 
   while ( !mCorrectionData.isEmpty() && chunksWrittenThisTick < maxChunksPerTick )
   {

--- a/src/core/positioning/qfbluetoothlowenergyreceiver.h
+++ b/src/core/positioning/qfbluetoothlowenergyreceiver.h
@@ -92,6 +92,16 @@ class QfBluetoothLowEnergyReceiver : public QfNmeaGnssReceiver
     QByteArray mCorrectionData;
     QTimer mCorrectionTimer;
 
+    qint64 mBleRxBytes = 0;
+    qint64 mBleRxNotifications = 0;
+    qint64 mBleRxSentences = 0;
+    qint64 mCorrectionBytesReceived = 0;
+    qint64 mCorrectionBytesWritten = 0;
+    qint64 mCorrectionChunksWritten = 0;
+    qint64 mLastBleRxLogMs = 0;
+    qint64 mLastCorrectionLogMs = 0;
+    qsizetype mBleTxPayloadSize = 20;
+
     bool mDisconnecting = false;
     bool mConnectOnDisconnect = false;
     int mConnectionFailureCount = 0;

--- a/src/core/positioning/qfbluetoothlowenergyreceiver.h
+++ b/src/core/positioning/qfbluetoothlowenergyreceiver.h
@@ -70,6 +70,7 @@ class QfBluetoothLowEnergyReceiver : public QfNmeaGnssReceiver
 
   private:
     void clearService();
+    void updateBleTxPayloadSize( int mtu );
 
     //! Used to wait for previous connection to finish disconnecting
     void doConnectDevice();

--- a/src/core/positioning/qfbluetoothlowenergyreceiver.h
+++ b/src/core/positioning/qfbluetoothlowenergyreceiver.h
@@ -105,6 +105,12 @@ class QfBluetoothLowEnergyReceiver : public QfNmeaGnssReceiver
     bool mDisconnecting = false;
     bool mConnectOnDisconnect = false;
     int mConnectionFailureCount = 0;
+
+    static constexpr int CORRECTION_TIMER_INTERVAL_MS = 20;
+    static constexpr qsizetype CORRECTION_CATCH_UP_THRESHOLD_BYTES = 4096;
+    static constexpr int NORMAL_CORRECTION_CHUNKS_PER_TICK = 3;
+    static constexpr int CATCH_UP_CORRECTION_CHUNKS_PER_TICK = 6;
+    static constexpr qsizetype DEFAULT_BLE_TX_PAYLOAD_SIZE = 20;
 };
 
 #endif //QFBLUETOOTHLOWENERGYRECEIVER_H

--- a/src/core/positioning/qfnmeagnssreceiver.cpp
+++ b/src/core/positioning/qfnmeagnssreceiver.cpp
@@ -17,6 +17,7 @@
 #include "qfnmeagnssreceiver.h"
 #include "qfpositioningsource.h"
 
+#include <QDebug>
 #include <QFileInfo>
 #include <QSettings>
 
@@ -90,6 +91,21 @@ void QfNmeaGnssReceiver::stateChanged( const QgsGpsInformation &info )
                                                                    info.hacc, info.vacc, info.utcDateTime, info.fixMode, info.fixType, info.quality, info.satellitesUsed, info.status,
                                                                    info.satPrn, info.satInfoComplete, std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(),
                                                                    0, QStringLiteral( "nmea" ) );
+
+  const QString fixStatusDescription = mCurrentNmeaGnssPositionInformation.fixStatusDescription();
+  const QString qualityDescription = mCurrentNmeaGnssPositionInformation.qualityDescription();
+  if ( fixStatusDescription != mLastLoggedFixStatusDescription || qualityDescription != mLastLoggedQualityDescription )
+  {
+    qInfo() << QStringLiteral( "NMEA receiver: position quality changed fix=%1 quality=%2 hacc=%3 vacc=%4 satellitesUsed=%5 pdop=%6" )
+                 .arg( fixStatusDescription,
+                       qualityDescription,
+                       QString::number( info.hacc, 'f', 3 ),
+                       QString::number( info.vacc, 'f', 3 ),
+                       QString::number( info.satellitesUsed ),
+                       QString::number( info.pdop, 'f', 1 ) );
+    mLastLoggedFixStatusDescription = fixStatusDescription;
+    mLastLoggedQualityDescription = qualityDescription;
+  }
 }
 
 void QfNmeaGnssReceiver::onNmeaSentenceReceived( const QString &substring )

--- a/src/core/positioning/qfnmeagnssreceiver.cpp
+++ b/src/core/positioning/qfnmeagnssreceiver.cpp
@@ -96,13 +96,13 @@ void QfNmeaGnssReceiver::stateChanged( const QgsGpsInformation &info )
   const QString qualityDescription = mCurrentNmeaGnssPositionInformation.qualityDescription();
   if ( fixStatusDescription != mLastLoggedFixStatusDescription || qualityDescription != mLastLoggedQualityDescription )
   {
-    qInfo() << QStringLiteral( "NMEA receiver: position quality changed fix=%1 quality=%2 hacc=%3 vacc=%4 satellitesUsed=%5 pdop=%6" )
-                 .arg( fixStatusDescription,
-                       qualityDescription,
-                       QString::number( info.hacc, 'f', 3 ),
-                       QString::number( info.vacc, 'f', 3 ),
-                       QString::number( info.satellitesUsed ),
-                       QString::number( info.pdop, 'f', 1 ) );
+    qDebug() << QStringLiteral( "NMEA receiver: position quality changed fix=%1 quality=%2 hacc=%3 vacc=%4 satellitesUsed=%5 pdop=%6" )
+                  .arg( fixStatusDescription,
+                        qualityDescription,
+                        QString::number( info.hacc, 'f', 3 ),
+                        QString::number( info.vacc, 'f', 3 ),
+                        QString::number( info.satellitesUsed ),
+                        QString::number( info.pdop, 'f', 1 ) );
     mLastLoggedFixStatusDescription = fixStatusDescription;
     mLastLoggedQualityDescription = qualityDescription;
   }

--- a/src/core/positioning/qfnmeagnssreceiver.h
+++ b/src/core/positioning/qfnmeagnssreceiver.h
@@ -63,6 +63,8 @@ class QfNmeaGnssReceiver : public QfAbstractGnssReceiver
     void processImuSentence( const QString &sentence );
 
     QTime mLastGnssPositionUtcTime;
+    QString mLastLoggedFixStatusDescription;
+    QString mLastLoggedQualityDescription;
 
     QFile mLogFile;
     QTextStream mLogStream;

--- a/src/core/positioning/qfntripclient.cpp
+++ b/src/core/positioning/qfntripclient.cpp
@@ -24,6 +24,12 @@
 #include <QFileInfo>
 #include <QRegularExpression>
 
+namespace
+{
+  constexpr qint64 CorrectionStatsLogIntervalMs = 5000;
+  constexpr qint64 GgaForwardingLogIntervalMs = 30000;
+} // namespace
+
 
 QfNtripClient::QfNtripClient( QObject *parent )
   : QObject( parent )
@@ -83,17 +89,17 @@ void QfNtripClient::start( const QfNtripSettings &ntripSettings, QfAbstractGnssR
     mCorrectionBlocksReceived++;
 
     const qint64 now = QDateTime::currentMSecsSinceEpoch();
-    if ( mLastCorrectionLogMs == 0 || now - mLastCorrectionLogMs >= 5000 )
+    if ( mLastCorrectionLogMs == 0 || now - mLastCorrectionLogMs >= CorrectionStatsLogIntervalMs )
     {
       const qint64 deltaMs = mLastCorrectionLogMs == 0 ? 0 : now - mLastCorrectionLogMs;
       const qint64 deltaBytes = mBytesReceived - mLastCorrectionLogBytes;
       const double bytesPerSecond = deltaMs > 0 ? deltaBytes * 1000.0 / deltaMs : 0.0;
-      qInfo() << QStringLiteral( "NTRIP Client: correction stats bytesReceived=%1 blocks=%2 lastBlock=%3 approxRate=%4 B/s receiverReady=%5" )
-                   .arg( mBytesReceived )
-                   .arg( mCorrectionBlocksReceived )
-                   .arg( data.size() )
-                   .arg( bytesPerSecond, 0, 'f', 1 )
-                   .arg( mReceiver ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+      qDebug() << QStringLiteral( "NTRIP Client: correction stats bytesReceived=%1 blocks=%2 lastBlock=%3 approxRate=%4 B/s receiverReady=%5" )
+                    .arg( mBytesReceived )
+                    .arg( mCorrectionBlocksReceived )
+                    .arg( data.size() )
+                    .arg( bytesPerSecond, 0, 'f', 1 )
+                    .arg( mReceiver ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
       mLastCorrectionLogMs = now;
       mLastCorrectionLogBytes = mBytesReceived;
     }
@@ -145,11 +151,11 @@ void QfNtripClient::sendNmeaSentence( const QString &sentence )
   {
     mBytesSent += bytesWritten;
     emit bytesSentChanged();
-    qInfo() << QStringLiteral( "NTRIP Client: Sent NMEA sentence to caster, bytesWritten=%1 totalBytesSent=%2 sentence=%3" ).arg( bytesWritten ).arg( mBytesSent ).arg( sentence.left( 6 ) );
+    qDebug() << QStringLiteral( "NTRIP Client: Sent NMEA sentence to caster, bytesWritten=%1 totalBytesSent=%2 sentence=%3" ).arg( bytesWritten ).arg( mBytesSent ).arg( sentence.left( 6 ) );
   }
   else
   {
-    qInfo() << QStringLiteral( "NTRIP Client: Failed to send NMEA sentence to caster, socket not connected or write failed" );
+    qDebug() << QStringLiteral( "NTRIP Client: Failed to send NMEA sentence to caster, socket not connected or write failed" );
   }
 }
 
@@ -228,9 +234,9 @@ void QfNtripClient::nmeaSentenceReceived( const QString &sentence )
   }
 
   const qint64 now = QDateTime::currentMSecsSinceEpoch();
-  if ( mLastGgaLogMs == 0 || now - mLastGgaLogMs >= 30000 )
+  if ( mLastGgaLogMs == 0 || now - mLastGgaLogMs >= GgaForwardingLogIntervalMs )
   {
-    qInfo() << QStringLiteral( "NTRIP Client: Received GGA from receiver for caster forwarding, talker=%1 length=%2" ).arg( talkerId, QString::number( sentence.size() ) );
+    qDebug() << QStringLiteral( "NTRIP Client: Received GGA from receiver for caster forwarding, talker=%1 length=%2" ).arg( talkerId, QString::number( sentence.size() ) );
     mLastGgaLogMs = now;
   }
 

--- a/src/core/positioning/qfntripclient.cpp
+++ b/src/core/positioning/qfntripclient.cpp
@@ -68,14 +68,35 @@ void QfNtripClient::start( const QfNtripSettings &ntripSettings, QfAbstractGnssR
   }
 
   mLastNtripGgaSent = 0;
+  mLastGgaLogMs = 0;
   mBytesSent = 0;
   mBytesReceived = 0;
+  mCorrectionBlocksReceived = 0;
+  mLastCorrectionLogMs = 0;
+  mLastCorrectionLogBytes = 0;
 
   qInfo() << QStringLiteral( "Starting NTRIP client: host %1, port %2, mount point %3" ).arg( ntripSettings.host(), QString::number( ntripSettings.port() ), ntripSettings.mountPoint() );
   mSocket = new QfNtripSocket( this );
 
   connect( mSocket, &QfNtripSocket::correctionDataReceived, this, [this]( const QByteArray &data ) {
     mBytesReceived += data.size();
+    mCorrectionBlocksReceived++;
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    if ( mLastCorrectionLogMs == 0 || now - mLastCorrectionLogMs >= 5000 )
+    {
+      const qint64 deltaMs = mLastCorrectionLogMs == 0 ? 0 : now - mLastCorrectionLogMs;
+      const qint64 deltaBytes = mBytesReceived - mLastCorrectionLogBytes;
+      const double bytesPerSecond = deltaMs > 0 ? deltaBytes * 1000.0 / deltaMs : 0.0;
+      qInfo() << QStringLiteral( "NTRIP Client: correction stats bytesReceived=%1 blocks=%2 lastBlock=%3 approxRate=%4 B/s receiverReady=%5" )
+                   .arg( mBytesReceived )
+                   .arg( mCorrectionBlocksReceived )
+                   .arg( data.size() )
+                   .arg( bytesPerSecond, 0, 'f', 1 )
+                   .arg( mReceiver ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+      mLastCorrectionLogMs = now;
+      mLastCorrectionLogBytes = mBytesReceived;
+    }
 
     emit correctionDataReceived( data );
     emit bytesReceivedChanged();
@@ -124,6 +145,11 @@ void QfNtripClient::sendNmeaSentence( const QString &sentence )
   {
     mBytesSent += bytesWritten;
     emit bytesSentChanged();
+    qInfo() << QStringLiteral( "NTRIP Client: Sent NMEA sentence to caster, bytesWritten=%1 totalBytesSent=%2 sentence=%3" ).arg( bytesWritten ).arg( mBytesSent ).arg( sentence.left( 6 ) );
+  }
+  else
+  {
+    qInfo() << QStringLiteral( "NTRIP Client: Failed to send NMEA sentence to caster, socket not connected or write failed" );
   }
 }
 
@@ -199,6 +225,13 @@ void QfNtripClient::nmeaSentenceReceived( const QString &sentence )
   if ( sentenceId != QStringLiteral( "GGA" ) )
   {
     return;
+  }
+
+  const qint64 now = QDateTime::currentMSecsSinceEpoch();
+  if ( mLastGgaLogMs == 0 || now - mLastGgaLogMs >= 30000 )
+  {
+    qInfo() << QStringLiteral( "NTRIP Client: Received GGA from receiver for caster forwarding, talker=%1 length=%2" ).arg( talkerId, QString::number( sentence.size() ) );
+    mLastGgaLogMs = now;
   }
 
   QString sentenceToSend = sentence;

--- a/src/core/positioning/qfntripclient.cpp
+++ b/src/core/positioning/qfntripclient.cpp
@@ -24,12 +24,6 @@
 #include <QFileInfo>
 #include <QRegularExpression>
 
-namespace
-{
-  constexpr qint64 CorrectionStatsLogIntervalMs = 5000;
-  constexpr qint64 GgaForwardingLogIntervalMs = 30000;
-} // namespace
-
 
 QfNtripClient::QfNtripClient( QObject *parent )
   : QObject( parent )
@@ -89,7 +83,7 @@ void QfNtripClient::start( const QfNtripSettings &ntripSettings, QfAbstractGnssR
     mCorrectionBlocksReceived++;
 
     const qint64 now = QDateTime::currentMSecsSinceEpoch();
-    if ( mLastCorrectionLogMs == 0 || now - mLastCorrectionLogMs >= CorrectionStatsLogIntervalMs )
+    if ( mLastCorrectionLogMs == 0 || now - mLastCorrectionLogMs >= CORRECTION_STATS_LOG_INTERVAL_MS )
     {
       const qint64 deltaMs = mLastCorrectionLogMs == 0 ? 0 : now - mLastCorrectionLogMs;
       const qint64 deltaBytes = mBytesReceived - mLastCorrectionLogBytes;
@@ -234,7 +228,7 @@ void QfNtripClient::nmeaSentenceReceived( const QString &sentence )
   }
 
   const qint64 now = QDateTime::currentMSecsSinceEpoch();
-  if ( mLastGgaLogMs == 0 || now - mLastGgaLogMs >= GgaForwardingLogIntervalMs )
+  if ( mLastGgaLogMs == 0 || now - mLastGgaLogMs >= GGA_FORWARDING_LOG_INTERVAL_MS )
   {
     qDebug() << QStringLiteral( "NTRIP Client: Received GGA from receiver for caster forwarding, talker=%1 length=%2" ).arg( talkerId, QString::number( sentence.size() ) );
     mLastGgaLogMs = now;

--- a/src/core/positioning/qfntripclient.h
+++ b/src/core/positioning/qfntripclient.h
@@ -108,12 +108,16 @@ class QfNtripClient : public QObject
     QfNtripSocket *mSocket = nullptr;
     qint64 mBytesSent = 0;
     qint64 mBytesReceived = 0;
+    qint64 mCorrectionBlocksReceived = 0;
+    qint64 mLastCorrectionLogMs = 0;
+    qint64 mLastCorrectionLogBytes = 0;
 
     QFile mLogFile;
     QDataStream mLogStream;
     int mLogBlockCount = 0;
 
     qint64 mLastNtripGgaSent = 0;
+    qint64 mLastGgaLogMs = 0;
 
     QPointer<QfAbstractGnssReceiver> mReceiver;
 };

--- a/src/core/positioning/qfntripclient.h
+++ b/src/core/positioning/qfntripclient.h
@@ -120,6 +120,9 @@ class QfNtripClient : public QObject
     qint64 mLastGgaLogMs = 0;
 
     QPointer<QfAbstractGnssReceiver> mReceiver;
+
+    static constexpr qint64 CORRECTION_STATS_LOG_INTERVAL_MS = 5000;
+    static constexpr qint64 GGA_FORWARDING_LOG_INTERVAL_MS = 30000;
 };
 
 


### PR DESCRIPTION
## Summary

This pull request improves how RTCM/NTRIP correction data is forwarded over Bluetooth Low Energy connections.

When using BLE, correction data could accumulate faster than it was written to the GNSS receiver. This caused the receiver to eventually receive stale RTCM data and lose RTK correction status, falling back to autonomous positioning.

The issue was observed on iOS and was also blocking reliable RTK usage over BLE on Android. Android SPP did not show the same issue because it provides higher throughput than BLE.

## Problem

The previous implementation forwarded only one BLE packet per timer tick. With the default BLE ATT MTU of 23 bytes, this meant only 20 bytes of RTCM payload were sent every cycle.

For NTRIP streams around 2-3 KB/s, this was not enough. The correction buffer kept growing, causing increasing latency between received RTCM data and data actually written to the GNSS receiver.

In practice, the application could show the NTRIP client as connected while the receiver eventually dropped from Fixed RTK back to Autonomous because corrections were arriving too late.

## Changes

- Use the negotiated BLE MTU payload size when available.
- Forward multiple RTCM chunks per timer tick instead of only one.
- Increase forwarding rate when the correction buffer starts accumulating.
- Stop the forwarding timer once the correction buffer is empty.
- Add diagnostics to make NTRIP correction throughput and GNSS quality changes easier to debug.

## Testing

Tested on iOS with a BLE GNSS receiver and an NTRIP caster.

Before the change, the RTCM pending buffer kept increasing and RTK was eventually lost.

After the change, the pending buffer remains bounded and is able to recover after temporary spikes. The receiver stayed in Fixed RTK during the test.

Android BLE is expected to benefit from the same change, but has not been tested yet in this branch. Android SPP was already working correctly and is not affected by this change.

## Notes

The iOS BLE stack used through Qt did not expose a way to explicitly request a larger MTU. In the tested setup, the connection stayed at MTU 23, so the fix focuses on improving throughput by sending several 20-byte BLE payloads per cycle.