### PR TITLE
Show a busy overlay while printing

### DIFF
--- a/src/app/qgismobileapp.cpp
+++ b/src/app/qgismobileapp.cpp
@@ -88,8 +88,10 @@
 #include "qgsquickmapcanvasmap.h"
 #include "qgsquickmapsettings.h"
 
+#include <QCoreApplication>
 #include <QDateTime>
 #include <QDesktopServices>
+#include <QEventLoop>
 #include <QFileInfo>
 #include <QFontDatabase>
 #include <QPalette>
@@ -98,6 +100,7 @@
 #include <QResource>
 #include <QScreen>
 #include <QSslConfiguration>
+#include <QTimer>
 #include <QtQml/QQmlApplicationEngine>
 #include <QtQml/QQmlContext>
 #include <QtQml/QQmlEngine>
@@ -106,6 +109,7 @@
 #include <qgscoordinatereferencesystem.h>
 #include <qgsexpressionfunction.h>
 #include <qgsfeature.h>
+#include <qgsfeedback.h>
 #include <qgsfield.h>
 #include <qgsfieldconstraints.h>
 #include <qgsfontmanager.h>
@@ -310,6 +314,9 @@ QgisMobileapp::QgisMobileapp( QgsApplication *app, QObject *parent )
   connect( this, &QgisMobileapp::loadProjectTriggered, mIface, &QfAppInterface::loadProjectTriggered );
   connect( this, &QgisMobileapp::loadProjectEnded, mIface, &QfAppInterface::loadProjectEnded );
   connect( this, &QgisMobileapp::setMapExtent, mIface, &QfAppInterface::setMapExtent );
+  connect( this, &QgisMobileapp::printTriggered, mIface, &QfAppInterface::printTriggered );
+  connect( this, &QgisMobileapp::printProgress, mIface, &QfAppInterface::printProgress );
+  connect( this, &QgisMobileapp::printEnded, mIface, &QfAppInterface::printEnded );
 
   QTimer::singleShot( 1, this, &QgisMobileapp::onAfterFirstRendering );
 
