### PR TITLE
Restore every saved QFieldCloud cookie by substituting the index into its settings key

### DIFF
--- a/src/core/qfieldcloud/qfcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfcloudconnection.cpp
@@ -1199,7 +1199,7 @@ void QfCloudConnection::saveCookies()
   {
     if ( !cookies[idx].isSessionCookie() && QDateTime::currentSecsSinceEpoch() < cookies[idx].expirationDate().toSecsSinceEpoch() )
     {
-      settings.setValue( QStringLiteral( "/QFieldCloud/cookies/%1" ), cookies[idx].toRawForm() );
+      settings.setValue( QStringLiteral( "/QFieldCloud/cookies/%1" ).arg( idx ), cookies[idx].toRawForm() );
     }
   }
 }


### PR DESCRIPTION
Fixes #7939.

`saveCookies()` writes every cookie to the settings key `"/QFieldCloud/cookies/%1"` without substituting the placeholder, so each cookie overwrites the previous one under the literal key `%1`, and `restoreCookies()`, which iterates `childKeys()`, restores at most one cookie. QFieldCloud sets two persistent cookies (`sessionid`, `csrftoken`); whenever `sessionid` is not the survivor, a restarted app has no session, re-sends its stored OIDC ID token, and QFieldCloud answers 500 `OAuth2Error: token already used` — the symptom #7321 introduced this code to fix (#7187).

The change substitutes the loop index into the key. `saveCookies()` already removes the whole `/QFieldCloud/cookies` group before writing, so indexed keys cannot accumulate across saves, and `restoreCookies()` needs no change.

Reproduced on QField 4.2.4 (iOS) against a self-hosted QFieldCloud with an OpenID Connect provider: sign in, force-quit, reopen → 500 and the login screen. Not built locally; relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
