### PR TITLE
Center the video camera quality slider

### DIFF
--- a/src/gui/qml/QfCamera.qml
+++ b/src/gui/qml/QfCamera.qml
@@ -1111,12 +1111,10 @@ Popup {
       readonly property int selectedQuality: qualities.indexOf(cameraSettings.videoQuality) >= 0 ? cameraSettings.videoQuality : 0
       readonly property size targetResolution: captureLoader.item ? cameraItem.videoResolutionForQuality(captureLoader.item.cameraResolution, selectedQuality) : Qt.size(0, 0)
 
-      readonly property real availableWidth: cameraItem.isPortraitMode ? parent.width : parent.width - captureBar.width
-
-      width: Math.min(availableWidth - 80, 320)
+      width: Math.min(parent.width - 80, 320)
       height: videoQualityColumn.height
 
-      x: availableWidth / 2 - width / 2
+      anchors.horizontalCenter: parent.horizontalCenter
       y: parent.height - height - 20 - (cameraItem.isPortraitMode ? captureBar.height : mainWindow.sceneBottomMargin)
 
       Column {


### PR DESCRIPTION
### 🚀 Description
Follow-up to #7901: Center the video quality slider.

### Demo

| Landscape | Portrait |
| --- | --- |
| <img width="271" alt="image" src="https://github.com/user-attachments/assets/116a23fb-3a3d-4e93-8caa-bc5e8cb3bd5e" /> | <img width="271" alt="image" src="https://github.com/user-attachments/assets/989fab72-a9f9-4dae-8c61-d8f83e5d19b6" /> | 