@@ -1054,6 +1061,11 @@ bool QgisMobileapp::readProjectBoolEntry( const QString &scope, const QString &k
 
 bool QgisMobileapp::print( const QString &layoutName )
 {
+  if ( mIsPrinting )
+  {
+    return false;
+  }
+
   const QList<QgsPrintLayout *> printLayouts = mProject->layoutManager()->printLayouts();
   QgsPrintLayout *layoutToPrint = nullptr;
   std::unique_ptr<QgsPrintLayout> templateLayout;
@@ -1093,8 +1105,14 @@ bool QgisMobileapp::print( const QString &layoutName )
   if ( !layoutToPrint || layoutToPrint->pageCollection()->pageCount() == 0 )
     return false;
 
-  const QString destination = QStringLiteral( "%1/layouts/%2-%3.pdf" ).arg( mProject->homePath(), layoutToPrint->name(), QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_hhmmss" ) ) );
+  const QString destination = QStringLiteral( "%1/%2-%3.pdf" ).arg( layoutsFolder(), layoutToPrint->name(), QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_hhmmss" ) ) );
 
+  mIsPrinting = true;
+  emit printTriggered( layoutToPrint->name() );
+  waitForBusyOverlay();
+
+  QString openPath;
+  bool success = false;
   if ( !layoutToPrint->atlas() || !layoutToPrint->atlas()->enabled() )
   {
     if ( layoutToPrint->referenceMap() )
@@ -1109,33 +1127,40 @@ bool QgisMobileapp::print( const QString &layoutName )
     pdfSettings.appendGeoreference = true;
     pdfSettings.exportMetadata = true;
     pdfSettings.simplifyGeometries = true;
-    QgsLayoutExporter::ExportResult result = exporter.exportToPdf( destination, pdfSettings );
 
-    if ( result == QgsLayoutExporter::Success )
-      QfPlatformUtilities::instance()->open( destination );
-
-    return result == QgsLayoutExporter::Success ? true : false;
+    success = exporter.exportToPdf( destination, pdfSettings ) == QgsLayoutExporter::Success;
+    if ( success )
+    {
+      openPath = destination;
+    }
   }
   else
   {
-    bool success = printAtlas( layoutToPrint, destination );
-    if ( success )
+    success = printAtlas( layoutToPrint, destination );
+    if ( success && layoutToPrint->customProperty( QStringLiteral( "singleFile" ), true ).toBool() )
     {
-      if ( layoutToPrint->customProperty( QStringLiteral( "singleFile" ), true ).toBool() )
-      {
-        QfPlatformUtilities::instance()->open( destination );
-      }
-      else
-      {
-        QfPlatformUtilities::instance()->open( mProject->homePath() );
-      }
+      openPath = destination;
     }
-    return success;
   }
+
+  mIsPrinting = false;
+  emit printEnded( success, success ? layoutsFolder() : QString() );
+
+  if ( !openPath.isEmpty() )
+  {
+    QfPlatformUtilities::instance()->open( openPath );
+  }
+
+  return success;
 }
 
 bool QgisMobileapp::printAtlasFeatures( const QString &layoutName, const QList<long long> &featureIds )
 {
+  if ( mIsPrinting )
+  {
+    return false;
+  }
+
   const QList<QgsPrintLayout *> printLayouts = mProject->layoutManager()->printLayouts();
   QgsPrintLayout *layoutToPrint = nullptr;
   auto match = std::find_if( printLayouts.begin(), printLayouts.end(), [&layoutName]( QgsPrintLayout *layout ) { return layout->name() == layoutName; } );
@@ -1146,6 +1171,10 @@ bool QgisMobileapp::printAtlasFeatures( const QString &layoutName, const QList<l
 
   if ( !layoutToPrint || !layoutToPrint->atlas() )
     return false;
+
+  mIsPrinting = true;
+  emit printTriggered( layoutToPrint->name() );
+  waitForBusyOverlay();
 
   QStringList ids;
   for ( const auto id : featureIds )
@@ -1159,35 +1188,31 @@ bool QgisMobileapp::printAtlasFeatures( const QString &layoutName, const QList<l
 
   layoutToPrint->atlas()->setFilterExpression( QStringLiteral( "@id IN (%1)" ).arg( ids.join( ',' ) ), error );
   layoutToPrint->atlas()->setFilterFeatures( true );
-  layoutToPrint->atlas()->updateFeatures();
 
-  const QString destination = QStringLiteral( "%1/layouts/%2-%3.pdf" ).arg( mProject->homePath(), layoutToPrint->name(), QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_hhmmss" ) ) );
-  QString finalDestination;
-  const bool destinationSingleFile = layoutToPrint->customProperty( QStringLiteral( "singleFile" ), true ).toBool();
-  if ( !destinationSingleFile && ids.size() == 1 )
+  const QString destination = QStringLiteral( "%1/%2-%3.pdf" ).arg( layoutsFolder(), layoutToPrint->name(), QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_hhmmss" ) ) );
+  QString openPath;
+  if ( layoutToPrint->customProperty( QStringLiteral( "singleFile" ), true ).toBool() )
   {
+    openPath = destination;
+  }
+  else if ( ids.size() == 1 )
+  {
+    layoutToPrint->atlas()->updateFeatures();
     layoutToPrint->atlas()->first();
-    finalDestination = mProject->homePath() + '/' + layoutToPrint->atlas()->currentFilename() + QStringLiteral( ".pdf" );
+    openPath = layoutsFolder() + '/' + layoutToPrint->atlas()->currentFilename() + QStringLiteral( ".pdf" );
   }
-  else
-  {
-    finalDestination = destination;
-  }
+
   const bool success = printAtlas( layoutToPrint, destination );
 
   layoutToPrint->atlas()->setFilterExpression( priorFilterExpression, error );
   layoutToPrint->atlas()->setFilterFeatures( priorFilterFeatures );
 
-  if ( success )
+  mIsPrinting = false;
+  emit printEnded( success, success ? layoutsFolder() : QString() );
+
+  if ( success && !openPath.isEmpty() )
   {
-    if ( destinationSingleFile || ids.size() == 1 )
-    {
-      QfPlatformUtilities::instance()->open( finalDestination );
-    }
-    else
-    {
-      QfPlatformUtilities::instance()->open( mProject->homePath() );
-    }
+    QfPlatformUtilities::instance()->open( openPath );
   }
   return success;
 }
@@ -1220,24 +1245,44 @@ bool QgisMobileapp::printAtlas( QgsPrintLayout *layoutToPrint, const QString &de
   pdfSettings.simplifyGeometries = true;
   pdfSettings.predefinedMapScales = mapScales;
 
-  if ( layoutToPrint->atlas()->updateFeatures() )
+  if ( !layoutToPrint->atlas()->updateFeatures() )
   {
-    QgsLayoutExporter exporter = QgsLayoutExporter( layoutToPrint );
-    QgsLayoutExporter::ExportResult result;
-
-    if ( layoutToPrint->customProperty( QStringLiteral( "singleFile" ), true ).toBool() )
-    {
-      result = exporter.exportToPdf( layoutToPrint->atlas(), destination, pdfSettings, error );
-    }
-    else
-    {
-      result = exporter.exportToPdfs( layoutToPrint->atlas(), destination, pdfSettings, error );
-    }
-
-    return result == QgsLayoutExporter::Success ? true : false;
+    return false;
   }
 
-  return false;
+  QgsFeedback feedback;
+  connect( &feedback, &QgsFeedback::progressChanged, this, [this]( double progress ) {
+    emit printProgress( progress / 100.0 );
+    QCoreApplication::processEvents();
+  } );
+
+  QgsLayoutExporter exporter = QgsLayoutExporter( layoutToPrint );
+  QgsLayoutExporter::ExportResult result;
+
+  if ( layoutToPrint->customProperty( QStringLiteral( "singleFile" ), true ).toBool() )
+  {
+    result = exporter.exportToPdf( layoutToPrint->atlas(), destination, pdfSettings, error, &feedback );
+  }
+  else
+  {
+    result = exporter.exportToPdfs( layoutToPrint->atlas(), destination, pdfSettings, error, &feedback );
+  }
+
+  return result == QgsLayoutExporter::Success;
+}
+
+QString QgisMobileapp::layoutsFolder() const
+{
+  return mProject->homePath() + QStringLiteral( "/layouts" );
+}
+
+void QgisMobileapp::waitForBusyOverlay()
+{
+  const int busyOverlayFadeInDelay = 300;
+
+  QEventLoop loop;
+  QTimer::singleShot( busyOverlayFadeInDelay, &loop, &QEventLoop::quit );
+  loop.exec();
 }
 
 void QgisMobileapp::setScreenDimmerTimeout( int timeoutSeconds )

--- a/src/app/qgismobileapp.cpp
+++ b/src/app/qgismobileapp.cpp
@@ -88,10 +88,8 @@
 #include "qgsquickmapcanvasmap.h"
 #include "qgsquickmapsettings.h"
 
-#include <QCoreApplication>
 #include <QDateTime>
 #include <QDesktopServices>
-#include <QEventLoop>
 #include <QFileInfo>
 #include <QFontDatabase>
 #include <QPalette>
@@ -1105,53 +1103,54 @@ bool QgisMobileapp::print( const QString &layoutName )
   if ( !layoutToPrint || layoutToPrint->pageCollection()->pageCount() == 0 )
     return false;
 
-  const QString destination = QStringLiteral( "%1/%2-%3.pdf" ).arg( layoutsFolder(), layoutToPrint->name(), QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_hhmmss" ) ) );
-
   mIsPrinting = true;
   emit printTriggered( layoutToPrint->name() );
-  waitForBusyOverlay();
 
-  QString openPath;
-  bool success = false;
-  if ( !layoutToPrint->atlas() || !layoutToPrint->atlas()->enabled() )
-  {
-    if ( layoutToPrint->referenceMap() )
-      layoutToPrint->referenceMap()->zoomToExtent( mMapCanvas->mapSettings()->visibleExtent() );
-    layoutToPrint->refresh();
+  QTimer::singleShot( 300, this, [this, layoutToPrint, templateLayout = std::move( templateLayout )]() {
+    const QString destination = QStringLiteral( "%1/%2-%3.pdf" ).arg( layoutsFolder(), layoutToPrint->name(), QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_hhmmss" ) ) );
 
-    QgsLayoutExporter exporter = QgsLayoutExporter( layoutToPrint );
-
-    QgsLayoutExporter::PdfExportSettings pdfSettings;
-    pdfSettings.rasterizeWholeImage = layoutToPrint->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
-    pdfSettings.dpi = layoutToPrint->renderContext().dpi();
-    pdfSettings.appendGeoreference = true;
-    pdfSettings.exportMetadata = true;
-    pdfSettings.simplifyGeometries = true;
-
-    success = exporter.exportToPdf( destination, pdfSettings ) == QgsLayoutExporter::Success;
-    if ( success )
+    QString openPath;
+    bool success = false;
+    if ( !layoutToPrint->atlas() || !layoutToPrint->atlas()->enabled() )
     {
-      openPath = destination;
+      if ( layoutToPrint->referenceMap() )
+        layoutToPrint->referenceMap()->zoomToExtent( mMapCanvas->mapSettings()->visibleExtent() );
+      layoutToPrint->refresh();
+
+      QgsLayoutExporter exporter = QgsLayoutExporter( layoutToPrint );
+
+      QgsLayoutExporter::PdfExportSettings pdfSettings;
+      pdfSettings.rasterizeWholeImage = layoutToPrint->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
+      pdfSettings.dpi = layoutToPrint->renderContext().dpi();
+      pdfSettings.appendGeoreference = true;
+      pdfSettings.exportMetadata = true;
+      pdfSettings.simplifyGeometries = true;
+
+      success = exporter.exportToPdf( destination, pdfSettings ) == QgsLayoutExporter::Success;
+      if ( success )
+      {
+        openPath = destination;
+      }
     }
-  }
-  else
-  {
-    success = printAtlas( layoutToPrint, destination );
-    if ( success && layoutToPrint->customProperty( QStringLiteral( "singleFile" ), true ).toBool() )
+    else
     {
-      openPath = destination;
+      success = printAtlas( layoutToPrint, destination );
+      if ( success && layoutToPrint->customProperty( QStringLiteral( "singleFile" ), true ).toBool() )
+      {
+        openPath = destination;
+      }
     }
-  }
 
-  mIsPrinting = false;
-  emit printEnded( success, success ? layoutsFolder() : QString() );
+    mIsPrinting = false;
+    emit printEnded( success, success ? layoutsFolder() : QString() );
 
-  if ( !openPath.isEmpty() )
-  {
-    QfPlatformUtilities::instance()->open( openPath );
-  }
+    if ( !openPath.isEmpty() )
+    {
+      QfPlatformUtilities::instance()->open( openPath );
+    }
+  } );
 
-  return success;
+  return true;
 }
 
 bool QgisMobileapp::printAtlasFeatures( const QString &layoutName, const QList<long long> &featureIds )
@@ -1174,47 +1173,49 @@ bool QgisMobileapp::printAtlasFeatures( const QString &layoutName, const QList<l
 
   mIsPrinting = true;
   emit printTriggered( layoutToPrint->name() );
-  waitForBusyOverlay();
 
-  QStringList ids;
-  for ( const auto id : featureIds )
-  {
-    ids << QString::number( id );
-  }
+  QTimer::singleShot( 300, this, [this, layoutToPrint, featureIds]() {
+    QStringList ids;
+    for ( const long long id : featureIds )
+    {
+      ids << QString::number( id );
+    }
 
-  QString error;
-  const QString priorFilterExpression = layoutToPrint->atlas()->filterExpression();
-  const bool priorFilterFeatures = layoutToPrint->atlas()->filterFeatures();
+    QString error;
+    const QString priorFilterExpression = layoutToPrint->atlas()->filterExpression();
+    const bool priorFilterFeatures = layoutToPrint->atlas()->filterFeatures();
 
-  layoutToPrint->atlas()->setFilterExpression( QStringLiteral( "@id IN (%1)" ).arg( ids.join( ',' ) ), error );
-  layoutToPrint->atlas()->setFilterFeatures( true );
+    layoutToPrint->atlas()->setFilterExpression( QStringLiteral( "@id IN (%1)" ).arg( ids.join( ',' ) ), error );
+    layoutToPrint->atlas()->setFilterFeatures( true );
 
-  const QString destination = QStringLiteral( "%1/%2-%3.pdf" ).arg( layoutsFolder(), layoutToPrint->name(), QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_hhmmss" ) ) );
-  QString openPath;
-  if ( layoutToPrint->customProperty( QStringLiteral( "singleFile" ), true ).toBool() )
-  {
-    openPath = destination;
-  }
-  else if ( ids.size() == 1 )
-  {
-    layoutToPrint->atlas()->updateFeatures();
-    layoutToPrint->atlas()->first();
-    openPath = layoutsFolder() + '/' + layoutToPrint->atlas()->currentFilename() + QStringLiteral( ".pdf" );
-  }
+    const QString destination = QStringLiteral( "%1/%2-%3.pdf" ).arg( layoutsFolder(), layoutToPrint->name(), QDateTime::currentDateTime().toString( QStringLiteral( "yyyyMMdd_hhmmss" ) ) );
+    QString openPath;
+    if ( layoutToPrint->customProperty( QStringLiteral( "singleFile" ), true ).toBool() )
+    {
+      openPath = destination;
+    }
+    else if ( ids.size() == 1 )
+    {
+      layoutToPrint->atlas()->updateFeatures();
+      layoutToPrint->atlas()->first();
+      openPath = layoutsFolder() + '/' + layoutToPrint->atlas()->currentFilename() + QStringLiteral( ".pdf" );
+    }
 
-  const bool success = printAtlas( layoutToPrint, destination );
+    const bool success = printAtlas( layoutToPrint, destination );
 
-  layoutToPrint->atlas()->setFilterExpression( priorFilterExpression, error );
-  layoutToPrint->atlas()->setFilterFeatures( priorFilterFeatures );
+    layoutToPrint->atlas()->setFilterExpression( priorFilterExpression, error );
+    layoutToPrint->atlas()->setFilterFeatures( priorFilterFeatures );
 
-  mIsPrinting = false;
-  emit printEnded( success, success ? layoutsFolder() : QString() );
+    mIsPrinting = false;
+    emit printEnded( success, success ? layoutsFolder() : QString() );
 
-  if ( success && !openPath.isEmpty() )
-  {
-    QfPlatformUtilities::instance()->open( openPath );
-  }
-  return success;
+    if ( success && !openPath.isEmpty() )
+    {
+      QfPlatformUtilities::instance()->open( openPath );
+    }
+  } );
+
+  return true;
 }
 
 bool QgisMobileapp::printAtlas( QgsPrintLayout *layoutToPrint, const QString &destination )
@@ -1253,7 +1254,6 @@ bool QgisMobileapp::printAtlas( QgsPrintLayout *layoutToPrint, const QString &de
   QgsFeedback feedback;
   connect( &feedback, &QgsFeedback::progressChanged, this, [this]( double progress ) {
     emit printProgress( progress / 100.0 );
-    QCoreApplication::processEvents();
   } );
 
   QgsLayoutExporter exporter = QgsLayoutExporter( layoutToPrint );
@@ -1274,15 +1274,6 @@ bool QgisMobileapp::printAtlas( QgsPrintLayout *layoutToPrint, const QString &de
 QString QgisMobileapp::layoutsFolder() const
 {
   return mProject->homePath() + QStringLiteral( "/layouts" );
-}
-
-void QgisMobileapp::waitForBusyOverlay()
-{
-  const int busyOverlayFadeInDelay = 300;
-
-  QEventLoop loop;
-  QTimer::singleShot( busyOverlayFadeInDelay, &loop, &QEventLoop::quit );
-  loop.exec();
 }
 
 void QgisMobileapp::setScreenDimmerTimeout( int timeoutSeconds )

--- a/src/app/qgismobileapp.h
+++ b/src/app/qgismobileapp.h
@@ -194,6 +194,28 @@ class QFIELD_APP_EXPORT QgisMobileapp : public QQmlApplicationEngine, public QfA
      */
     void setMapExtent( const QgsRectangle &extent );
 
+    /**
+     * Emitted when a layout print has been triggered
+     *
+     * @param name The name of the layout being printed
+     */
+    void printTriggered( const QString &name );
+
+    /**
+     * Emitted when an ongoing print reports its progress
+     *
+     * @param progress The progress, between 0.0 and 1.0
+     */
+    void printProgress( double progress );
+
+    /**
+     * Emitted when a print has ended
+     *
+     * @param success Whether the layout made it to a PDF file
+     * @param folderPath The folder the output was written into, empty when the print failed
+     */
+    void printEnded( bool success, const QString &folderPath );
+
   private slots:
 
     void onAfterFirstRendering();
@@ -205,7 +227,10 @@ class QFIELD_APP_EXPORT QgisMobileapp : public QQmlApplicationEngine, public QfA
     void loadProjectQuirks();
     void saveProjectPreviewImage();
     bool printAtlas( QgsPrintLayout *layoutToPrint, const QString &destination );
+    QString layoutsFolder() const;
+    void waitForBusyOverlay();
 
+    bool mIsPrinting = false;
     QgsOfflineEditing *mOfflineEditing = nullptr;
     QfLayerTreeMapCanvasBridge *mLayerTreeCanvasBridge = nullptr;
     QfFlatLayerTreeModel *mFlatLayerTree = nullptr;

--- a/src/app/qgismobileapp.h
+++ b/src/app/qgismobileapp.h
@@ -148,7 +148,7 @@ class QFIELD_APP_EXPORT QgisMobileapp : public QQmlApplicationEngine, public QfA
     /**
      * Prints a given layout from the currently opened project to a PDF file
      * \param layoutName the layout name that will be printed
-     * \return TRUE if the layout was successfully printed
+     * \return TRUE if the print was started, its outcome is reported through printEnded()
      */
     bool print( const QString &layoutName ) override;
 
@@ -156,7 +156,7 @@ class QFIELD_APP_EXPORT QgisMobileapp : public QQmlApplicationEngine, public QfA
      * Prints a given atlas-driven layout from the currently opened project to one or more PDF files
      * \param layoutName the layout name that will be printed
      * \param featureIds the features from the atlas coverage vector layer that will be used to print the layout
-     * \return TRUE if the layout was successfully printed
+     * \return TRUE if the print was started, its outcome is reported through printEnded()
      */
     bool printAtlasFeatures( const QString &layoutName, const QList<long long> &featureIds ) override;
 
@@ -228,7 +228,6 @@ class QFIELD_APP_EXPORT QgisMobileapp : public QQmlApplicationEngine, public QfA
     void saveProjectPreviewImage();
     bool printAtlas( QgsPrintLayout *layoutToPrint, const QString &destination );
     QString layoutsFolder() const;
-    void waitForBusyOverlay();
 
     bool mIsPrinting = false;
     QgsOfflineEditing *mOfflineEditing = nullptr;

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -4835,6 +4835,7 @@ ApplicationWindow {
     }
 
     function onImportTriggered(name) {
+      busyOverlay.reset();
       busyOverlay.text = qsTr("Importing %1").arg(name);
       busyOverlay.state = "visible";
     }
@@ -4862,6 +4863,32 @@ ApplicationWindow {
       }
     }
 
+    function onPrintTriggered(name) {
+      busyOverlay.isPrinting = true;
+      busyOverlay.reset();
+      busyOverlay.text = qsTr("Printing %1").arg(name);
+      busyOverlay.state = "visible";
+    }
+
+    function onPrintProgress(progress) {
+      busyOverlay.progress = progress;
+    }
+
+    function onPrintEnded(success, folderPath) {
+      busyOverlay.isPrinting = false;
+      busyOverlay.state = "hidden";
+      if (!success) {
+        displayToast(qsTr('Print failed'), 'error');
+      } else {
+        displayToast(qsTr('Printed and placed in your project layouts folder'), 'info', qsTr('Open folder'), () => {
+          dashBoard.close();
+          qfieldLocalDataPickerScreen.projectFolderView = true;
+          qfieldLocalDataPickerScreen.model.resetToPath(folderPath);
+          qfieldLocalDataPickerScreen.visible = true;
+        });
+      }
+    }
+
     function onLoadProjectTriggered(path, name) {
       qfieldAuthRequestHandler.isProjectLoading = true;
       messageLogModel.suppress({
@@ -4880,6 +4907,7 @@ ApplicationWindow {
       dashBoard.layerTree.freeze();
       mapCanvasMap.stopRendering();
       mapCanvasMap.freeze('projectload');
+      busyOverlay.reset();
       busyOverlay.text = qsTr("Loading %1").arg(name !== '' ? name : path);
       busyOverlay.state = "visible";
       navigation.clearDestinationFeature();
@@ -5623,12 +5651,22 @@ ApplicationWindow {
   QfBusyOverlay {
     id: busyOverlay
     objectName: 'busyOverlay'
+
+    parent: Overlay.overlay
+    z: dashBoard.z + 1
+
+    property bool isPrinting: false
+
     state: iface.hasProjectOnLaunch() ? "visible" : "hidden"
   }
 
   property bool closeAlreadyRequested: false
 
   onClosing: close => {
+    if (busyOverlay.isPrinting) {
+      close.accepted = false;
+      return;
+    }
     if (screenLocker.enabled) {
       close.accepted = false;
       displayToast(qsTr("Unlock the screen to close project and app"));

--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -4876,6 +4876,7 @@ ApplicationWindow {
 
     function onPrintEnded(success, folderPath) {
       busyOverlay.isPrinting = false;
+      busyOverlay.reset();
       busyOverlay.state = "hidden";
       if (!success) {
         displayToast(qsTr('Print failed'), 'error');

--- a/src/core/qfappinterface.h
+++ b/src/core/qfappinterface.h
@@ -265,6 +265,24 @@ class QfAppInterface : public QObject
      */
     void loadProjectEnded( const QString &path, const QString &name );
 
+    /**
+     * Emitted when a layout print has been triggered.
+     * \param name the name of the layout being printed
+     */
+    void printTriggered( const QString &name );
+
+    /**
+     * Emitted when an ongoing print reports its \a progress.
+     * \note only atlas prints report progress, others stay indefinite
+     */
+    void printProgress( double progress );
+
+    /**
+     * Emitted when a print has ended, \a success telling whether a PDF was written.
+     * \param folderPath the folder the output was written into, empty when the print failed
+     */
+    void printEnded( bool success, const QString &folderPath );
+
     //! Requests QField to set its map to the provided \a extent.
     void setMapExtent( const QgsRectangle &extent );
 

--- a/src/core/qfappinterface.h
+++ b/src/core/qfappinterface.h
@@ -104,6 +104,7 @@ class QfAppInterface : public QObject
     /**
      * Prints a project layout to PDF.
      * \param layoutName the layout name
+     * \returns TRUE if the print was started, its outcome is reported through printEnded()
      */
     Q_INVOKABLE bool print( const QString &layoutName );
 
@@ -111,6 +112,7 @@ class QfAppInterface : public QObject
      * Prints an atlas-driven project layout to PDF.
      * \param layoutName the layout name
      * \param featureIds the list of atlas feature IDs
+     * \returns TRUE if the print was started, its outcome is reported through printEnded()
      */
     Q_INVOKABLE bool printAtlasFeatures( const QString &layoutName, const QList<long long> &featureIds );
 

--- a/src/gui/qml/QfBusyOverlay.qml
+++ b/src/gui/qml/QfBusyOverlay.qml
@@ -55,8 +55,7 @@ Rectangle {
         }
         ScriptAction {
           script: {
-            busyProgress.value = 0.0;
-            busyOverlay.showProgress = false;
+            busyOverlay.reset();
           }
         }
         NumberAnimation {
@@ -85,6 +84,11 @@ Rectangle {
       }
     }
   ]
+
+  function reset() {
+    busyOverlay.showProgress = false;
+    busyOverlay.progress = 0.0;
+  }
 
   // Auto-enable progress tracking when progress value is set > 0
   onProgressChanged: {
@@ -156,6 +160,8 @@ Rectangle {
               color: QfTheme.mainColor
 
               Behavior on width {
+                enabled: busyOverlay.showProgress
+
                 NumberAnimation {
                   duration: 200
                   easing.type: Easing.OutCubic

--- a/src/gui/qml/QfNavigationBar.qml
+++ b/src/gui/qml/QfNavigationBar.qml
@@ -920,9 +920,7 @@ Rectangle {
         } else {
           ids.push(selection.focusedFeature.id);
         }
-        if (iface.printAtlasFeatures(printName, ids)) {
-          displayToast(qsTr('Atlas feature(s) successfully printed and placed in your project folder'));
-        }
+        iface.printAtlasFeatures(printName, ids);
       }
     }
   }

--- a/src/gui/qml/QfNavigationBar.qml
+++ b/src/gui/qml/QfNavigationBar.qml
@@ -912,9 +912,9 @@ Rectangle {
       interval: 500
       repeat: false
       onTriggered: {
-        var ids = [];
+        let ids = [];
         if (toolBar.state === "Indication") {
-          for (var i = 0; i < model.selectedFeatures.length; i++) {
+          for (let i = 0; i < model.selectedFeatures.length; i++) {
             ids.push(model.selectedFeatures[i].id);
           }
         } else {

--- a/src/gui/qml/editorwidgets/QfRelationEditorBase.qml
+++ b/src/gui/qml/editorwidgets/QfRelationEditorBase.qml
@@ -416,9 +416,7 @@ QfEditorWidgetBase {
           repeat: false
           onTriggered: {
             var ids = [childMenu.entryReferencingFeature.id];
-            if (iface.printAtlasFeatures(printName, ids)) {
-              displayToast(qsTr('Atlas feature(s) successfully printed and placed in your project folder'));
-            }
+            iface.printAtlasFeatures(printName, ids);
           }
         }
       }

--- a/src/gui/qml/editorwidgets/QfRelationEditorBase.qml
+++ b/src/gui/qml/editorwidgets/QfRelationEditorBase.qml
@@ -415,7 +415,7 @@ QfEditorWidgetBase {
           interval: 500
           repeat: false
           onTriggered: {
-            var ids = [childMenu.entryReferencingFeature.id];
+            const ids = [childMenu.entryReferencingFeature.id];
             iface.printAtlasFeatures(printName, ids);
           }
         }


### PR DESCRIPTION
### 🚀 Description

Printing a layout gave zero feedback. On a large atlas the app just sits there and looks frozen/crashed.

### ✨ Key changes

- busy overlay while printing, with a real progress bar
- toast when it's done, with an "Open folder" button that jumps to the project layouts folder

### Demo

| Dialog | Toast |
| --- | --- |
| <img width="271" alt="image" src="https://github.com/user-attachments/assets/f677706c-427e-4e7a-91f0-5c14b30b42b2" /> | <img width="271" alt="image" src="https://github.com/user-attachments/assets/29399ba7-286d-43ff-978d-f439231b8c50" /> | 
