### PR TITLE
Update sentry-cocoa to last 7.X version

### DIFF
--- a/vcpkg/ports/sentry-cocoa/SentryCocoaConfig.cmake.in
+++ b/vcpkg/ports/sentry-cocoa/SentryCocoaConfig.cmake.in
@@ -20,6 +20,8 @@ if("@CMAKE_SYSTEM_NAME@" STREQUAL "Darwin")
   target_link_libraries(SentryCocoa::sentry_cocoa INTERFACE "-framework AppKit")
 elseif("@CMAKE_SYSTEM_NAME@" STREQUAL "iOS")
   target_link_libraries(SentryCocoa::sentry_cocoa INTERFACE "-framework UiKit")
+  target_link_libraries(SentryCocoa::sentry_cocoa INTERFACE "-framework SystemConfiguration")
+  target_link_libraries(SentryCocoa::sentry_cocoa INTERFACE "-framework UserNotifications")
 endif()
 
 # Cleanup temporary variables.

--- a/vcpkg/ports/sentry-cocoa/portfile.cmake
+++ b/vcpkg/ports/sentry-cocoa/portfile.cmake
@@ -1,8 +1,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO getsentry/sentry-cocoa
-    REF 7.23.0
-    SHA512 2cc9d1dc39221b31dbbfb650ebbed30356f44d9adac7a8a9c13fdaabc58aa3a7f5d4192d521a4296efe45f17ca0a86c53f9171697340a25c50e75be602033b68
+    REF 7.31.5
+    SHA512 328190f6794e1174c6c95bc1cf10ff7d39e8a5f1e3da88781e083c5e8fe3b5dc656fa7ca96de4dd77a2e5f04a0e43b83d0b40b7697a2d5c96024a567362cf511
     HEAD_REF master
     PATCHES
       stdint.patch

--- a/vcpkg/ports/sentry-cocoa/portfile.cmake
+++ b/vcpkg/ports/sentry-cocoa/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
 )
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
+
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/SentryCocoaConfig.cmake.in DESTINATION ${SOURCE_PATH})
 
 if(VCPKG_CROSSCOMPILING)

--- a/vcpkg/ports/sentry-cocoa/stdint.patch
+++ b/vcpkg/ports/sentry-cocoa/stdint.patch
@@ -1,11 +1,13 @@
-diff -ur a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h
---- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h	2022-08-05 19:04:26.000000000 +0200
-+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h	2022-08-05 19:05:34.000000000 +0200
-@@ -32,6 +32,7 @@
- #endif
- 
+diff --git a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h
+index 468c4fcc8..fa865ef82 100644
+--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h
++++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h
+@@ -34,6 +34,8 @@ extern "C" {
  #include "SentryCrashMonitor.h"
-+#include <stdint.h>
+ #import "SentryInternalDefines.h"
  
++#include <stdint.h>
++
  /** Access the Monitor API.
   */
+ SentryCrashMonitorAPI *sentrycrashcm_system_getAPI(void);


### PR DESCRIPTION
Fallback plan if sentry-cocoa 8.X is too intrusive to backport.