### PR TITLE
[Backport release-4_3] Restore every saved QFieldCloud cookie by substituting the index into its settings key

### DIFF
--- a/src/core/qfieldcloud/qfcloudconnection.cpp
+++ b/src/core/qfieldcloud/qfcloudconnection.cpp
@@ -1199,7 +1199,7 @@ void QfCloudConnection::saveCookies()
   {
     if ( !cookies[idx].isSessionCookie() && QDateTime::currentSecsSinceEpoch() < cookies[idx].expirationDate().toSecsSinceEpoch() )
     {
-      settings.setValue( QStringLiteral( "/QFieldCloud/cookies/%1" ), cookies[idx].toRawForm() );
+      settings.setValue( QStringLiteral( "/QFieldCloud/cookies/%1" ).arg( idx ), cookies[idx].toRawForm() );
     }
   }
 }


### PR DESCRIPTION
Backport #7941
 **Authored by:** @tw0b33rs