### PR TITLE
Fix <i></i> presence in the value relation editor widget's items list

### DIFF
--- a/src/core/qffeaturelistmodel.cpp
+++ b/src/core/qffeaturelistmodel.cpp
@@ -429,7 +429,7 @@ void QfFeatureListModel::processFeatureList()
 
   if ( mAddNull )
   {
-    entries.append( Entry( QStringLiteral( "<i>NULL</i>" ), QVariant(), QVariant(), QgsFeatureId(), QString() ) );
+    entries.append( Entry( QStringLiteral( "NULL" ), QVariant(), QVariant(), QgsFeatureId(), QString() ) );
   }
 
   const QVector<QfFeatureExpressionValuesGatherer::Entry> gatheredEntries = mGatherer->entries();

--- a/test/qml/tst_editorwidgets.qml
+++ b/test/qml/tst_editorwidgets.qml
@@ -849,7 +849,7 @@ TestCase {
     const valueRelationRepeater = Utils.findChildren(valueRelationListComponentParent, "valueRelationRepeater");
     const featureListModel = valueRelationRepeater.model;
     const expectedOrderedData = {
-      "name": ["<i>NULL</i>", "Ethan", "Olivia", "Mason", "Liam", "Mathieu", "Sophia", "Noah", "Ava"]
+      "name": ["NULL", "Ethan", "Olivia", "Mason", "Liam", "Mathieu", "Sophia", "Noah", "Ava"]
     };
     compare(valueRelationRepeater.count, expectedOrderedData["name"].length);
     for (let i = 0; i < valueRelationRepeater.count; ++i) {

--- a/test/test_featurelistmodel.cpp
+++ b/test/test_featurelistmodel.cpp
@@ -215,7 +215,7 @@ TEST_CASE( "FeatureListModel behaviours" )
     }
 
     REQUIRE( featureListModel.rowCount() == 4 );
-    REQUIRE( featureListModel.dataFromRowIndex( 0, QfFeatureListModel::DisplayStringRole ).toString() == QStringLiteral( "<i>NULL</i>" ) );
+    REQUIRE( featureListModel.dataFromRowIndex( 0, QfFeatureListModel::DisplayStringRole ).toString() == QStringLiteral( "NULL" ) );
 
     // Current implementation, if key not found and addNull enabled -> returns 0
     REQUIRE( featureListModel.findKey( QVariant( 999 ) ) == 0 );


### PR DESCRIPTION
This has horrified me one time too many:

<img width="482" height="855" alt="Screenshot From 2026-09-05 14-16-33" src="https://github.com/user-attachments/assets/02a0340f-b701-4946-a056-ed67e9c3a238" />
