### PR TITLE
enable compress-and-send action for cloud projects

### DIFF
--- a/src/app/qml/QfLocalDataPickerScreen.qml
+++ b/src/app/qml/QfLocalDataPickerScreen.qml
@@ -459,9 +459,10 @@ Page {
         id: actionButton
         round: true
 
-        property bool isLocalProject: qgisProject && QfCloudUtils.getProjectId(qgisProject.fileName) === '' && (projectInfo.filePath.endsWith('.qgs') || projectInfo.filePath.endsWith('.qgz'))
-        property bool isLocalProjectActionAvailable: updateProjectFromArchive.enabled || uploadProjectToWebdav.enabled || compressProjectAndSendTo.enabled
-        visible: (projectFolderView && isLocalProject && isLocalProjectActionAvailable && table.model.currentDepth === 1) || table.model.currentPath === 'root'
+        property bool isProject: qgisProject && (projectInfo.filePath.endsWith('.qgs') || projectInfo.filePath.endsWith('.qgz'))
+        property bool isLocalProject: isProject && QfCloudUtils.getProjectId(qgisProject.fileName) === ''
+        property bool isProjectActionAvailable: updateProjectFromArchive.enabled || uploadProjectToWebdav.enabled || compressProjectAndSendTo.enabled
+        visible: (projectFolderView && isProject && isProjectActionAvailable && table.model.currentDepth === 1) || table.model.currentPath === 'root'
 
         anchors.bottom: parent.bottom
         anchors.right: parent.right
@@ -830,7 +831,7 @@ Page {
       MenuItem {
         id: updateProjectFromArchive
 
-        enabled: platformUtilities.capabilities & QfPlatformUtilities.UpdateProjectFromArchive
+        enabled: actionButton.isLocalProject && platformUtilities.capabilities & QfPlatformUtilities.UpdateProjectFromArchive
         visible: enabled
         font: QfTheme.defaultFont
         width: parent.width


### PR DESCRIPTION
the project actions button was gated on isLocalProject, hiding it entirely for cloud projects now made available also for the cloud projects. Gating the button on isProject instead and keeping update-from-zip local-only so cloud projects only expose 'compress and send to'

![image](https://github.com/user-attachments/assets/813b5721-6530-4b31-a85f-1727e27a3fd5)