### PR TITLE
Fix cloud changes silently not being recorded after a project list rebuild

### DIFF
--- a/src/app/qml/QgisMobileapp.qml
+++ b/src/app/qml/QgisMobileapp.qml
@@ -5268,6 +5268,14 @@ ApplicationWindow {
     }
   }
 
+  Connections {
+    target: layerObserverAlias
+
+    function onChangesNotRecorded(layerName) {
+      displayToast(qsTr('Changes on layer %1 were saved on this device but not recorded for QFieldCloud').arg(layerName), 'error');
+    }
+  }
+
   QfCloudProjectsModel {
     id: cloudProjectsModel
     objectName: "cloudProjectsModel"

--- a/src/core/qfieldcloud/qfcloudproject.cpp
+++ b/src/core/qfieldcloud/qfcloudproject.cpp
@@ -1602,6 +1602,7 @@ void QfCloudProject::push( bool shouldDownloadUpdates )
 
   if ( !mDeltaFileWrapper->toFile() )
   {
+    QgsMessageLog::logMessage( tr( "The changes waiting to be pushed could not be written to disk, so they were not sent: %1" ).arg( mDeltaFileWrapper->errorString() ), QStringLiteral( "QFieldCloud" ), Qgis::Critical );
     return;
   }
 
@@ -1659,6 +1660,7 @@ void QfCloudProject::push( bool shouldDownloadUpdates )
   if ( deltaFileToUpload.isEmpty() )
   {
     mDeltaFileWrapper->setIsPushing( false );
+    writePendingDeltas();
     setStatus( ProjectStatus::Idle );
     return;
   }
@@ -1691,6 +1693,7 @@ void QfCloudProject::push( bool shouldDownloadUpdates )
       QgsMessageLog::logMessage( QStringLiteral( "Failed to upload delta file, reason:\n%1\n%2" ).arg( deltasReply->errorString(), mDeltaFilePushStatusString ) );
 
       mDeltaFileWrapper->setIsPushing( false );
+      writePendingDeltas();
 
       cancelPush();
       return;
@@ -1817,6 +1820,14 @@ void QfCloudProject::push( bool shouldDownloadUpdates )
         }
     }
   } );
+}
+
+void QfCloudProject::writePendingDeltas()
+{
+  if ( mDeltaFileWrapper->isDirty() && !mDeltaFileWrapper->toFile() )
+  {
+    QgsMessageLog::logMessage( QStringLiteral( "Failed to write the delta file after the push. %1" ).arg( mDeltaFileWrapper->errorString() ) );
+  }
 }
 
 void QfCloudProject::cancelPush()

--- a/src/core/qfieldcloud/qfcloudproject.h
+++ b/src/core/qfieldcloud/qfcloudproject.h
@@ -386,6 +386,7 @@ class QfCloudProject : public QObject
 
     void ensureProjectCreated();
     void cancelPush();
+    void writePendingDeltas();
 
     void refreshDeltaList();
     void refreshModification();

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.cpp
@@ -112,6 +112,8 @@ void QfCloudProjectsModel::setLayerObserver( QfLayerObserver *layerObserver )
     return;
   }
 
+  refreshCurrentProject();
+
   emit layerObserverChanged();
 }
 
@@ -124,6 +126,7 @@ void QfCloudProjectsModel::setCurrentProjectId( const QString &currentProjectId 
 {
   if ( mCurrentProjectId == currentProjectId )
   {
+    refreshCurrentProject();
     return;
   }
 
@@ -137,6 +140,37 @@ void QfCloudProjectsModel::setCurrentProjectId( const QString &currentProjectId 
 
   emit currentProjectIdChanged();
   emit currentProjectChanged();
+}
+
+void QfCloudProjectsModel::refreshCurrentProject()
+{
+  if ( mCurrentProjectId.isEmpty() )
+  {
+    return;
+  }
+
+  QfCloudProject *project = findProject( mCurrentProjectId );
+  const bool changed = mCurrentProject != project || !project;
+
+  mCurrentProject = project;
+
+  if ( mLayerObserver )
+  {
+    mLayerObserver->setDeltaFileWrapper( mCurrentProject ? mCurrentProject->deltaFileWrapper() : nullptr );
+  }
+
+  if ( changed )
+  {
+    emit currentProjectChanged();
+  }
+}
+
+void QfCloudProjectsModel::writeCurrentProjectDeltas()
+{
+  if ( mCurrentProject && mCurrentProject->deltaFileWrapper() && mCurrentProject->deltaFileWrapper()->isDirty() )
+  {
+    mCurrentProject->deltaFileWrapper()->toFile();
+  }
 }
 
 QfCloudProject *QfCloudProjectsModel::currentProject() const
@@ -365,6 +399,8 @@ void QfCloudProjectsModel::removeLocalProject( const QString &projectId )
         beginRemoveRows( QModelIndex(), projectIndex.row(), projectIndex.row() );
         delete mProjects.takeAt( projectIndex.row() );
         endRemoveRows();
+
+        refreshCurrentProject();
       }
     }
   }
