### PR TITLE
Add ability to append a description when create a cloud project through template or cloning

### DIFF
--- a/src/app/qml/QfCloudScreen.qml
+++ b/src/app/qml/QfCloudScreen.qml
@@ -977,10 +977,12 @@ Page {
 
   QfDialog {
     id: cloneProjectDialog
+
+    property string sourceProjectId: ""
+
     parent: mainWindow.contentItem
     title: qsTr("Project Creation")
     width: mainWindow.width - 40
-    property string sourceProjectId: ""
 
     ColumnLayout {
       width: cloneProjectDialog.availableWidth
@@ -1004,6 +1006,24 @@ Page {
         font: QfTheme.tipFont
         color: QfTheme.secondaryTextColor
       }
+
+      Label {
+        Layout.fillWidth: true
+        wrapMode: Text.WordWrap
+        text: qsTr("Enter your project description")
+      }
+
+      ScrollView {
+        Layout.fillWidth: true
+        Layout.maximumHeight: 300
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        ScrollBar.vertical: QfScrollBar {}
+
+        TextArea {
+          id: cloneProjectDescription
+          wrapMode: TextEdit.Wrap
+        }
+      }
     }
 
     onAccepted: {
@@ -1011,7 +1031,7 @@ Page {
       if (trimmedName !== "") {
         busyOverlay.text = qsTr("Creating project…");
         busyOverlay.state = "visible";
-        cloudProjectsModel.createProject(trimmedName, sourceProjectId);
+        cloudProjectsModel.createProject(trimmedName, cloneProjectDescription.text.trim(), sourceProjectId);
       }
     }
   }

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
@@ -1129,7 +1129,7 @@ void QfCloudProjectsModel::setGpkgFlusher( QgsGpkgFlusher *flusher )
   emit gpkgFlusherChanged();
 }
 
-void QfCloudProjectsModel::createProject( const QString &name, const QString &fromProjectId )
+void QfCloudProjectsModel::createProject( const QString &name, const QString &description, const QString &fromProjectId )
 {
   if ( name.isEmpty() )
   {
@@ -1150,7 +1150,7 @@ void QfCloudProjectsModel::createProject( const QString &name, const QString &fr
   mCloudConnection->setAuthenticationDetails( request );
 
   const QfNetworkReply *listingreply = mCloudConnection->get( request, url );
-  connect( listingreply, &QfNetworkReply::finished, this, [this, sanitizedName, fromProjectId]() {
+  connect( listingreply, &QfNetworkReply::finished, this, [this, sanitizedName, description, fromProjectId]() {
     QfNetworkReply *reply = qobject_cast<QfNetworkReply *>( sender() );
     QNetworkReply *rawReply = reply->currentRawReply();
     Q_ASSERT( rawReply );
@@ -1183,7 +1183,7 @@ void QfCloudProjectsModel::createProject( const QString &name, const QString &fr
     QVariantMap params;
     params.insert( QStringLiteral( "name" ), finalizedName );
     params.insert( QStringLiteral( "owner" ), mUsername );
-    params.insert( QStringLiteral( "description" ), QString() );
+    params.insert( QStringLiteral( "description" ), description );
     params.insert( QStringLiteral( "private" ), true );
 
     if ( !fromProjectId.isEmpty() )

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.h
@@ -202,7 +202,7 @@ class QfCloudProjectsModel : public QAbstractListModel
      * The converted project will then be removed from the local storage in favor of a newly packaged
      * cloud project downloaded from the server.
      */
-    Q_INVOKABLE void createProject( const QString &name, const QString &fromProjectId = QString() );
+    Q_INVOKABLE void createProject( const QString &name, const QString &description, const QString &fromProjectId = QString() );
 
     /**
      * Returns TRUE if the source model contains at least one template project,

--- a/test/qml/tst_qfieldcloud_screen_ui.qml
+++ b/test/qml/tst_qfieldcloud_screen_ui.qml
@@ -590,7 +590,7 @@ TestCase {
     projectCreatedSpy.clear();
 
     const sourceId = "some-source-id";
-    cloudProjectsModel.createProject("", sourceId);
+    cloudProjectsModel.createProject("", "", sourceId);
     tryCompare(projectCreatedSpy, "count", 1, 5000);
 
     // projectCreated(projectId, fromProjectId, hasError, errorString)
@@ -648,7 +648,7 @@ TestCase {
 
     projectCreatedSpy.clear();
     const cloneName = "TestClone_" + Date.now();
-    cloudProjectsModel.createProject(cloneName, sourceProjectId);
+    cloudProjectsModel.createProject(cloneName, "", sourceProjectId);
 
     tryCompare(projectCreatedSpy, "count", 1, 60000);
 


### PR DESCRIPTION
This PR adds the ability to append a description to a newly created cloud project through template or cloning in QField.

This can come in handy in providing extra details on purpose of the project, etc. Plus, it has none of the project name character limitation so people can add text in their own language.

<img width="482" height="855" alt="Screenshot From 2026-09-05 17-21-57" src="https://github.com/user-attachments/assets/b9357b22-6496-407e-af73-9183f3a6f2a3" />
