### PR TITLE
Keep the SSO provider configuration when autologin fails for a reason other than a rejected credential

### DIFF
--- a/src/core/qfieldcloud/qfcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfcloudconnection.cpp
@@ -483,19 +483,19 @@ void QfCloudConnection::login( const QString &password )
         {
           emit loginFailed( tr( "Session expired" ) );
         }
+
+        if ( !mProvider.isEmpty() && !mProviderConfigId.isEmpty() )
+        {
+          QgsApplication::authManager()->removeAuthenticationConfig( mProviderConfigId );
+          mProviderConfigId.clear();
+          QSettings().remove( "/QFieldCloud/providerConfigId" );
+          emit providerConfigurationChanged();
+        }
       }
       else
       {
         QString message( errorString( rawReply ) );
         emit loginFailed( message );
-      }
-
-      if ( !mProvider.isEmpty() && !mProviderConfigId.isEmpty() )
-      {
-        QgsApplication::authManager()->removeAuthenticationConfig( mProviderConfigId );
-        mProviderConfigId.clear();
-        QSettings().remove( "/QFieldCloud/providerConfigId" );
-        emit providerConfigurationChanged();
       }
 
       setStatus( ConnectionStatus::Disconnected );


### PR DESCRIPTION
Fixes #7940.

In `login()`'s reply handler the block that removes the stored OAuth2 provider configuration (`removeAuthenticationConfig( mProviderConfigId )`, clearing `/QFieldCloud/providerConfigId`) sat outside the `if / else if / else` chain that only chooses the message, so it ran for **every** `QNetworkReply` error: `HostNotFoundError`, `TimeoutError`, any 5xx, as well as 400/401. Opening QField with no mobile signal, or hitting a transient server error, deleted the SSO credentials and sent the user to the login screen.

This moves the removal into the 400/401 branch: only a server that has rejected the stored credentials drops the configuration. Transport failures and server errors keep it, show their message, and leave `Disconnected` as before, so the next autologin retries with the stored tokens. The native-token path is unchanged (`mProvider` is empty there, as before).

Both paths were reproduced on QField 4.2.4 (iOS) against a self-hosted QFieldCloud with an OpenID Connect provider: a 500 on `/api/v1/auth/user/` (see #7939) and flight mode at launch each ended on the login screen with the configuration gone. Not built locally; relying on CI. Happy to adjust which status codes should count as a rejection if the maintainers prefer a different split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