@@ -497,6 +533,8 @@ void QfCloudProjectsModel::resetProjects()
 {
   if ( !mProjects.isEmpty() )
   {
+    writeCurrentProjectDeltas();
+
     beginResetModel();
     qDeleteAll( mProjects );
     mProjects.clear();
@@ -586,6 +624,8 @@ void QfCloudProjectsModel::projectListReceived()
 
   if ( resetModel && projectFetchOffset == 0 )
   {
+    writeCurrentProjectDeltas();
+
     beginResetModel();
     qDeleteAll( mProjects );
     mProjects.clear();
@@ -621,18 +661,6 @@ void QfCloudProjectsModel::projectListReceived()
   }
   else
   {
-    // All projects fetched, refresh current project details if found
-    if ( !mCurrentProjectId.isEmpty() )
-    {
-      mCurrentProject = findProject( mCurrentProjectId );
-      emit currentProjectChanged();
-
-      if ( mLayerObserver )
-      {
-        mLayerObserver->setDeltaFileWrapper( mCurrentProject ? mCurrentProject->deltaFileWrapper() : nullptr );
-      }
-    }
-
     mIsRefreshing = false;
     emit isRefreshingChanged();
   }
@@ -704,9 +732,10 @@ void QfCloudProjectsModel::insertProjects( const QList<QfCloudProject *> &projec
           mProjects[i]->setDataLastUpdatedAt( project->dataLastUpdatedAt() );
           mProjects[i]->setRestrictedDataLastUpdatedAt( project->restrictedDataLastUpdatedAt() );
           emit dataChanged( index( i, 0 ), index( i, 0 ) );
-
-          delete project;
         }
+
+        delete project;
+
         found = true;
         break;
       }
@@ -922,6 +951,8 @@ void QfCloudProjectsModel::loadProjects( const QJsonArray &remoteProjects, bool 
           continue;
         }
 
+        Q_ASSERT( projectId == cloudProject->id() );
+
         // If the cloud project is a special shared dataset project or if the cloud project
         // had a folder but was not downloaded properly, do not add to the model
         if ( cloudProject->type() == QfCloudProject::ProjectType::SharedDatasets || cloudProject->localPath().isEmpty() )
@@ -932,13 +963,13 @@ void QfCloudProjectsModel::loadProjects( const QJsonArray &remoteProjects, bool 
         {
           userSpecificProjects.push_back( cloudProject );
         }
-
-        Q_ASSERT( projectId == cloudProject->id() );
       }
     }
 
     insertProjects( userSpecificProjects );
   }
+
+  refreshCurrentProject();
 }
 
 int QfCloudProjectsModel::rowCount( const QModelIndex &parent ) const
