### PR TITLE
Cloudifying: Validate project 

### DIFF
--- a/src/app/qml/QfCloudPopup.qml
+++ b/src/app/qml/QfCloudPopup.qml
@@ -29,6 +29,7 @@ Popup {
     pendingAction = "";
     pendingCreationTitle = "";
     pendingUploadPath = "";
+    cloudifyError.titleText = "";
     swipeView.currentIndex = 1;
   }
 
@@ -391,6 +392,16 @@ Popup {
               iconSource: QfTheme.getThemeVectorIcon('ic_cloud_active_24dp')
               title: qsTr('Cloudify project')
               description: localProjectGrid.isCloudifying ? qsTr('Uploading the current project to QFieldCloud.') : qsTr('The current project is not stored on QFieldCloud. Storing projects on QFieldCloud offers seamless synchronization, offline editing, and team management.') + (Qt.platform.os !== "ios" ? ' <a href="https://qfield.cloud/">' + qsTr('Learn more about QFieldCloud') + '</a>.' : '')
+
+              QfCollapsibleMessage {
+                id: cloudifyError
+                Layout.fillWidth: true
+                Layout.topMargin: 4
+                visible: titleText !== ''
+                color: QfTheme.darkRed
+                font: QfTheme.tipFont
+                iconSource: QfTheme.getThemeVectorIcon('ic_error_outline_24dp')
+              }
 
               QfButton {
                 Layout.fillWidth: true
@@ -946,7 +957,7 @@ Popup {
         qfieldCloudPopup.visible = true;
       }
       if (hasError) {
-        displayToast(errorString, 'error');
+        cloudifyError.titleText = errorString;
         return;
       }
       const createdCloudProject = cloudProjectsModel.findProject(projectId);
@@ -963,7 +974,7 @@ Popup {
 
     function onUploadFinished(error) {
       if (error !== '') {
-        displayToast(error, 'error');
+        cloudifyError.titleText = error;
         cloudProjectCreationConnection.target = null;
         return;
       }
@@ -1103,11 +1114,13 @@ Popup {
     if (!opened) {
       show();
     }
+    cloudifyError.titleText = QfCloudUtils.cloudifyErrorString(path);
+    if (cloudifyError.titleText !== '') {
+      return;
+    }
     pendingCreationTitle = title;
     pendingUploadPath = path;
     if (cloudConnection.status === QfCloudConnection.LoggedIn) {
-      pendingCreationTitle = title;
-      pendingUploadPath = path;
       cloudProjectsModel.createProject(title);
     } else {
       popup.pendingAction = "cloudify";

--- a/src/app/qml/QfCloudPopup.qml
+++ b/src/app/qml/QfCloudPopup.qml
@@ -1114,7 +1114,7 @@ Popup {
     if (!opened) {
       show();
     }
-    cloudifyError.titleText = QfCloudUtils.cloudifyErrorString(path);
+    cloudifyError.titleText = QfCloudUtils.checkCloudifyFeasibility(path);
     if (cloudifyError.titleText !== '') {
       return;
     }

--- a/src/core/qfieldcloud/qfcloudproject.cpp
+++ b/src/core/qfieldcloud/qfcloudproject.cpp
@@ -2445,7 +2445,7 @@ void QfCloudProject::setupDeltaFileWrapper()
 
 void QfCloudProject::uploadLocalPath( QString localPath, bool deleteAfterSuccessfulUpload )
 {
-  const QString localPathError = QfCloudUtils::cloudifyErrorString( localPath );
+  const QString localPathError = QfCloudUtils::checkCloudifyFeasibility( localPath );
   if ( !localPathError.isEmpty() )
   {
     emit uploadFinished( localPathError );

--- a/src/core/qfieldcloud/qfcloudproject.cpp
+++ b/src/core/qfieldcloud/qfcloudproject.cpp
@@ -2445,39 +2445,21 @@ void QfCloudProject::setupDeltaFileWrapper()
 
 void QfCloudProject::uploadLocalPath( QString localPath, bool deleteAfterSuccessfulUpload )
 {
-  QFileInfo localInfo( localPath );
-  if ( !localInfo.exists() )
+  const QString localPathError = QfCloudUtils::cloudifyErrorString( localPath );
+  if ( !localPathError.isEmpty() )
   {
-    emit uploadFinished( tr( "Local path doesn't exist" ) );
+    emit uploadFinished( localPathError );
     return;
   }
 
+  const QFileInfo localInfo( localPath );
   if ( localInfo.isFile() )
   {
     localPath = localInfo.absolutePath();
   }
 
-  QFileInfo projectFileInfo;
-  QDirIterator projectDirIterator( localPath, { "*.qgs", "*.qgz" }, QDir::Files, QDirIterator::Subdirectories );
-  while ( projectDirIterator.hasNext() )
-  {
-    projectDirIterator.next();
-    if ( projectFileInfo.exists() )
-    {
-      emit uploadFinished( tr( "Local path to upload cannot be used as it has multiple project files" ) );
-      return;
-    }
-    projectFileInfo = projectDirIterator.fileInfo();
-  }
-
-  if ( !projectFileInfo.exists() || projectFileInfo.size() == 0 )
-  {
-    emit uploadFinished( tr( "Local path to upload is missing a valid project file" ) );
-    return;
-  }
-
   const QString currentProjectLocalPath = QfFileUtils::absolutePath( QgsProject::instance()->fileName() );
-  if ( projectFileInfo.absoluteFilePath() == currentProjectLocalPath )
+  if ( !currentProjectLocalPath.isEmpty() && QDir( localPath ) == QDir( currentProjectLocalPath ) )
   {
     // we need to close the project to safely flush the gpkg files and avoid file lock on Windows
     QDirIterator it( localPath, { QStringLiteral( "*.gpkg" ), QStringLiteral( "*.sqlite" ) }, QDir::Filter::Files, QDirIterator::Subdirectories );

--- a/src/core/utils/qfcloudutils.cpp
+++ b/src/core/utils/qfcloudutils.cpp
@@ -20,6 +20,7 @@
 #include "qfstringutils.h"
 
 #include <QDir>
+#include <QDirIterator>
 #include <QFile>
 #include <QLockFile>
 #include <QStandardPaths>
@@ -118,6 +119,36 @@ QString QfCloudUtils::documentationFromErrorString( const QString &errorString )
   if ( errorString.contains( errorCodeOverQuota() ) )
   {
     return QStringLiteral( "https://docs.qfield.org/get-started/storage-qfc/#adding-qfieldcloud-storage" );
+  }
+
+  return QString();
+}
+
+QString QfCloudUtils::cloudifyErrorString( const QString &localPath )
+{
+  const QFileInfo localPathInfo( localPath );
+  if ( !localPathInfo.exists() )
+  {
+    return tr( "The project folder could not be found." );
+  }
+
+  const QString projectDirectoryPath = localPathInfo.isFile() ? localPathInfo.absolutePath() : localPathInfo.absoluteFilePath();
+
+  QFileInfo projectFileInfo;
+  QDirIterator projectDirIterator( projectDirectoryPath, { QStringLiteral( "*.qgs" ), QStringLiteral( "*.qgz" ) }, QDir::Files, QDirIterator::Subdirectories );
+  while ( projectDirIterator.hasNext() )
+  {
+    projectDirIterator.next();
+    if ( projectFileInfo.exists() )
+    {
+      return tr( "The project folder contains more than one project file, move the project into a folder of its own and try again." );
+    }
+    projectFileInfo = projectDirIterator.fileInfo();
+  }
+
+  if ( !projectFileInfo.exists() || projectFileInfo.size() == 0 )
+  {
+    return tr( "The project folder does not contain a valid project file." );
   }
 
   return QString();

--- a/src/core/utils/qfcloudutils.cpp
+++ b/src/core/utils/qfcloudutils.cpp
@@ -124,7 +124,7 @@ QString QfCloudUtils::documentationFromErrorString( const QString &errorString )
   return QString();
 }
 
-QString QfCloudUtils::cloudifyErrorString( const QString &localPath )
+QString QfCloudUtils::checkCloudifyFeasibility( const QString &localPath )
 {
   const QFileInfo localPathInfo( localPath );
   if ( !localPathInfo.exists() )
@@ -134,21 +134,26 @@ QString QfCloudUtils::cloudifyErrorString( const QString &localPath )
 
   const QString projectDirectoryPath = localPathInfo.isFile() ? localPathInfo.absolutePath() : localPathInfo.absoluteFilePath();
 
-  QFileInfo projectFileInfo;
+  bool projectFileFound = false;
   QDirIterator projectDirIterator( projectDirectoryPath, { QStringLiteral( "*.qgs" ), QStringLiteral( "*.qgz" ) }, QDir::Files, QDirIterator::Subdirectories );
   while ( projectDirIterator.hasNext() )
   {
-    projectDirIterator.next();
-    if ( projectFileInfo.exists() )
+    if ( projectFileFound )
     {
       return tr( "The project folder contains more than one project file, move the project into a folder of its own and try again." );
     }
-    projectFileInfo = projectDirIterator.fileInfo();
+    projectFileFound = true;
+
+    projectDirIterator.next();
+    if ( projectDirIterator.fileInfo().size() == 0 )
+    {
+      return tr( "The project folder does not contain a valid project file." );
+    }
   }
 
-  if ( !projectFileInfo.exists() || projectFileInfo.size() == 0 )
+  if ( !projectFileFound )
   {
-    return tr( "The project folder does not contain a valid project file." );
+    return tr( "The project folder does not contain a project file." );
   }
 
   return QString();

--- a/src/core/utils/qfcloudutils.h
+++ b/src/core/utils/qfcloudutils.h
@@ -329,10 +329,11 @@ class QfCloudUtils : public QObject
     Q_INVOKABLE static QString documentationFromErrorString( const QString &errorString );
 
     /**
-     * Returns the reason why the project found in \a localPath cannot be stored on QFieldCloud,
-     * or an empty string when it can. \a localPath can either be a project file or the folder holding it.
+     * Checks whether the project found in \a localPath can be stored on QFieldCloud, and returns the
+     * reason why it cannot, or an empty string when it can. \a localPath can either be a project file
+     * or the folder holding it.
      */
-    Q_INVOKABLE static QString cloudifyErrorString( const QString &localPath );
+    Q_INVOKABLE static QString checkCloudifyFeasibility( const QString &localPath );
 
     //! Sets a \a setting to a given \a value for project with given \a projectId to the permanent storage.
     static void setProjectSetting( const QString &projectId, const QString &setting, const QVariant &value );

--- a/src/core/utils/qfcloudutils.h
+++ b/src/core/utils/qfcloudutils.h
@@ -328,6 +328,12 @@ class QfCloudUtils : public QObject
      */
     Q_INVOKABLE static QString documentationFromErrorString( const QString &errorString );
 
+    /**
+     * Returns the reason why the project found in \a localPath cannot be stored on QFieldCloud,
+     * or an empty string when it can. \a localPath can either be a project file or the folder holding it.
+     */
+    Q_INVOKABLE static QString cloudifyErrorString( const QString &localPath );
+
     //! Sets a \a setting to a given \a value for project with given \a projectId to the permanent storage.
     static void setProjectSetting( const QString &projectId, const QString &setting, const QVariant &value );
 

--- a/test/test_qfieldcloudutils.cpp
+++ b/test/test_qfieldcloudutils.cpp
@@ -98,7 +98,7 @@ void writeFile( const QString &filePath, const QByteArray &content )
 }
 
 
-TEST_CASE( "QFieldCloudUtils::cloudifyErrorString" )
+TEST_CASE( "QFieldCloudUtils::checkCloudifyFeasibility" )
 {
   QTemporaryDir projectDir;
   REQUIRE( projectDir.isValid() );
@@ -107,22 +107,22 @@ TEST_CASE( "QFieldCloudUtils::cloudifyErrorString" )
 
   SECTION( "Missing folder returns an error" )
   {
-    REQUIRE_FALSE( QfCloudUtils::cloudifyErrorString( QStringLiteral( "%1/missing" ).arg( projectDir.path() ) ).isEmpty() );
+    REQUIRE_FALSE( QfCloudUtils::checkCloudifyFeasibility( QStringLiteral( "%1/missing" ).arg( projectDir.path() ) ).isEmpty() );
   }
 
   SECTION( "Folder without a valid project file returns an error" )
   {
-    REQUIRE_FALSE( QfCloudUtils::cloudifyErrorString( projectDir.path() ).isEmpty() );
+    REQUIRE_FALSE( QfCloudUtils::checkCloudifyFeasibility( projectDir.path() ).isEmpty() );
     writeFile( projectFilePath, QByteArray() );
-    REQUIRE_FALSE( QfCloudUtils::cloudifyErrorString( projectDir.path() ).isEmpty() );
+    REQUIRE_FALSE( QfCloudUtils::checkCloudifyFeasibility( projectDir.path() ).isEmpty() );
   }
 
   SECTION( "A single project file passes, a second one returns an error" )
   {
     writeFile( projectFilePath, QByteArray( "project" ) );
-    REQUIRE( QfCloudUtils::cloudifyErrorString( projectDir.path() ).isEmpty() );
-    REQUIRE( QfCloudUtils::cloudifyErrorString( projectFilePath ).isEmpty() );
+    REQUIRE( QfCloudUtils::checkCloudifyFeasibility( projectDir.path() ).isEmpty() );
+    REQUIRE( QfCloudUtils::checkCloudifyFeasibility( projectFilePath ).isEmpty() );
     writeFile( QStringLiteral( "%1/other.qgs" ).arg( projectDir.path() ), QByteArray( "project" ) );
-    REQUIRE_FALSE( QfCloudUtils::cloudifyErrorString( projectDir.path() ).isEmpty() );
+    REQUIRE_FALSE( QfCloudUtils::checkCloudifyFeasibility( projectDir.path() ).isEmpty() );
   }
 }

--- a/test/test_qfieldcloudutils.cpp
+++ b/test/test_qfieldcloudutils.cpp
@@ -18,7 +18,10 @@
 #include "qfieldcloud/qfcloudconnection.h"
 #include "utils/qfcloudutils.h"
 
+#include <QDir>
+#include <QFile>
 #include <QJsonObject>
+#include <QTemporaryDir>
 
 
 TEST_CASE( "CloudSubscriptionInformation" )
@@ -83,5 +86,43 @@ TEST_CASE( "QFieldCloudUtils::subscriptionManagementUrl" )
   SECTION( "Community plan takes precedence over owner check" )
   {
     REQUIRE( QfCloudUtils::subscriptionManagementUrl( defaultUrl, QStringLiteral( "Community" ), QStringLiteral( "org_owner" ), QStringLiteral( "alice" ) ) == QStringLiteral( "https://app.qfield.cloud/plans" ) );
+  }
+}
+
+
+void writeFile( const QString &filePath, const QByteArray &content )
+{
+  QFile file( filePath );
+  REQUIRE( file.open( QIODevice::WriteOnly ) );
+  file.write( content );
+}
+
+
+TEST_CASE( "QFieldCloudUtils::cloudifyErrorString" )
+{
+  QTemporaryDir projectDir;
+  REQUIRE( projectDir.isValid() );
+
+  const QString projectFilePath = QStringLiteral( "%1/project.qgz" ).arg( projectDir.path() );
+
+  SECTION( "Missing folder returns an error" )
+  {
+    REQUIRE_FALSE( QfCloudUtils::cloudifyErrorString( QStringLiteral( "%1/missing" ).arg( projectDir.path() ) ).isEmpty() );
+  }
+
+  SECTION( "Folder without a valid project file returns an error" )
+  {
+    REQUIRE_FALSE( QfCloudUtils::cloudifyErrorString( projectDir.path() ).isEmpty() );
+    writeFile( projectFilePath, QByteArray() );
+    REQUIRE_FALSE( QfCloudUtils::cloudifyErrorString( projectDir.path() ).isEmpty() );
+  }
+
+  SECTION( "A single project file passes, a second one returns an error" )
+  {
+    writeFile( projectFilePath, QByteArray( "project" ) );
+    REQUIRE( QfCloudUtils::cloudifyErrorString( projectDir.path() ).isEmpty() );
+    REQUIRE( QfCloudUtils::cloudifyErrorString( projectFilePath ).isEmpty() );
+    writeFile( QStringLiteral( "%1/other.qgs" ).arg( projectDir.path() ), QByteArray( "project" ) );
+    REQUIRE_FALSE( QfCloudUtils::cloudifyErrorString( projectDir.path() ).isEmpty() );
   }
 }


### PR DESCRIPTION
### 🚀 Description

Cloudifying a project that cannot be uploaded now fails and says why.

### ✨ Key changes

- The local path checks moved to `QfCloudUtils::cloudifyErrorString()` and run before `createProject()`, so a failed cloudify no longer leaves an empty project on the account.
- The reason is shown in the cloudify card.
- Added tests for `cloudifyErrorString()`.




### Before

 https://github.com/user-attachments/assets/beb7b76d-bfba-4649-ab5e-ae40325d9a4b


### After 
https://github.com/user-attachments/assets/c6b3190a-652a-4eca-ab2f-dde8a914b006 
