### PR TITLE
Let's try to build iOS using OpenSSL

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -52,6 +52,11 @@
 #include <QTranslator>
 #include <QtWebView/QtWebView>
 
+#if defined( Q_OS_IOS )
+#include <QSslCertificate>
+#include <QSslConfiguration>
+#endif
+
 #include <proj.h>
 
 #if HAVE_STATIC_QCA_PLUGINS
@@ -175,6 +180,13 @@ int main( int argc, char **argv )
 
   QfPlatformUtilities *platformUtils = QfPlatformUtilities::instance();
   platformUtils->initSystem();
+
+#if defined( RELATIVE_PREFIX_PATH ) && defined( Q_OS_IOS )
+  const QList<QSslCertificate> certs = QSslCertificate::fromPath( QDir::toNativeSeparators( QfPlatformUtilities::instance()->systemSharedDataLocation() + "/cacert.pem" ) );
+  QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
+  sslConfig.setCaCertificates( certs );
+  QSslConfiguration::setDefaultConfiguration( sslConfig );
+#endif
 
   // Let's make sure we have a writable path for the QGIS profile on every platform
   const QString profilePath = platformUtils->systemLocalDataLocation( QStringLiteral( "profiles/default" ) );

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -71,11 +71,7 @@ void initGraphics()
 #ifdef WITH_SPIX
   // Set antialiasing method to vertex to get same antialiasing across environments
   qputenv( "QSG_ANTIALIASING_METHOD", "vertex" );
-#endif
 
-#if not defined( Q_OS_ANDROID )
-  // Enables antialiasing in QML scenes
-  // Avoid enabling on Android OS as it leads to serious regressions on old devices
   QSurfaceFormat format;
   format.setSamples( 4 );
   QSurfaceFormat::setDefaultFormat( format );

--- a/vcpkg/ports/qgis/vcpkg.json
+++ b/vcpkg/ports/qgis/vcpkg.json
@@ -79,16 +79,9 @@
         "jpeg",
         "network",
         "opengl",
-        {
-          "name": "openssl",
-          "platform": "!ios"
-        },
+        "openssl",
         "pcre2",
         "png",
-        {
-          "name": "securetransport",
-          "platform": "ios"
-        },
         "sql",
         "sql-sqlite",
         "testlib",

--- a/vcpkg/ports/qtbase/vcpkg.json
+++ b/vcpkg/ports/qtbase/vcpkg.json
@@ -102,10 +102,7 @@
       "name": "opengl",
       "platform": "!ios"
     },
-    {
-      "name": "openssl",
-      "platform": "!ios"
-    },
+    "openssl",
     "pcre2",
     "png",
     {


### PR DESCRIPTION
> On devices with iOS 12.2 or later, TLS 1.3 is enabled by default for Network.framework and NSURLSession APIs. **TLS clients using the SecureTransport APIs can’t use TLS 1.3**. (https://support.apple.com/en-ng/guide/security/sec100a75d12/web)

Years ago, we realized our iOS builds was better using SecureTransport to manage SSL connections. Flash forward to 2026, Apple has deprecated the framework, and lacks support for TLS 1.3. 

We're now aware that certain websites (e.g. OSRM routing offered by openstreetmap.de) have TLS 1.3-only HTTPS connections leading to failure to connect to that endpoint on iOS.

This PR tries to use OpenSSL on iOS to see if it is OK to do so nowadays. A nice bonus here would be that _all_ our platforms we end up relying on the OpenSSL backend.