@@ -1221,10 +1252,12 @@ void QfCloudProjectsModel::projectCreationReceived()
   QfCloudProject *cloudProject = QfCloudProject::fromDetails( projectDetails, mCloudConnection, mGpkgFlusher ); // cppcheck-suppress constVariablePointer
   if ( cloudProject )
   {
-    insertProjects( QList<QfCloudProject *>() << cloudProject );
-    emit projectCreated( cloudProject->id(), fromProjectId, false, QString() );
+    const QString createdProjectId = cloudProject->id();
 
-    if ( QfCloudProject *project = findProject( cloudProject->id() ) )
+    insertProjects( QList<QfCloudProject *>() << cloudProject );
+    emit projectCreated( createdProjectId, fromProjectId, false, QString() );
+
+    if ( QfCloudProject *project = findProject( createdProjectId ) )
     {
       project->setStatus( QfCloudProject::ProjectStatus::Creating );
       project->ensureProjectCreated();

--- a/src/core/qfieldcloud/qfcloudprojectsmodel.h
+++ b/src/core/qfieldcloud/qfcloudprojectsmodel.h
@@ -243,6 +243,9 @@ class QfCloudProjectsModel : public QAbstractListModel
   private:
     void setupProjectConnections( QfCloudProject *project );
 
+    void refreshCurrentProject();
+    void writeCurrentProjectDeltas();
+
     QModelIndex findProjectIndex( const QString &projectId ) const;
 
     void loadProjects( const QJsonArray &remoteProjects = QJsonArray(), bool skipLocalProjects = false );

--- a/src/core/qfieldcloud/qfdeltafilewrapper.cpp
+++ b/src/core/qfieldcloud/qfdeltafilewrapper.cpp
@@ -23,6 +23,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QFileInfo>
+#include <QSaveFile>
 #include <QUuid>
 #include <qgsmessagelog.h>
 #include <qgsproject.h>
@@ -154,6 +155,8 @@ QfDeltaFileWrapper::QfDeltaFileWrapper( const QString &projectId, const QString 
     {
       setError( QfDeltaFileWrapper::ErrorType::IOError, deltaFile.errorString() );
     }
+
+    deltaFile.close();
 
     // toFile() modifies mErrorType and mErrorDetails, that's why we ignore the boolean return
     toFile();
@@ -316,9 +319,9 @@ QString QfDeltaFileWrapper::toString() const
 
 bool QfDeltaFileWrapper::toFile()
 {
-  QFile deltaFile( mFileName );
+  QSaveFile deltaFile( mFileName );
 
-  if ( !deltaFile.open( QIODevice::WriteOnly | QIODevice::Unbuffered ) )
+  if ( !deltaFile.open( QIODevice::WriteOnly ) )
   {
     setError( QfDeltaFileWrapper::ErrorType::IOError, deltaFile.errorString() );
     QgsMessageLog::logMessage( QStringLiteral( "File %1 cannot be open for writing. Reason: %2" ).arg( mFileName, mErrorDetails ) );
@@ -329,10 +332,17 @@ bool QfDeltaFileWrapper::toFile()
   {
     setError( QfDeltaFileWrapper::ErrorType::IOError, deltaFile.errorString() );
     QgsMessageLog::logMessage( QStringLiteral( "Contents of the file %1 has not been written. Reason %2" ).arg( mFileName, mErrorDetails ) );
+    deltaFile.cancelWriting();
     return false;
   }
 
-  deltaFile.close();
+  if ( !deltaFile.commit() )
+  {
+    setError( QfDeltaFileWrapper::ErrorType::IOError, deltaFile.errorString() );
+    QgsMessageLog::logMessage( QStringLiteral( "File %1 could not be replaced with its new contents. Reason: %2" ).arg( mFileName, mErrorDetails ) );
+    return false;
+  }
+
   mIsDirty = false;
   // QgsLogger::debug( "Finished writing deltas JSON" );
 

--- a/src/core/qfieldcloud/qflayerobserver.cpp
+++ b/src/core/qfieldcloud/qflayerobserver.cpp
@@ -48,13 +48,57 @@ QfDeltaFileWrapper *QfLayerObserver::deltaFileWrapper() const
 
 void QfLayerObserver::setDeltaFileWrapper( QfDeltaFileWrapper *wrapper )
 {
-  if ( mDeltaFileWrapper == wrapper )
+  if ( mDeltaFileWrapper == wrapper && wrapper )
   {
     return;
   }
 
   mDeltaFileWrapper = wrapper;
+
+  if ( mDeltaFileWrapper )
+  {
+    mUnrecordedLayerIds.clear();
+  }
+
   emit deltaFileWrapperChanged();
+}
+
+
+void QfLayerObserver::onAfterCommitChanges()
+{
+  if ( !mDeltaFileWrapper || !mDeltaFileWrapper->isDirty() )
+  {
+    return;
+  }
+
+  if ( !mDeltaFileWrapper->toFile() )
+  {
+    QgsMessageLog::logMessage( tr( "Failed to write the QFieldCloud delta file: %1" ).arg( mDeltaFileWrapper->errorString() ), QStringLiteral( "QFieldCloud" ), Qgis::Critical );
+  }
+}
+
+
+bool QfLayerObserver::canRecordDeltas( const QString &localLayerId )
+{
+  if ( mDeltaFileWrapper )
+  {
+    return true;
+  }
+
+  if ( !mUnrecordedLayerIds.contains( localLayerId ) )
+  {
+    mUnrecordedLayerIds.insert( localLayerId );
+
+    const QgsMapLayer *layer = mProject->mapLayer( localLayerId );
+    const QString layerName = layer ? layer->name() : localLayerId;
+
+    QgsMessageLog::logMessage( tr( "Changes committed on layer \"%1\" were not recorded for QFieldCloud: this project has no delta file attached. They are saved on this device only." ).arg( layerName ), QStringLiteral( "QFieldCloud" ), Qgis::Critical );
+
+    QMetaObject::invokeMethod(
+      this, [this, layerName]() { emit changesNotRecorded( layerName ); }, Qt::QueuedConnection );
+  }
+
+  return false;
 }
 
 
@@ -125,7 +169,7 @@ void QfLayerObserver::onBeforeCommitChanges()
 
 void QfLayerObserver::onCommittedFeaturesAdded( const QString &localLayerId, const QgsFeatureList &addedFeatures )
 {
-  if ( !mDeltaFileWrapper || mDeltaFileWrapper->isDeltaBeingApplied() )
+  if ( !canRecordDeltas( localLayerId ) || mDeltaFileWrapper->isDeltaBeingApplied() )
   {
     return;
   }
@@ -144,7 +188,7 @@ void QfLayerObserver::onCommittedFeaturesAdded( const QString &localLayerId, con
 
 void QfLayerObserver::onCommittedFeaturesRemoved( const QString &localLayerId, const QgsFeatureIds &deletedFeatureIds )
 {
-  if ( !mDeltaFileWrapper || mDeltaFileWrapper->isDeltaBeingApplied() )
+  if ( !canRecordDeltas( localLayerId ) || mDeltaFileWrapper->isDeltaBeingApplied() )
   {
     return;
   }
@@ -170,7 +214,7 @@ void QfLayerObserver::onCommittedFeaturesRemoved( const QString &localLayerId, c
 
 void QfLayerObserver::onCommittedAttributeValuesChanges( const QString &localLayerId, const QgsChangedAttributesMap &changedAttributesValues )
 {
-  if ( !mDeltaFileWrapper || mDeltaFileWrapper->isDeltaBeingApplied() )
+  if ( !canRecordDeltas( localLayerId ) || mDeltaFileWrapper->isDeltaBeingApplied() )
   {
     return;
   }
@@ -211,7 +255,7 @@ void QfLayerObserver::onCommittedAttributeValuesChanges( const QString &localLay
 
 void QfLayerObserver::onCommittedGeometriesChanges( const QString &localLayerId, const QgsGeometryMap &changedGeometries )
 {
-  if ( !mDeltaFileWrapper || mDeltaFileWrapper->isDeltaBeingApplied() )
+  if ( !canRecordDeltas( localLayerId ) || mDeltaFileWrapper->isDeltaBeingApplied() )
   {
     return;
   }
@@ -263,7 +307,7 @@ void QfLayerObserver::onEditingStopped()
   mPatchedFids.take( layerId );
   mChangedFeatures.take( layerId );
 
-  if ( !mDeltaFileWrapper->toFile() )
+  if ( mDeltaFileWrapper->isDirty() && !mDeltaFileWrapper->toFile() )
   {
     // TODO somehow indicate the user that writing failed
     QgsMessageLog::logMessage( QStringLiteral( "Failed writing JSON file" ) );
@@ -321,7 +365,7 @@ void QfLayerObserver::addLayerListeners()
         disconnect( vl, &QgsVectorLayer::committedFeaturesRemoved, this, &QfLayerObserver::onCommittedFeaturesRemoved );
         disconnect( vl, &QgsVectorLayer::committedAttributeValuesChanges, this, &QfLayerObserver::onCommittedAttributeValuesChanges );
         disconnect( vl, &QgsVectorLayer::committedGeometriesChanges, this, &QfLayerObserver::onCommittedGeometriesChanges );
-        // TODO use the future "afterCommitChanges" signal
+        disconnect( vl, &QgsVectorLayer::afterCommitChanges, this, &QfLayerObserver::onAfterCommitChanges );
         disconnect( vl, &QgsVectorLayer::editingStopped, this, &QfLayerObserver::onEditingStopped );
 
         // for `cloud` projects, we keep track of any change that has occurred
@@ -330,7 +374,7 @@ void QfLayerObserver::addLayerListeners()
         connect( vl, &QgsVectorLayer::committedFeaturesRemoved, this, &QfLayerObserver::onCommittedFeaturesRemoved );
         connect( vl, &QgsVectorLayer::committedAttributeValuesChanges, this, &QfLayerObserver::onCommittedAttributeValuesChanges );
         connect( vl, &QgsVectorLayer::committedGeometriesChanges, this, &QfLayerObserver::onCommittedGeometriesChanges );
-        // TODO use the future "afterCommitChanges" signal
+        connect( vl, &QgsVectorLayer::afterCommitChanges, this, &QfLayerObserver::onAfterCommitChanges );
         connect( vl, &QgsVectorLayer::editingStopped, this, &QfLayerObserver::onEditingStopped );
 
         mObservedLayerIds.insert( vl->id() );

--- a/src/core/qfieldcloud/qflayerobserver.h
+++ b/src/core/qfieldcloud/qflayerobserver.h
@@ -74,6 +74,7 @@ class QfLayerObserver : public QObject
   signals:
     void layerEdited( const QString &layerId );
     void deltaFileWrapperChanged();
+    void changesNotRecorded( const QString &layerName );
 
 
   private slots:
@@ -126,6 +127,9 @@ class QfLayerObserver : public QObject
     void onCommittedGeometriesChanges( const QString &localLayerId, const QgsGeometryMap &changedGeometries );
 
 
+    void onAfterCommitChanges();
+
+
     /**
      * Writes the deltas to the delta file
      */
@@ -133,10 +137,14 @@ class QfLayerObserver : public QObject
 
 
   private:
+    bool canRecordDeltas( const QString &localLayerId );
+
     /**
      * The current deltas file wrapper object
      */
     QPointer<QfDeltaFileWrapper> mDeltaFileWrapper;
+
+    QSet<QString> mUnrecordedLayerIds;
 
 
     /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -124,6 +124,7 @@ add_definitions(-DTEST_DATA_DIR="${TEST_DATA_DIR}")
 
 if (WITH_UNITTESTS)
   ADD_CATCH2_TEST(layerobservertest test_layerobserver.cpp FALSE)
+  ADD_CATCH2_TEST(cloudprojectsmodeltest test_cloudprojectsmodel.cpp FALSE)
   ADD_CATCH2_TEST(featureutilstest test_featureutils.cpp TRUE)
   ADD_CATCH2_TEST(featuremodeltest test_featuremodel.cpp TRUE)
   ADD_CATCH2_TEST(featurehistorytest test_featurehistory.cpp FALSE)

--- a/test/test_cloudprojectsmodel.cpp
+++ b/test/test_cloudprojectsmodel.cpp
@@ -1,0 +1,96 @@
+/***************************************************************************
+                        test_cloudprojectsmodel.cpp
+                        ---------------------------
+  begin                : Sep 2026
+  copyright            : (C) 2026 by tw0b33rs
+  email                : 28195707+tw0b33rs@users.noreply.github.com
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#define QFIELDTEST_MAIN
+#include "catch2.h"
+#include "qfcloudconnection.h"
+#include "qfcloudprojectsmodel.h"
+#include "qfdeltafilewrapper.h"
+#include "qflayerobserver.h"
+#include "utils/qfcloudutils.h"
+
+#include <QDir>
+#include <QFile>
+#include <QPointer>
+#include <QSettings>
+#include <QTemporaryDir>
+#include <qgsproject.h>
+
+TEST_CASE( "CloudProjectsModel" )
+{
+  static QTemporaryDir dataDir;
+
+  REQUIRE( dataDir.isValid() );
+
+  QSettings::setDefaultFormat( QSettings::IniFormat );
+  QSettings::setPath( QSettings::IniFormat, QSettings::UserScope, dataDir.path() );
+
+  const QString username( QStringLiteral( "surveyor" ) );
+  const QString projectId( QStringLiteral( "00000000-0000-4000-8000-000000000001" ) );
+  const QString cloudDirectory = QStringLiteral( "%1/cloud_projects" ).arg( dataDir.path() );
+  const QString projectDirectory = QStringLiteral( "%1/%2/%3" ).arg( cloudDirectory, username, projectId );
+
+  QfCloudUtils::setLocalCloudDirectory( cloudDirectory );
+
+  REQUIRE( QDir().mkpath( projectDirectory ) );
+
+  QFile projectFile( QStringLiteral( "%1/project.qgs" ).arg( projectDirectory ) );
+
+  REQUIRE( projectFile.open( QIODevice::WriteOnly ) );
+
+  projectFile.close();
+
+  QfCloudUtils::setProjectSetting( projectId, QStringLiteral( "name" ), QStringLiteral( "Test project" ) );
+  QfCloudUtils::setProjectSetting( projectId, QStringLiteral( "owner" ), username );
+  QfCloudUtils::setProjectSetting( projectId, QStringLiteral( "lastLocalExportId" ), QStringLiteral( "TEST_EXPORT_ID" ) );
+
+  QfCloudConnection connection;
+  QfLayerObserver layerObserver( QgsProject::instance() );
+  QfCloudProjectsModel model;
+
+  model.setCloudConnection( &connection );
+  model.setLayerObserver( &layerObserver );
+
+  connection.setUsername( username );
+  model.setCurrentProjectId( projectId );
+
+  REQUIRE( model.currentProject() );
+  REQUIRE( layerObserver.deltaFileWrapper() );
+
+  SECTION( "TheLayerObserverSurvivesAProjectListRebuild" )
+  {
+    QPointer<QfDeltaFileWrapper> wrapperBefore = layerObserver.deltaFileWrapper();
+
+    connection.setUsername( QStringLiteral( "somebody-else" ) );
+    connection.setUsername( username );
+
+    REQUIRE( wrapperBefore.isNull() );
+    REQUIRE( model.currentProject() );
+    REQUIRE( layerObserver.deltaFileWrapper() );
+    REQUIRE( layerObserver.deltaFileWrapper() == model.currentProject()->deltaFileWrapper() );
+  }
+
+  SECTION( "TheLayerObserverIsDetachedWhenTheProjectIsGone" )
+  {
+    connection.setUsername( QStringLiteral( "somebody-else" ) );
+
+    REQUIRE( !model.currentProject() );
+    REQUIRE( !layerObserver.deltaFileWrapper() );
+  }
+
+  QfCloudUtils::setLocalCloudDirectory( QString() );
+}

--- a/test/test_layerobserver.cpp
+++ b/test/test_layerobserver.cpp
@@ -164,6 +164,22 @@ TEST_CASE( "LayerObserver" )
   }
 
 
+  SECTION( "WritesAfterCommitWhileStillEditing" )
+  {
+    QgsFeature f1( mLayer->fields() );
+    f1.setAttribute( QStringLiteral( "fid" ), 1004 );
+    f1.setAttribute( QStringLiteral( "str" ), "new_string" );
+    f1.setGeometry( QgsGeometry( new QgsPoint( 25.9657, 43.8356 ) ) );
+
+    REQUIRE( mLayer->startEditing() );
+    REQUIRE( mLayer->addFeature( f1 ) );
+    REQUIRE( mLayer->commitChanges( false ) );
+    REQUIRE( mLayer->isEditable() );
+    REQUIRE( getDeltaOperations( mLayerObserver->deltaFileWrapper()->fileName() ) == QStringList( { "create" } ) );
+    REQUIRE( mLayer->commitChanges() );
+  }
+
+
   SECTION( "ObservesAdded" )
   {
     QgsFeature f1( mLayer->fields() );


### PR DESCRIPTION
Editing a downloaded cloud project after the project list has been rebuilt saves
the change locally but records no delta: the cloud button shows no badge, the
popup lists nothing to push, auto-push never starts, and the next download replaces
the dataset the change lives in.

QfLayerObserver holds the delta file wrapper as a QPointer owned by a
QfCloudProject. Rebuilding the list destroys the projects, the pointer becomes null
without a signal, and the post-commit slots drop every change without a log line.
#7710 (for #7708) re-attaches once a listing comes back from the server; offline,
nothing does. resetProjects(), loadProjects(), insertProjects() and
removeLocalProject() never re-attached, and setCurrentProjectId() returned early on
an unchanged id.

- Route every rebuild through one refreshCurrentProject(); announce a null outcome
  too, and write the current project's unsaved deltas before the projects are
  destroyed.
- Log and show it when a committed change cannot be recorded.
- Write the delta file on QgsVectorLayer::afterCommitChanges() rather than only
  on editingStopped(), which never fires for a layer committed while it stays
  editable; write it through QSaveFile; write deltas recorded during a push on the
  two failure paths that did not.
- Also fixed on the way: a leaked duplicate project holding a second wrapper on
  the same delta file, and an assertion reading a deleted project.

Tests: the observer must keep recording across a rebuild triggered by a sign-in,
and commitChanges( false ) must write the delta file. Both fail on master.
Verified on an iPad: an edit made in airplane mode is recorded and reaches the
server on the next push with the same delta file id.
