### PR TITLE
add selection count and total size to local data picker header

### DIFF
--- a/src/app/qml/QfLocalDataPickerScreen.qml
+++ b/src/app/qml/QfLocalDataPickerScreen.qml
@@ -72,7 +72,7 @@ Page {
 
         Text {
           Layout.fillWidth: true
-          text: table.model.currentTitle
+          text: localFilesModel.inSelectionMode ? qsTr('%n item(s) selected', '', localFilesModel.selectedCount) : table.model.currentTitle
           font.pointSize: QfTheme.defaultFont.pointSize
           font.bold: true
           color: QfTheme.mainTextColor
@@ -82,7 +82,7 @@ Page {
         Text {
           Layout.fillWidth: true
           visible: text !== ''
-          text: table.model.currentPath !== 'root' ? table.model.currentPath : ''
+          text: localFilesModel.inSelectionMode ? QfFileUtils.representFileSize(localFilesModel.selectedSize) : (table.model.currentPath !== 'root' ? table.model.currentPath : '')
           font: QfTheme.tipFont
           color: QfTheme.mainTextColor
           wrapMode: Text.NoWrap

--- a/src/gui/qflocalfilesmodel.cpp
+++ b/src/gui/qflocalfilesmodel.cpp
@@ -24,6 +24,8 @@
 #include <QFile>
 #include <QImageReader>
 
+#include <algorithm>
+
 QfLocalFilesModel::QfLocalFilesModel( QObject *parent )
   : QAbstractListModel( parent )
 {
@@ -419,6 +421,18 @@ bool QfLocalFilesModel::inSelectionMode()
   return std::any_of( mItems.begin(), mItems.end(), []( const QfLocalFileItem &item ) { return item.checked(); } );
 }
 
+int QfLocalFilesModel::selectedCount() const
+{
+  return static_cast<int>( std::count_if( mItems.begin(), mItems.end(), []( const QfLocalFileItem &item ) { return item.checked(); } ) );
+}
+
+qint64 QfLocalFilesModel::selectedSize() const
+{
+  return std::accumulate( mItems.begin(), mItems.end(), qint64( 0 ), []( qint64 sum, const QfLocalFileItem &item ) {
+    return item.checked() ? sum + item.size() : sum;
+  } );
+}
+
 void QfLocalFilesModel::setChecked( const int &mIdx, const bool &checked )
 {
   if ( mIdx < 0 || mIdx >= mItems.size() )
@@ -439,6 +453,7 @@ void QfLocalFilesModel::setChecked( const int &mIdx, const bool &checked )
     {
       emit inSelectionModeChanged();
     }
+    emit selectionDetailsChanged();
   }
 }
 
@@ -449,5 +464,6 @@ void QfLocalFilesModel::clearSelection()
     item.setChecked( false );
   }
   emit inSelectionModeChanged();
+  emit selectionDetailsChanged();
   emit dataChanged( index( 0, 0, QModelIndex() ), index( static_cast<int>( mItems.size() ) - 1, 0, QModelIndex() ), { ItemCheckedRole } );
 }

--- a/src/gui/qflocalfilesmodel.h
+++ b/src/gui/qflocalfilesmodel.h
@@ -32,6 +32,8 @@ class QfLocalFilesModel : public QAbstractListModel
     Q_PROPERTY( int currentDepth READ currentDepth NOTIFY currentPathChanged )
     Q_PROPERTY( bool isDeletedAllowedInCurrentPath READ isDeletedAllowedInCurrentPath NOTIFY currentPathChanged )
     Q_PROPERTY( bool inSelectionMode READ inSelectionMode NOTIFY inSelectionModeChanged )
+    Q_PROPERTY( int selectedCount READ selectedCount NOTIFY selectionDetailsChanged )
+    Q_PROPERTY( qint64 selectedSize READ selectedSize NOTIFY selectionDetailsChanged )
 
   public:
     enum ItemMetaType
@@ -121,6 +123,12 @@ class QfLocalFilesModel : public QAbstractListModel
     //! Returns whether list is in multi-selection mode or not
     bool inSelectionMode();
 
+    //! Returns the number of checked items
+    int selectedCount() const;
+
+    //! Returns the summed size of checked items in bytes
+    qint64 selectedSize() const;
+
     //! Set checked state of an item in list
     Q_INVOKABLE void setChecked( const int &mIdx, const bool &checked );
 
@@ -132,6 +140,8 @@ class QfLocalFilesModel : public QAbstractListModel
     void currentPathChanged();
 
     void inSelectionModeChanged();
+
+    void selectionDetailsChanged();
 
   private:
     void reloadModel();


### PR DESCRIPTION
when items are selected, the header now shows the selection count in place of the folder title and the summed file size in place of the path

also fixes setChecked to emit inSelectionModeChanged on every checked state change, not just when selection presence flips, the count/size were stale going from 1 to 2 selected otherwise

## demo


https://github.com/user-attachments/assets/77d9c4f6-3d88-4174-afd9-babfc07ea85c

